### PR TITLE
[HOTSPOT-100] 가족 & 구성원별 적용된 정책 및 차단 서비스조회 API 구현

### DIFF
--- a/src/main/java/hotspot/user/auth/controller/port/IssueTokenService.java
+++ b/src/main/java/hotspot/user/auth/controller/port/IssueTokenService.java
@@ -8,5 +8,5 @@ import hotspot.user.member.domain.Member;
  * 토큰 발급 및 로그인을 처리하는 서비스
  */
 public interface IssueTokenService {
-    TokenResponse issue(Member member, String email, FamilyRole familyRole);
+    TokenResponse issue(Member member, String email, FamilyRole familyRole, Long familyId);
 }

--- a/src/main/java/hotspot/user/auth/controller/response/LoginResponse.java
+++ b/src/main/java/hotspot/user/auth/controller/response/LoginResponse.java
@@ -16,5 +16,5 @@ public record LoginResponse(
         String email,
         Status status,
         FamilyRole familyRole,
-        Long familyId // 가족 ID 추가
+        Long familyId
 ) {}

--- a/src/main/java/hotspot/user/auth/controller/response/LoginResponse.java
+++ b/src/main/java/hotspot/user/auth/controller/response/LoginResponse.java
@@ -15,5 +15,6 @@ public record LoginResponse(
         Long memberId,
         String email,
         Status status,
-        FamilyRole familyRole
+        FamilyRole familyRole,
+        Long familyId // 가족 ID 추가
 ) {}

--- a/src/main/java/hotspot/user/auth/domain/mapper/LoginResponseMapper.java
+++ b/src/main/java/hotspot/user/auth/domain/mapper/LoginResponseMapper.java
@@ -14,24 +14,26 @@ public class LoginResponseMapper {
     /**
      * 신규 회원 가입 시 LoginResponse 생성
      */
-    public static LoginResponse from(Member member, CreateSocialAccountRequest request) {
+    public static LoginResponse from(Member member, CreateSocialAccountRequest request, Long familyId) {
         return new LoginResponse(
                 member.getId(),
                 request.email(),
                 member.getStatus(),
-                FamilyRole.CHILD // 신규 회원의 기본 역할
+                FamilyRole.CHILD, // 신규 회원의 기본 역할
+                familyId
         );
     }
 
     /**
      * 기존 회원 로그인 시 LoginResponse 생성
      */
-    public static LoginResponse from(Member member, SocialAccount socialAccount, FamilyRole familyRole) {
+    public static LoginResponse from(Member member, SocialAccount socialAccount, FamilyRole familyRole, Long familyId) {
         return new LoginResponse(
                 member.getId(),
                 socialAccount.getEmail(),
                 member.getStatus(),
-                familyRole
+                familyRole,
+                familyId
         );
     }
 }

--- a/src/main/java/hotspot/user/auth/service/IssueTokenServiceImpl.java
+++ b/src/main/java/hotspot/user/auth/service/IssueTokenServiceImpl.java
@@ -28,11 +28,12 @@ public class IssueTokenServiceImpl implements IssueTokenService {
     private final SaveTokenService saveTokenService;
 
     @Override
-    public TokenResponse issue(Member member, String email, FamilyRole familyRole) {
-        // 인증 객체 생성
+    public TokenResponse issue(Member member, String email, FamilyRole familyRole, Long familyId) {
+        // 인증 객체 생성 (빌더 패턴 사용)
         PrincipalDetails principal = PrincipalDetails.builder()
                 .id(member.getId())
                 .email(email)
+                .familyId(familyId) // family id 추가
                 .role(familyRole)
                 .status(member.getStatus())
                 .build();

--- a/src/main/java/hotspot/user/auth/service/IssueTokenServiceImpl.java
+++ b/src/main/java/hotspot/user/auth/service/IssueTokenServiceImpl.java
@@ -33,7 +33,7 @@ public class IssueTokenServiceImpl implements IssueTokenService {
         PrincipalDetails principal = PrincipalDetails.builder()
                 .id(member.getId())
                 .email(email)
-                .familyId(familyId) // family id 추가
+                .familyId(familyId)
                 .role(familyRole)
                 .status(member.getStatus())
                 .build();

--- a/src/main/java/hotspot/user/auth/service/OnboardingServiceImpl.java
+++ b/src/main/java/hotspot/user/auth/service/OnboardingServiceImpl.java
@@ -12,7 +12,6 @@ import hotspot.user.common.exception.code.MemberErrorCode;
 import hotspot.user.common.util.PhoneUtil;
 import hotspot.user.family.domain.FamilySubscription;
 import hotspot.user.family.service.port.FamilySubscriptionRepository;
-import hotspot.user.member.domain.FamilyRole;
 import hotspot.user.member.domain.Member;
 import hotspot.user.member.domain.SocialAccount;
 import hotspot.user.member.domain.Status;
@@ -47,9 +46,9 @@ public class OnboardingServiceImpl implements OnboardingService {
 
         // 3. 가족 정보 조회 (Role 및 familyId)
         FamilySubscription familySub = getFamilySubscription(subscription.getId());
-        
+
         // 4. 토큰 발급 (가족 ID 포함)
-        return issueTokenService.issue(finalMember, socialAccount.getEmail(), 
+        return issueTokenService.issue(finalMember, socialAccount.getEmail(),
                 familySub.getFamilyRole(), familySub.getFamily().getId());
     }
 

--- a/src/main/java/hotspot/user/auth/service/OnboardingServiceImpl.java
+++ b/src/main/java/hotspot/user/auth/service/OnboardingServiceImpl.java
@@ -45,9 +45,12 @@ public class OnboardingServiceImpl implements OnboardingService {
         // 2. 신규 승인 또는 기존 회원 통합 처리
         Member finalMember = handleMemberIntegration(subscription, pendingMember, socialAccount, request.birthDate());
 
-        // 3. 역할 조회 및 토큰 발급
-        FamilyRole familyRole = getFamilyRole(subscription.getId());
-        return issueTokenService.issue(finalMember, socialAccount.getEmail(), familyRole);
+        // 3. 가족 정보 조회 (Role 및 familyId)
+        FamilySubscription familySub = getFamilySubscription(subscription.getId());
+        
+        // 4. 토큰 발급 (가족 ID 포함)
+        return issueTokenService.issue(finalMember, socialAccount.getEmail(), 
+                familySub.getFamilyRole(), familySub.getFamily().getId());
     }
 
     // 전화번호로 회선을 조회 및 검증
@@ -111,10 +114,9 @@ public class OnboardingServiceImpl implements OnboardingService {
         return approvedMember;
     }
 
-    // 가족-회선 매핑에 할당된 familyRole 조회
-    private FamilyRole getFamilyRole(Long subId) {
+    // 가족-회선 매핑 정보 조회
+    private FamilySubscription getFamilySubscription(Long subId) {
         return familySubscriptionRepository.findBySubId(subId)
-                .map(FamilySubscription::getFamilyRole)
                 .orElseThrow(() -> new ApplicationException(MemberErrorCode.FAMILY_SUBSCRIPTION_NOT_FOUND));
     }
 }

--- a/src/main/java/hotspot/user/common/exception/code/AuthErrorCode.java
+++ b/src/main/java/hotspot/user/common/exception/code/AuthErrorCode.java
@@ -11,7 +11,8 @@ public enum AuthErrorCode implements BaseErrorCode {
 
     REFRESH_TOKEN_NOT_FOUND(HttpStatus.BAD_REQUEST, "AUTH_001", "리프레시 토큰을 찾을 수 없습니다."),
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_002", "유효하지 않은 토큰입니다."),
-    TOKEN_NOT_MATCH(HttpStatus.UNAUTHORIZED, "AUTH_003", "토큰 정보가 일치하지 않습니다.");
+    TOKEN_NOT_MATCH(HttpStatus.UNAUTHORIZED, "AUTH_003", "토큰 정보가 일치하지 않습니다."),
+    ACCESS_DENIED(HttpStatus.FORBIDDEN, "AUTH_004", "해당 요청에 대한 접근 권한이 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String customCode;

--- a/src/main/java/hotspot/user/common/security/PrincipalDetails.java
+++ b/src/main/java/hotspot/user/common/security/PrincipalDetails.java
@@ -36,7 +36,8 @@ public class PrincipalDetails implements UserDetails, OidcUser {
         this.attributes = null;
     }
 
-    public PrincipalDetails(Long id, String email, Long familyId, FamilyRole role, Status status, Map<String, Object> attributes) {
+    public PrincipalDetails(Long id, String email, Long familyId, FamilyRole role, Status status,
+                            Map<String, Object> attributes) {
         this.id = id;
         this.email = email;
         this.familyId = familyId;

--- a/src/main/java/hotspot/user/common/security/PrincipalDetails.java
+++ b/src/main/java/hotspot/user/common/security/PrincipalDetails.java
@@ -22,7 +22,7 @@ public class PrincipalDetails implements UserDetails, OidcUser {
 
     private final Long id;
     private final String email;
-    private final Long familyId; // 가족 ID 추가
+    private final Long familyId;
     private final FamilyRole role;
     private final Status status;
     private final Map<String, Object> attributes;

--- a/src/main/java/hotspot/user/common/security/PrincipalDetails.java
+++ b/src/main/java/hotspot/user/common/security/PrincipalDetails.java
@@ -22,21 +22,24 @@ public class PrincipalDetails implements UserDetails, OidcUser {
 
     private final Long id;
     private final String email;
+    private final Long familyId; // 가족 ID 추가
     private final FamilyRole role;
     private final Status status;
     private final Map<String, Object> attributes;
 
-    public PrincipalDetails(Long id, String email, FamilyRole role, Status status) {
+    public PrincipalDetails(Long id, String email, Long familyId, FamilyRole role, Status status) {
         this.id = id;
         this.email = email;
+        this.familyId = familyId;
         this.role = role;
         this.status = status;
         this.attributes = null;
     }
 
-    public PrincipalDetails(Long id, String email, FamilyRole role, Status status, Map<String, Object> attributes) {
+    public PrincipalDetails(Long id, String email, Long familyId, FamilyRole role, Status status, Map<String, Object> attributes) {
         this.id = id;
         this.email = email;
+        this.familyId = familyId;
         this.role = role;
         this.status = status;
         this.attributes = attributes;

--- a/src/main/java/hotspot/user/common/security/jwt/JwtProvider.java
+++ b/src/main/java/hotspot/user/common/security/jwt/JwtProvider.java
@@ -41,6 +41,7 @@ public class JwtProvider {
     private static final String TYPE_CLAIM = "type";
     private static final String ROLE_CLAIM = "role";
     private static final String STATUS_CLAIM = "status";
+    private static final String FAMILY_ID_CLAIM = "familyId";
     private static final String ACCESS_TOKEN_TYPE = "ACCESS";
     private static final String REFRESH_TOKEN_TYPE = "REFRESH";
 
@@ -73,6 +74,7 @@ public class JwtProvider {
                 .claim(TYPE_CLAIM, type) // 토큰 타입 명시
                 .claim(ROLE_CLAIM, principal.getRole().name()) // 모든 토큰에 권한 정보 포함 (재발급 시 필요)
                 .claim(STATUS_CLAIM, principal.getStatus().name())
+                .claim(FAMILY_ID_CLAIM, principal.getFamilyId()) // 가족 ID 추가
                 .subject(authentication.getName())
                 .issuedAt(now)
                 .expiration(expiredDate)
@@ -113,14 +115,15 @@ public class JwtProvider {
         Long memberId = claims.get("memberId", Long.class);
         String roleStr = claims.get(ROLE_CLAIM, String.class);
         String statusStr = claims.get(STATUS_CLAIM, String.class);
+        Long familyId = claims.get(FAMILY_ID_CLAIM, Long.class);
 
         // 2. 권한 정보 검증 (기본값 제거)
         if (roleStr == null || statusStr == null) {
             throw new MalformedJwtException("필수 권한 정보가 없는 토큰입니다.");
         }
 
-        PrincipalDetails principal = new PrincipalDetails(memberId, email, FamilyRole.valueOf(roleStr),
-            Status.valueOf(statusStr));
+        PrincipalDetails principal = new PrincipalDetails(memberId, email, familyId, 
+            FamilyRole.valueOf(roleStr), Status.valueOf(statusStr));
 
         return new UsernamePasswordAuthenticationToken(principal, token, principal.getAuthorities());
     }

--- a/src/main/java/hotspot/user/common/security/jwt/JwtProvider.java
+++ b/src/main/java/hotspot/user/common/security/jwt/JwtProvider.java
@@ -122,7 +122,7 @@ public class JwtProvider {
             throw new MalformedJwtException("필수 권한 정보가 없는 토큰입니다.");
         }
 
-        PrincipalDetails principal = new PrincipalDetails(memberId, email, familyId, 
+        PrincipalDetails principal = new PrincipalDetails(memberId, email, familyId,
             FamilyRole.valueOf(roleStr), Status.valueOf(statusStr));
 
         return new UsernamePasswordAuthenticationToken(principal, token, principal.getAuthorities());

--- a/src/main/java/hotspot/user/common/security/jwt/JwtProvider.java
+++ b/src/main/java/hotspot/user/common/security/jwt/JwtProvider.java
@@ -74,7 +74,7 @@ public class JwtProvider {
                 .claim(TYPE_CLAIM, type) // 토큰 타입 명시
                 .claim(ROLE_CLAIM, principal.getRole().name()) // 모든 토큰에 권한 정보 포함 (재발급 시 필요)
                 .claim(STATUS_CLAIM, principal.getStatus().name())
-                .claim(FAMILY_ID_CLAIM, principal.getFamilyId()) // 가족 ID 추가
+                .claim(FAMILY_ID_CLAIM, principal.getFamilyId())
                 .subject(authentication.getName())
                 .issuedAt(now)
                 .expiration(expiredDate)

--- a/src/main/java/hotspot/user/common/security/oauth/CustomOidcUserService.java
+++ b/src/main/java/hotspot/user/common/security/oauth/CustomOidcUserService.java
@@ -88,7 +88,7 @@ public class CustomOidcUserService extends OidcUserService {
         return PrincipalDetails.builder()
             .id(loginResult.memberId())
             .email(loginResult.email())
-            .familyId(loginResult.familyId()) // 추가된 familyId 반영
+            .familyId(loginResult.familyId())
             .role(loginResult.familyRole())
             .status(loginResult.status())
             .attributes(claims)

--- a/src/main/java/hotspot/user/common/security/oauth/CustomOidcUserService.java
+++ b/src/main/java/hotspot/user/common/security/oauth/CustomOidcUserService.java
@@ -85,12 +85,13 @@ public class CustomOidcUserService extends OidcUserService {
 
         log.info("[OIDC] 로그인 성공: provider={}, email={}", request.provider(), request.email());
 
-        return new PrincipalDetails(
-            loginResult.memberId(),
-            loginResult.email(),
-            loginResult.familyRole(),
-            loginResult.status(),
-            claims
-        );
+        return PrincipalDetails.builder()
+            .id(loginResult.memberId())
+            .email(loginResult.email())
+            .familyId(loginResult.familyId()) // 추가된 familyId 반영
+            .role(loginResult.familyRole())
+            .status(loginResult.status())
+            .attributes(claims)
+            .build();
     }
 }

--- a/src/main/java/hotspot/user/family/infrastructure/FamilySubscriptionJpaRepository.java
+++ b/src/main/java/hotspot/user/family/infrastructure/FamilySubscriptionJpaRepository.java
@@ -1,5 +1,6 @@
 package hotspot.user.family.infrastructure;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.EntityGraph;
@@ -12,6 +13,12 @@ import hotspot.user.family.infrastructure.entity.FamilySubscriptionEntity;
  */
 public interface FamilySubscriptionJpaRepository extends JpaRepository<FamilySubscriptionEntity, Long> {
 
-    @EntityGraph(attributePaths = {"family", "subscription"})
+    @EntityGraph(attributePaths = {"family", "subscription", "subscription.member"})
     Optional<FamilySubscriptionEntity> findBySubscriptionSubId(Long subId);
+
+    @EntityGraph(attributePaths = {"family", "subscription", "subscription.member"})
+    List<FamilySubscriptionEntity> findByFamilyFamilyId(Long familyId);
+
+    @EntityGraph(attributePaths = {"family", "subscription", "subscription.member"})
+    Optional<FamilySubscriptionEntity> findBySubscriptionMemberId(Long memberId);
 }

--- a/src/main/java/hotspot/user/family/infrastructure/FamilySubscriptionRepositoryImpl.java
+++ b/src/main/java/hotspot/user/family/infrastructure/FamilySubscriptionRepositoryImpl.java
@@ -1,5 +1,6 @@
 package hotspot.user.family.infrastructure;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.stereotype.Repository;
@@ -18,6 +19,19 @@ public class FamilySubscriptionRepositoryImpl implements FamilySubscriptionRepos
     @Override
     public Optional<FamilySubscription> findBySubId(Long subId) {
         return jpaRepository.findBySubscriptionSubId(subId)
+                .map(FamilySubscriptionEntity::entityToDomain);
+    }
+
+    @Override
+    public List<FamilySubscription> findByFamilyId(Long familyId) {
+        return jpaRepository.findByFamilyFamilyId(familyId).stream()
+                .map(FamilySubscriptionEntity::entityToDomain)
+                .toList();
+    }
+
+    @Override
+    public Optional<FamilySubscription> findByMemberId(Long memberId) {
+        return jpaRepository.findBySubscriptionMemberId(memberId)
                 .map(FamilySubscriptionEntity::entityToDomain);
     }
 }

--- a/src/main/java/hotspot/user/family/service/port/FamilySubscriptionRepository.java
+++ b/src/main/java/hotspot/user/family/service/port/FamilySubscriptionRepository.java
@@ -1,5 +1,6 @@
 package hotspot.user.family.service.port;
 
+import java.util.List;
 import java.util.Optional;
 
 import hotspot.user.family.domain.FamilySubscription;
@@ -9,4 +10,6 @@ import hotspot.user.family.domain.FamilySubscription;
  */
 public interface FamilySubscriptionRepository {
     Optional<FamilySubscription> findBySubId(Long subId);
+    List<FamilySubscription> findByFamilyId(Long familyId);
+    Optional<FamilySubscription> findByMemberId(Long memberId);
 }

--- a/src/main/java/hotspot/user/member/service/RegisterSocialMemberServiceImpl.java
+++ b/src/main/java/hotspot/user/member/service/RegisterSocialMemberServiceImpl.java
@@ -39,6 +39,6 @@ public class RegisterSocialMemberServiceImpl implements RegisterSocialMemberServ
         socialAccountRepository.save(socialAccount);
 
         // 4. LoginResponseMapper를 사용하여 DTO 반환
-        return LoginResponseMapper.from(member, request);
+        return LoginResponseMapper.from(member, request, null);
     }
 }

--- a/src/main/java/hotspot/user/member/service/SocialLoginServiceImpl.java
+++ b/src/main/java/hotspot/user/member/service/SocialLoginServiceImpl.java
@@ -49,7 +49,7 @@ public class SocialLoginServiceImpl implements SocialLoginService {
             Member member = memberRepository.findById(socialAccount.getMemberId())
                     .orElseThrow(() -> new ApplicationException(MemberErrorCode.MEMBER_NOT_FOUND));
 
-            // FamilyRole 및 FamilyId 조회 (기존 회원)
+            // 3. FamilyRole 및 FamilyId 조회 (기존 회원)
             FamilyRole familyRole = FamilyRole.CHILD; // 기본값
             Long familyId = null;
             Optional<Subscription> subscriptionOptional =

--- a/src/main/java/hotspot/user/member/service/SocialLoginServiceImpl.java
+++ b/src/main/java/hotspot/user/member/service/SocialLoginServiceImpl.java
@@ -49,8 +49,9 @@ public class SocialLoginServiceImpl implements SocialLoginService {
             Member member = memberRepository.findById(socialAccount.getMemberId())
                     .orElseThrow(() -> new ApplicationException(MemberErrorCode.MEMBER_NOT_FOUND));
 
-            // FamilyRole 조회 (기존 회원)
+            // FamilyRole 및 FamilyId 조회 (기존 회원)
             FamilyRole familyRole = FamilyRole.CHILD; // 기본값
+            Long familyId = null;
             Optional<Subscription> subscriptionOptional =
                     subscriptionRepository.findByMemberId(member.getId());
 
@@ -59,10 +60,11 @@ public class SocialLoginServiceImpl implements SocialLoginService {
                         familySubscriptionRepository.findBySubId(subscriptionOptional.get().getId());
                 if (familySubscriptionOptional.isPresent()) {
                     familyRole = familySubscriptionOptional.get().getFamilyRole();
+                    familyId = familySubscriptionOptional.get().getFamily().getId();
                 }
             }
 
-            return LoginResponseMapper.from(member, socialAccount, familyRole);
+            return LoginResponseMapper.from(member, socialAccount, familyRole, familyId);
         }
 
         // 3. 소셜 계정이 없으면 신규 회원 가입 진행

--- a/src/main/java/hotspot/user/policy/controller/AppliedPolicyController.java
+++ b/src/main/java/hotspot/user/policy/controller/AppliedPolicyController.java
@@ -1,0 +1,79 @@
+package hotspot.user.policy.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import hotspot.user.common.ApiResponse;
+import hotspot.user.common.exception.ApplicationException;
+import hotspot.user.common.exception.code.AuthErrorCode;
+import hotspot.user.common.security.PrincipalDetails;
+import hotspot.user.member.domain.FamilyRole;
+import hotspot.user.policy.controller.port.FindFamilyAppliedPolicyService;
+import hotspot.user.policy.controller.port.FindMemberAppliedPolicyService;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 적용된 정책(시간 정책 및 앱 차단) 조회 컨트롤러
+ */
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/policies/applied")
+public class AppliedPolicyController {
+
+    private final FindMemberAppliedPolicyService findMemberAppliedPolicyService; // 구성원별 적용 정책 조회
+    private final FindFamilyAppliedPolicyService findFamilyAppliedPolicyService; // 가족 구성원 전체 적용 정책 조회
+
+    /**
+     * 적용된 정책 목록을 조회 Test API
+     * @param isFamily true일 경우 가족 전체의 정책을, false일 경우 본인의 정책만 조회
+     * 우리 정보로 만들어진 더미 데이터가 없기 때문에 파라미터로 memberId, familyId 전달할 수 있도록 한다.
+     * [To-Do] 더미 데이터 및 로그인 기능 최종 완료 시 삭제 예정
+     */
+    @GetMapping("/test")
+    public ResponseEntity<ApiResponse<Object>> getAppliedPoliciesTest(
+            @RequestParam(defaultValue = "false") boolean isFamily,
+            @RequestParam(required = false) Long testMemberId,
+            @RequestParam(required = false) Long testFamilyId
+    ) {
+        if (isFamily) {
+            return ResponseEntity.ok(ApiResponse.success(
+                    findFamilyAppliedPolicyService.findByFamilyId(testFamilyId)
+            ));
+        }
+
+        return ResponseEntity.ok(ApiResponse.success(
+                findMemberAppliedPolicyService.findByMemberId(testMemberId)
+        ));
+    }
+
+    /**
+     * 적용된 정책 목록을 조회 API
+     * @param isFamily true일 경우 가족 전체의 정책을, false일 경우 본인의 정책만 조회
+     */
+    @GetMapping
+    public ResponseEntity<ApiResponse<Object>> getAppliedPolicies(
+            @RequestParam(defaultValue = "false") boolean isFamily,
+            @AuthenticationPrincipal PrincipalDetails principal
+    ) {
+        if (isFamily) {
+            // 가족 전체 조회 시 권한 검증: OWNER 또는 PARENT만 가능
+            if (principal.getRole() != FamilyRole.OWNER && principal.getRole() != FamilyRole.PARENT) {
+                throw new ApplicationException(AuthErrorCode.ACCESS_DENIED);
+            }
+
+            // 토큰에 저장된 familyId를 사용하여 조회
+            return ResponseEntity.ok(ApiResponse.success(
+                findFamilyAppliedPolicyService.findByFamilyId(principal.getFamilyId())
+            ));
+        }
+
+        // 본인 정책 조회
+        return ResponseEntity.ok(ApiResponse.success(
+            findMemberAppliedPolicyService.findByMemberId(principal.getId())
+        ));
+    }
+}

--- a/src/main/java/hotspot/user/policy/controller/port/FindFamilyAppliedPolicyService.java
+++ b/src/main/java/hotspot/user/policy/controller/port/FindFamilyAppliedPolicyService.java
@@ -1,0 +1,10 @@
+package hotspot.user.policy.controller.port;
+
+import hotspot.user.policy.controller.response.FamilyAppliedPolicyResponse;
+
+/**
+ * 가족 전체 구성원의 적용된 통합 정책 조회 서비스
+ */
+public interface FindFamilyAppliedPolicyService {
+    FamilyAppliedPolicyResponse findByFamilyId(Long familyId);
+}

--- a/src/main/java/hotspot/user/policy/controller/port/FindMemberAppliedPolicyService.java
+++ b/src/main/java/hotspot/user/policy/controller/port/FindMemberAppliedPolicyService.java
@@ -1,0 +1,10 @@
+package hotspot.user.policy.controller.port;
+
+import hotspot.user.policy.controller.response.AppliedPolicyResponse;
+
+/**
+ * 특정 구성원의 적용된 통합 정책 조회 서비스
+ */
+public interface FindMemberAppliedPolicyService {
+    AppliedPolicyResponse findByMemberId(Long memberId);
+}

--- a/src/main/java/hotspot/user/policy/controller/response/AppBlockedServiceResponse.java
+++ b/src/main/java/hotspot/user/policy/controller/response/AppBlockedServiceResponse.java
@@ -1,6 +1,5 @@
 package hotspot.user.policy.controller.response;
 
-import hotspot.user.policy.domain.AppBlockedService;
 import lombok.Builder;
 
 /**
@@ -12,12 +11,4 @@ public record AppBlockedServiceResponse(
         String name,
         String serviceCode // 카테고리 표시 때문에 필요할 듯
 ) {
-
-    public static AppBlockedServiceResponse from(AppBlockedService appBlockedService) {
-        return AppBlockedServiceResponse.builder()
-                .id(appBlockedService.getId())
-                .name(appBlockedService.getName())
-                .serviceCode(appBlockedService.getServiceCode())
-                .build();
-    }
 }

--- a/src/main/java/hotspot/user/policy/controller/response/AppliedPolicyResponse.java
+++ b/src/main/java/hotspot/user/policy/controller/response/AppliedPolicyResponse.java
@@ -1,0 +1,28 @@
+package hotspot.user.policy.controller.response;
+
+import java.util.List;
+
+import hotspot.user.member.domain.FamilyRole;
+import lombok.Builder;
+
+/**
+ * 개인별 적용된 정책 조회 응답 dto
+ * @param memberId
+ * @param memberName
+ * @param dataLimit
+ * @param priority
+ * @param familyRole
+ * @param blockPolicyResponseList
+ * @param appBlockedServiceResponseList
+ */
+@Builder
+public record AppliedPolicyResponse(
+        Long memberId,
+        String memberName,
+        int dataLimit, // 개인별 한도
+        int priority, // 구성원 내 우선 순위
+        FamilyRole familyRole, // 가족 내 역할
+        List<BlockPolicyResponse> blockPolicyResponseList,
+        List<AppBlockedServiceResponse> appBlockedServiceResponseList
+) {
+}

--- a/src/main/java/hotspot/user/policy/controller/response/AppliedPolicyResponse.java
+++ b/src/main/java/hotspot/user/policy/controller/response/AppliedPolicyResponse.java
@@ -2,18 +2,14 @@ package hotspot.user.policy.controller.response;
 
 import java.util.List;
 
-import hotspot.user.member.domain.FamilyRole;
+import hotspot.user.family.domain.FamilySubscription;
+import hotspot.user.policy.domain.BlockedServiceSub;
+import hotspot.user.policy.domain.PolicySub;
+import hotspot.user.policy.domain.mapper.AppliedPolicyMapper;
 import lombok.Builder;
 
 /**
  * 개인별 적용된 정책 조회 응답 dto
- * @param memberId
- * @param memberName
- * @param dataLimit
- * @param priority
- * @param familyRole
- * @param blockPolicyResponseList
- * @param appBlockedServiceResponseList
  */
 @Builder
 public record AppliedPolicyResponse(
@@ -21,8 +17,28 @@ public record AppliedPolicyResponse(
         String memberName,
         int dataLimit, // 개인별 한도
         int priority, // 구성원 내 우선 순위
-        FamilyRole familyRole, // 가족 내 역할
         List<BlockPolicyResponse> blockPolicyResponseList,
         List<AppBlockedServiceResponse> appBlockedServiceResponseList
 ) {
+    /**
+     * 도메인 객체들을 조합하여 AppliedPolicyResponse DTO를 생성한다.
+     */
+    public static AppliedPolicyResponse from(
+            FamilySubscription familySub,
+            List<PolicySub> policySubList,
+            List<BlockedServiceSub> blockedServiceSubList
+    ) {
+        return AppliedPolicyResponse.builder()
+                .memberId(familySub.getSubscription().getMember().getId())
+                .memberName(familySub.getSubscription().getMember().getName())
+                .dataLimit(familySub.getDataLimit())
+                .priority(familySub.getPriority())
+                .blockPolicyResponseList(policySubList.stream()
+                        .map(AppliedPolicyMapper::toBlockPolicyResponse)
+                        .toList())
+                .appBlockedServiceResponseList(blockedServiceSubList.stream()
+                        .map(AppliedPolicyMapper::toAppBlockedServiceResponse)
+                        .toList())
+                .build();
+    }
 }

--- a/src/main/java/hotspot/user/policy/controller/response/AppliedPolicyResponse.java
+++ b/src/main/java/hotspot/user/policy/controller/response/AppliedPolicyResponse.java
@@ -2,10 +2,6 @@ package hotspot.user.policy.controller.response;
 
 import java.util.List;
 
-import hotspot.user.family.domain.FamilySubscription;
-import hotspot.user.policy.domain.BlockedServiceSub;
-import hotspot.user.policy.domain.PolicySub;
-import hotspot.user.policy.domain.mapper.AppliedPolicyMapper;
 import lombok.Builder;
 
 /**
@@ -20,25 +16,4 @@ public record AppliedPolicyResponse(
         List<BlockPolicyResponse> blockPolicyResponseList,
         List<AppBlockedServiceResponse> appBlockedServiceResponseList
 ) {
-    /**
-     * 도메인 객체들을 조합하여 AppliedPolicyResponse DTO를 생성한다.
-     */
-    public static AppliedPolicyResponse from(
-            FamilySubscription familySub,
-            List<PolicySub> policySubList,
-            List<BlockedServiceSub> blockedServiceSubList
-    ) {
-        return AppliedPolicyResponse.builder()
-                .memberId(familySub.getSubscription().getMember().getId())
-                .memberName(familySub.getSubscription().getMember().getName())
-                .dataLimit(familySub.getDataLimit())
-                .priority(familySub.getPriority())
-                .blockPolicyResponseList(policySubList.stream()
-                        .map(AppliedPolicyMapper::toBlockPolicyResponse)
-                        .toList())
-                .appBlockedServiceResponseList(blockedServiceSubList.stream()
-                        .map(AppliedPolicyMapper::toAppBlockedServiceResponse)
-                        .toList())
-                .build();
-    }
 }

--- a/src/main/java/hotspot/user/policy/controller/response/BlockPolicyResponse.java
+++ b/src/main/java/hotspot/user/policy/controller/response/BlockPolicyResponse.java
@@ -1,6 +1,5 @@
 package hotspot.user.policy.controller.response;
 
-import hotspot.user.policy.domain.BlockPolicy;
 import hotspot.user.policy.domain.PolicySnapshot;
 import hotspot.user.policy.domain.PolicyType;
 import lombok.Builder;
@@ -15,13 +14,4 @@ public record BlockPolicyResponse(
         PolicyType policyType,
         PolicySnapshot policySnapshot
 ) {
-
-    public static BlockPolicyResponse from(BlockPolicy blockPolicy) {
-        return BlockPolicyResponse.builder()
-                .id(blockPolicy.getId())
-                .name(blockPolicy.getName())
-                .policyType(blockPolicy.getPolicyType())
-                .policySnapshot(blockPolicy.getPolicySnapshot())
-                .build();
-    }
 }

--- a/src/main/java/hotspot/user/policy/controller/response/FamilyAppliedPolicyResponse.java
+++ b/src/main/java/hotspot/user/policy/controller/response/FamilyAppliedPolicyResponse.java
@@ -2,23 +2,31 @@ package hotspot.user.policy.controller.response;
 
 import java.util.List;
 
+import hotspot.user.family.domain.Family;
 import hotspot.user.family.domain.PriorityType;
 import lombok.Builder;
 
 /**
  * 가족 전체 구성원의 적용된 정책 조회 응답 dto
- * @param familyId
- * @param familyNum
- * @param familyDataAmount
- * @param priorityType
- * @param memberPolicies
  */
 @Builder
 public record FamilyAppliedPolicyResponse(
         Long familyId,
-        int familyNum, // 가족 구성원 수
-        int familyDataAmount, // 가족 데이터 한도량
-        PriorityType priorityType, // 가족의 데이터 사용 우선순위 방식 (FIFO or PRIORITY)
+        int familyNum,
+        int familyDataAmount,
+        PriorityType priorityType,
         List<AppliedPolicyResponse> memberPolicies
 ) {
+    /**
+     * Family 도메인과 조립된 memberPolicies 리스트를 사용하여 DTO를 생성한다.
+     */
+    public static FamilyAppliedPolicyResponse from(Family family, List<AppliedPolicyResponse> memberPolicies) {
+        return FamilyAppliedPolicyResponse.builder()
+                .familyId(family.getId())
+                .familyNum(family.getFamilyNum())
+                .familyDataAmount(family.getFamilyDataAmount())
+                .priorityType(family.getPriorityType())
+                .memberPolicies(memberPolicies)
+                .build();
+    }
 }

--- a/src/main/java/hotspot/user/policy/controller/response/FamilyAppliedPolicyResponse.java
+++ b/src/main/java/hotspot/user/policy/controller/response/FamilyAppliedPolicyResponse.java
@@ -1,0 +1,24 @@
+package hotspot.user.policy.controller.response;
+
+import java.util.List;
+
+import hotspot.user.family.domain.PriorityType;
+import lombok.Builder;
+
+/**
+ * 가족 전체 구성원의 적용된 정책 조회 응답 dto
+ * @param familyId
+ * @param familyNum
+ * @param familyDataAmount
+ * @param priorityType
+ * @param memberPolicies
+ */
+@Builder
+public record FamilyAppliedPolicyResponse(
+        Long familyId,
+        int familyNum, // 가족 구성원 수
+        int familyDataAmount, // 가족 데이터 한도량
+        PriorityType priorityType, // 가족의 데이터 사용 우선순위 방식 (FIFO or PRIORITY)
+        List<AppliedPolicyResponse> memberPolicies
+) {
+}

--- a/src/main/java/hotspot/user/policy/controller/response/FamilyAppliedPolicyResponse.java
+++ b/src/main/java/hotspot/user/policy/controller/response/FamilyAppliedPolicyResponse.java
@@ -2,7 +2,6 @@ package hotspot.user.policy.controller.response;
 
 import java.util.List;
 
-import hotspot.user.family.domain.Family;
 import hotspot.user.family.domain.PriorityType;
 import lombok.Builder;
 
@@ -17,16 +16,4 @@ public record FamilyAppliedPolicyResponse(
         PriorityType priorityType,
         List<AppliedPolicyResponse> memberPolicies
 ) {
-    /**
-     * Family 도메인과 조립된 memberPolicies 리스트를 사용하여 DTO를 생성한다.
-     */
-    public static FamilyAppliedPolicyResponse from(Family family, List<AppliedPolicyResponse> memberPolicies) {
-        return FamilyAppliedPolicyResponse.builder()
-                .familyId(family.getId())
-                .familyNum(family.getFamilyNum())
-                .familyDataAmount(family.getFamilyDataAmount())
-                .priorityType(family.getPriorityType())
-                .memberPolicies(memberPolicies)
-                .build();
-    }
 }

--- a/src/main/java/hotspot/user/policy/domain/BlockedServiceSub.java
+++ b/src/main/java/hotspot/user/policy/domain/BlockedServiceSub.java
@@ -1,5 +1,6 @@
 package hotspot.user.policy.domain;
 
+import hotspot.user.subscription.domain.Subscription;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -12,7 +13,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public class BlockedServiceSub {
     private final Long id;
-    private final Long subId;
-    private final Long blockedServiceId;
+    private final Subscription subscription;
+    private final AppBlockedService appBlockedService;
 
 }

--- a/src/main/java/hotspot/user/policy/domain/DateSnapshot.java
+++ b/src/main/java/hotspot/user/policy/domain/DateSnapshot.java
@@ -1,0 +1,23 @@
+package hotspot.user.policy.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 정책 적용 시점의 전체 정보를 담는 스냅샷 도메인
+ * JSON 구조: {"policyName": "...", "policyType": "...", "data": {...}}
+ */
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class DateSnapshot {
+
+    private String policyName;
+
+    private PolicyType policyType;
+
+    private PolicySnapshot data; // 세부 시간 설정 (요일, 시간 등)
+}

--- a/src/main/java/hotspot/user/policy/domain/PolicySub.java
+++ b/src/main/java/hotspot/user/policy/domain/PolicySub.java
@@ -1,5 +1,6 @@
 package hotspot.user.policy.domain;
 
+import hotspot.user.subscription.domain.Subscription;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -12,7 +13,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public class PolicySub {
     private final Long id;
-    private final Long subId;
+    private final Subscription subscription;
     private final PolicySnapshot policySnapshot;
 
 }

--- a/src/main/java/hotspot/user/policy/domain/PolicySub.java
+++ b/src/main/java/hotspot/user/policy/domain/PolicySub.java
@@ -6,7 +6,7 @@ import lombok.Builder;
 import lombok.Getter;
 
 /**
- * 관리자가 생성한 차단 정책 도메인
+ * 정책 - 회선 매핑 도메인
  */
 @Getter
 @Builder
@@ -14,6 +14,5 @@ import lombok.Getter;
 public class PolicySub {
     private final Long id;
     private final Subscription subscription;
-    private final PolicySnapshot policySnapshot;
-
+    private final DateSnapshot dateSnapshot;
 }

--- a/src/main/java/hotspot/user/policy/domain/mapper/AppBlockedServiceMapper.java
+++ b/src/main/java/hotspot/user/policy/domain/mapper/AppBlockedServiceMapper.java
@@ -2,6 +2,7 @@ package hotspot.user.policy.domain.mapper;
 
 import hotspot.user.policy.controller.response.AppBlockedServiceResponse;
 import hotspot.user.policy.domain.AppBlockedService;
+import hotspot.user.policy.domain.BlockedServiceSub;
 
 /**
  * request -> 도메인
@@ -11,7 +12,21 @@ public class AppBlockedServiceMapper {
     // request -> domain
 
     // domain -> response
+    // AppBlockedService(앱 차단 서비스 원본) 도메인을 AppBlockedServiceResponse DTO로 변환
     public static AppBlockedServiceResponse toAppBlockedServiceResponse(AppBlockedService appBlockedService) {
-        return AppBlockedServiceResponse.from(appBlockedService);
+        return AppBlockedServiceResponse.builder()
+                .id(appBlockedService.getId())
+                .name(appBlockedService.getName())
+                .serviceCode(appBlockedService.getServiceCode())
+                .build();
+    }
+
+    // BlockedServiceSub(적용된 앱 차단) 도메인을 AppBlockedServiceResponse DTO로 변환
+    public static AppBlockedServiceResponse toAppBlockedServiceResponse(BlockedServiceSub blockedSub) {
+        return AppBlockedServiceResponse.builder()
+                .id(blockedSub.getAppBlockedService().getId())
+                .name(blockedSub.getAppBlockedService().getName())
+                .serviceCode(blockedSub.getAppBlockedService().getServiceCode())
+                .build();
     }
 }

--- a/src/main/java/hotspot/user/policy/domain/mapper/AppliedPolicyMapper.java
+++ b/src/main/java/hotspot/user/policy/domain/mapper/AppliedPolicyMapper.java
@@ -1,0 +1,53 @@
+package hotspot.user.policy.domain.mapper;
+
+import java.util.List;
+
+import hotspot.user.family.domain.Family;
+import hotspot.user.family.domain.FamilySubscription;
+
+import hotspot.user.policy.controller.response.AppliedPolicyResponse;
+
+import hotspot.user.policy.controller.response.FamilyAppliedPolicyResponse;
+
+import hotspot.user.policy.domain.BlockedServiceSub;
+import hotspot.user.policy.domain.PolicySub;
+
+/**
+ * 구성원별 적용된 정책 <-> Dto 변환하는 매퍼 클래스
+ */
+public class AppliedPolicyMapper {
+
+    // 개인별 정책 정보를 조립하여 AppliedPolicyResponse DTO를 생성
+    public static AppliedPolicyResponse toAppliedPolicyResponse(
+            FamilySubscription familySub,
+            List<PolicySub> policySubs,
+            List<BlockedServiceSub> blockedServiceSubs
+    ) {
+        return AppliedPolicyResponse.builder()
+                .memberId(familySub.getSubscription().getMember().getId())
+                .memberName(familySub.getSubscription().getMember().getName())
+                .dataLimit(familySub.getDataLimit())
+                .priority(familySub.getPriority())
+                .blockPolicyResponseList(policySubs.stream()
+                        .map(BlockPolicyMapper::toBlockPolicyResponse)
+                        .toList())
+                .appBlockedServiceResponseList(blockedServiceSubs.stream()
+                        .map(AppBlockedServiceMapper::toAppBlockedServiceResponse)
+                        .toList())
+                .build();
+    }
+
+    // 가족 정보와 조립된 멤버별 정책 리스트를 사용하여 FamilyAppliedPolicyResponse DTO를 생성
+    public static FamilyAppliedPolicyResponse toFamilyAppliedPolicyResponse(
+            Family family,
+            List<AppliedPolicyResponse> memberPolicies
+    ) {
+        return FamilyAppliedPolicyResponse.builder()
+                .familyId(family.getId())
+                .familyNum(family.getFamilyNum())
+                .familyDataAmount(family.getFamilyDataAmount())
+                .priorityType(family.getPriorityType())
+                .memberPolicies(memberPolicies)
+                .build();
+    }
+}

--- a/src/main/java/hotspot/user/policy/domain/mapper/AppliedPolicyMapper.java
+++ b/src/main/java/hotspot/user/policy/domain/mapper/AppliedPolicyMapper.java
@@ -4,11 +4,8 @@ import java.util.List;
 
 import hotspot.user.family.domain.Family;
 import hotspot.user.family.domain.FamilySubscription;
-
 import hotspot.user.policy.controller.response.AppliedPolicyResponse;
-
 import hotspot.user.policy.controller.response.FamilyAppliedPolicyResponse;
-
 import hotspot.user.policy.domain.BlockedServiceSub;
 import hotspot.user.policy.domain.PolicySub;
 

--- a/src/main/java/hotspot/user/policy/domain/mapper/BlockPolicyMapper.java
+++ b/src/main/java/hotspot/user/policy/domain/mapper/BlockPolicyMapper.java
@@ -2,6 +2,7 @@ package hotspot.user.policy.domain.mapper;
 
 import hotspot.user.policy.controller.response.BlockPolicyResponse;
 import hotspot.user.policy.domain.BlockPolicy;
+import hotspot.user.policy.domain.PolicySub;
 
 /**
  * request -> 도메인
@@ -12,7 +13,23 @@ public class BlockPolicyMapper {
     // request -> domain
 
     // domain -> response
+    // 관리자 차단 정책 도메인 -> response dto로 매핑
     public static BlockPolicyResponse toBlockPolicyResponse(BlockPolicy blockPolicy) {
-        return BlockPolicyResponse.from(blockPolicy);
+        return BlockPolicyResponse.builder()
+                .id(blockPolicy.getId())
+                .name(blockPolicy.getName())
+                .policyType(blockPolicy.getPolicyType())
+                .policySnapshot(blockPolicy.getPolicySnapshot())
+                .build();
+    }
+
+    // PolicySub(적용된 시간 정책) 도메인을 BlockPolicyResponse DTO로 변환
+    public static BlockPolicyResponse toBlockPolicyResponse(PolicySub policySub) {
+        return BlockPolicyResponse.builder()
+                .id(policySub.getId())
+                .name(policySub.getDateSnapshot().getPolicyName())
+                .policyType(policySub.getDateSnapshot().getPolicyType())
+                .policySnapshot(policySub.getDateSnapshot().getData())
+                .build();
     }
 }

--- a/src/main/java/hotspot/user/policy/infrastructure/BlockedServiceSubJpaRepository.java
+++ b/src/main/java/hotspot/user/policy/infrastructure/BlockedServiceSubJpaRepository.java
@@ -1,10 +1,10 @@
 package hotspot.user.policy.infrastructure;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import hotspot.user.policy.infrastructure.entity.BlockedServiceSubEntity;
-
-import java.util.List;
 
 public interface BlockedServiceSubJpaRepository extends JpaRepository<BlockedServiceSubEntity, Long> {
     List<BlockedServiceSubEntity> findBySubscriptionSubId(Long subId);

--- a/src/main/java/hotspot/user/policy/infrastructure/BlockedServiceSubJpaRepository.java
+++ b/src/main/java/hotspot/user/policy/infrastructure/BlockedServiceSubJpaRepository.java
@@ -4,5 +4,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import hotspot.user.policy.infrastructure.entity.BlockedServiceSubEntity;
 
+import java.util.List;
+
 public interface BlockedServiceSubJpaRepository extends JpaRepository<BlockedServiceSubEntity, Long> {
+    List<BlockedServiceSubEntity> findBySubscriptionSubId(Long subId);
 }

--- a/src/main/java/hotspot/user/policy/infrastructure/BlockedServiceSubRepositoryImpl.java
+++ b/src/main/java/hotspot/user/policy/infrastructure/BlockedServiceSubRepositoryImpl.java
@@ -1,0 +1,23 @@
+package hotspot.user.policy.infrastructure;
+
+import java.util.List;
+
+import org.springframework.stereotype.Repository;
+
+import hotspot.user.policy.domain.BlockedServiceSub;
+import hotspot.user.policy.infrastructure.entity.BlockedServiceSubEntity;
+import hotspot.user.policy.service.port.BlockedServiceSubRepository;
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class BlockedServiceSubRepositoryImpl implements BlockedServiceSubRepository {
+    private final BlockedServiceSubJpaRepository jpaRepository;
+
+    @Override
+    public List<BlockedServiceSub> findBySubId(Long subId) {
+        return jpaRepository.findBySubscriptionSubId(subId).stream()
+                .map(BlockedServiceSubEntity::entityToDomain)
+                .toList();
+    }
+}

--- a/src/main/java/hotspot/user/policy/infrastructure/PolicySubJpaRepository.java
+++ b/src/main/java/hotspot/user/policy/infrastructure/PolicySubJpaRepository.java
@@ -1,10 +1,10 @@
 package hotspot.user.policy.infrastructure;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import hotspot.user.policy.infrastructure.entity.PolicySubEntity;
-
-import java.util.List;
 
 public interface PolicySubJpaRepository extends JpaRepository<PolicySubEntity, Long> {
     List<PolicySubEntity> findBySubscriptionSubId(Long subId);

--- a/src/main/java/hotspot/user/policy/infrastructure/PolicySubJpaRepository.java
+++ b/src/main/java/hotspot/user/policy/infrastructure/PolicySubJpaRepository.java
@@ -4,5 +4,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import hotspot.user.policy.infrastructure.entity.PolicySubEntity;
 
+import java.util.List;
+
 public interface PolicySubJpaRepository extends JpaRepository<PolicySubEntity, Long> {
+    List<PolicySubEntity> findBySubscriptionSubId(Long subId);
 }

--- a/src/main/java/hotspot/user/policy/infrastructure/PolicySubRepositoryImpl.java
+++ b/src/main/java/hotspot/user/policy/infrastructure/PolicySubRepositoryImpl.java
@@ -1,0 +1,23 @@
+package hotspot.user.policy.infrastructure;
+
+import java.util.List;
+
+import org.springframework.stereotype.Repository;
+
+import hotspot.user.policy.domain.PolicySub;
+import hotspot.user.policy.infrastructure.entity.PolicySubEntity;
+import hotspot.user.policy.service.port.PolicySubRepository;
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class PolicySubRepositoryImpl implements PolicySubRepository {
+    private final PolicySubJpaRepository policySubJpaRepository;
+
+    @Override
+    public List<PolicySub> findBySubId(Long subId) {
+        return policySubJpaRepository.findBySubscriptionSubId(subId).stream()
+                .map(PolicySubEntity::entityToDomain)
+                .toList();
+    }
+}

--- a/src/main/java/hotspot/user/policy/infrastructure/entity/BlockedServiceSubEntity.java
+++ b/src/main/java/hotspot/user/policy/infrastructure/entity/BlockedServiceSubEntity.java
@@ -14,6 +14,7 @@ import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
 
 import hotspot.user.common.BaseEntity;
+import hotspot.user.policy.domain.BlockedServiceSub;
 import hotspot.user.subscription.infrastructure.entity.SubscriptionEntity;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -40,13 +41,21 @@ public class BlockedServiceSubEntity extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "sub_id")
-    private SubscriptionEntity subscriptionEntity;
+    private SubscriptionEntity subscription;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "blocked_service_id")
-    private AppBlockedServiceEntity appBlockedServiceEntity;
+    private AppBlockedServiceEntity appBlockedService;
 
     @Column(name = "is_deleted", nullable = false)
     @Builder.Default
     private Boolean isDeleted = false;
+
+    public BlockedServiceSub entityToDomain() {
+        return BlockedServiceSub.builder()
+                .id(this.blockedServiceSubId)
+                .subscription(this.subscription.entityToDomain())
+                .appBlockedService(this.appBlockedService.entityToDomain())
+                .build();
+    }
 }

--- a/src/main/java/hotspot/user/policy/infrastructure/entity/PolicySubEntity.java
+++ b/src/main/java/hotspot/user/policy/infrastructure/entity/PolicySubEntity.java
@@ -17,6 +17,7 @@ import org.hibernate.type.SqlTypes;
 
 import hotspot.user.common.BaseEntity;
 import hotspot.user.policy.domain.PolicySnapshot;
+import hotspot.user.policy.domain.PolicySub;
 import hotspot.user.subscription.infrastructure.entity.SubscriptionEntity;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -42,13 +43,21 @@ public class PolicySubEntity extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "sub_id")
-    private SubscriptionEntity subscriptionEntity;
+    private SubscriptionEntity subscription;
 
     @JdbcTypeCode(SqlTypes.JSON)
     @Column(columnDefinition = "jsonb") // PostgreSQL
-    private PolicySnapshot dateSnapshot; // [To-Do] dateSnapshot 도메인 클래스 생성 필요
+    private PolicySnapshot dateSnapshot;
 
     @Column(name = "is_deleted", nullable = false)
     @Builder.Default
     private Boolean isDeleted = false;
+
+    public PolicySub entityToDomain() {
+        return PolicySub.builder()
+                .id(this.policySubId)
+                .subscription(this.subscription.entityToDomain())
+                .policySnapshot(this.dateSnapshot)
+                .build();
+    }
 }

--- a/src/main/java/hotspot/user/policy/infrastructure/entity/PolicySubEntity.java
+++ b/src/main/java/hotspot/user/policy/infrastructure/entity/PolicySubEntity.java
@@ -16,7 +16,7 @@ import org.hibernate.annotations.Where;
 import org.hibernate.type.SqlTypes;
 
 import hotspot.user.common.BaseEntity;
-import hotspot.user.policy.domain.PolicySnapshot;
+import hotspot.user.policy.domain.DateSnapshot;
 import hotspot.user.policy.domain.PolicySub;
 import hotspot.user.subscription.infrastructure.entity.SubscriptionEntity;
 import lombok.AccessLevel;
@@ -47,7 +47,7 @@ public class PolicySubEntity extends BaseEntity {
 
     @JdbcTypeCode(SqlTypes.JSON)
     @Column(columnDefinition = "jsonb") // PostgreSQL
-    private PolicySnapshot dateSnapshot;
+    private DateSnapshot dateSnapshot;
 
     @Column(name = "is_deleted", nullable = false)
     @Builder.Default
@@ -57,7 +57,7 @@ public class PolicySubEntity extends BaseEntity {
         return PolicySub.builder()
                 .id(this.policySubId)
                 .subscription(this.subscription.entityToDomain())
-                .policySnapshot(this.dateSnapshot)
+                .dateSnapshot(this.dateSnapshot)
                 .build();
     }
 }

--- a/src/main/java/hotspot/user/policy/service/FindFamilyAppliedPolicyServiceImpl.java
+++ b/src/main/java/hotspot/user/policy/service/FindFamilyAppliedPolicyServiceImpl.java
@@ -1,0 +1,45 @@
+package hotspot.user.policy.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import hotspot.user.common.exception.ApplicationException;
+import hotspot.user.common.exception.code.FamilyErrorCode;
+import hotspot.user.family.domain.Family;
+import hotspot.user.family.domain.FamilySubscription;
+import hotspot.user.family.service.port.FamilyRepository;
+import hotspot.user.family.service.port.FamilySubscriptionRepository;
+import hotspot.user.policy.controller.port.FindFamilyAppliedPolicyService;
+import hotspot.user.policy.controller.port.FindMemberAppliedPolicyService;
+import hotspot.user.policy.controller.response.AppliedPolicyResponse;
+import hotspot.user.policy.controller.response.FamilyAppliedPolicyResponse;
+import hotspot.user.policy.domain.mapper.AppliedPolicyMapper;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class FindFamilyAppliedPolicyServiceImpl implements FindFamilyAppliedPolicyService {
+
+    private final FamilyRepository familyRepository;
+    private final FamilySubscriptionRepository familySubscriptionRepository;
+    private final FindMemberAppliedPolicyService findMemberAppliedPolicyService;
+
+    @Override
+    public FamilyAppliedPolicyResponse findByFamilyId(Long familyId) {
+        Family family = familyRepository.findById(familyId)
+                .orElseThrow(() -> new ApplicationException(FamilyErrorCode.FAMILY_NOT_FOUND));
+
+        List<FamilySubscription> memberMappings = familySubscriptionRepository.findByFamilyId(familyId);
+
+        List<AppliedPolicyResponse> memberPolicies = memberMappings.stream()
+                .map(mapping -> findMemberAppliedPolicyService
+                        .findByMemberId(mapping.getSubscription().getMember().getId()))
+                .toList();
+
+        // 매퍼의 통합 조립 메서드 호출
+        return AppliedPolicyMapper.toFamilyAppliedPolicyResponse(family, memberPolicies);
+    }
+}

--- a/src/main/java/hotspot/user/policy/service/FindMemberAppliedPolicyServiceImpl.java
+++ b/src/main/java/hotspot/user/policy/service/FindMemberAppliedPolicyServiceImpl.java
@@ -1,0 +1,43 @@
+package hotspot.user.policy.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import hotspot.user.common.exception.ApplicationException;
+import hotspot.user.common.exception.code.MemberErrorCode;
+import hotspot.user.family.domain.FamilySubscription;
+import hotspot.user.family.service.port.FamilySubscriptionRepository;
+import hotspot.user.policy.controller.port.FindMemberAppliedPolicyService;
+import hotspot.user.policy.controller.response.AppliedPolicyResponse;
+import hotspot.user.policy.domain.BlockedServiceSub;
+import hotspot.user.policy.domain.PolicySub;
+import hotspot.user.policy.domain.mapper.AppliedPolicyMapper;
+import hotspot.user.policy.service.port.BlockedServiceSubRepository;
+import hotspot.user.policy.service.port.PolicySubRepository;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class FindMemberAppliedPolicyServiceImpl implements FindMemberAppliedPolicyService {
+
+    private final FamilySubscriptionRepository familySubscriptionRepository;
+    private final PolicySubRepository policySubRepository;
+    private final BlockedServiceSubRepository blockedServiceSubRepository;
+
+    @Override
+    public AppliedPolicyResponse findByMemberId(Long memberId) {
+        FamilySubscription familySub = familySubscriptionRepository.findByMemberId(memberId)
+                .orElseThrow(() -> new ApplicationException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+        Long subId = familySub.getSubscription().getId();
+
+        List<PolicySub> policySubs = policySubRepository.findBySubId(subId);
+        List<BlockedServiceSub> blockedServiceSubs = blockedServiceSubRepository.findBySubId(subId);
+
+        // 매퍼의 통합 조립 메서드 호출
+        return AppliedPolicyMapper.toAppliedPolicyResponse(familySub, policySubs, blockedServiceSubs);
+    }
+}

--- a/src/main/java/hotspot/user/policy/service/port/BlockedServiceSubRepository.java
+++ b/src/main/java/hotspot/user/policy/service/port/BlockedServiceSubRepository.java
@@ -1,8 +1,8 @@
 package hotspot.user.policy.service.port;
 
-import hotspot.user.policy.domain.BlockedServiceSub;
-
 import java.util.List;
+
+import hotspot.user.policy.domain.BlockedServiceSub;
 
 /**
  * 앱 차단 서비스 - 회선 매핑 테이블 리포지토리 (컨트롤러 - 서비스 구간)

--- a/src/main/java/hotspot/user/policy/service/port/BlockedServiceSubRepository.java
+++ b/src/main/java/hotspot/user/policy/service/port/BlockedServiceSubRepository.java
@@ -1,0 +1,12 @@
+package hotspot.user.policy.service.port;
+
+import hotspot.user.policy.domain.BlockedServiceSub;
+
+import java.util.List;
+
+/**
+ * 앱 차단 서비스 - 회선 매핑 테이블 리포지토리 (컨트롤러 - 서비스 구간)
+ */
+public interface BlockedServiceSubRepository {
+    List<BlockedServiceSub> findBySubId(Long subId);
+}

--- a/src/main/java/hotspot/user/policy/service/port/PolicySubRepository.java
+++ b/src/main/java/hotspot/user/policy/service/port/PolicySubRepository.java
@@ -1,0 +1,12 @@
+package hotspot.user.policy.service.port;
+
+import hotspot.user.policy.domain.PolicySub;
+
+import java.util.List;
+
+/**
+ * 정책-회선 매핑 테이블 리포지토리 (컨트롤러 - 서비스 구간)
+ */
+public interface PolicySubRepository {
+    List<PolicySub> findBySubId(Long subId);
+}

--- a/src/main/java/hotspot/user/policy/service/port/PolicySubRepository.java
+++ b/src/main/java/hotspot/user/policy/service/port/PolicySubRepository.java
@@ -1,8 +1,8 @@
 package hotspot.user.policy.service.port;
 
-import hotspot.user.policy.domain.PolicySub;
-
 import java.util.List;
+
+import hotspot.user.policy.domain.PolicySub;
 
 /**
  * 정책-회선 매핑 테이블 리포지토리 (컨트롤러 - 서비스 구간)

--- a/src/test/java/hotspot/user/auth/service/IssueTokenServiceImplTest.java
+++ b/src/test/java/hotspot/user/auth/service/IssueTokenServiceImplTest.java
@@ -48,7 +48,7 @@ class IssueTokenServiceImplTest {
         given(jwtProvider.createRefreshToken(any(Authentication.class))).willReturn("refresh-token");
 
         // when
-        TokenResponse response = issueTokenService.issue(member, email, role);
+        TokenResponse response = issueTokenService.issue(member, email, role, 100L);
 
         // then
         assertThat(response.accessToken()).isEqualTo("access-token");

--- a/src/test/java/hotspot/user/auth/service/LogoutServiceImplTest.java
+++ b/src/test/java/hotspot/user/auth/service/LogoutServiceImplTest.java
@@ -41,10 +41,8 @@ class LogoutServiceImplTest {
                 TokenRequest request = new TokenRequest(refreshToken);
                 Long memberId = 1L;
 
-                PrincipalDetails principal = new PrincipalDetails(memberId,
-                        "test@test.com",
-                        FamilyRole.CHILD,
-                        Status.APPROVED);
+                        PrincipalDetails principal = new PrincipalDetails(memberId, "test@test.com", 100L,
+                FamilyRole.CHILD, Status.APPROVED);
 
                 Authentication authentication = Mockito.mock(Authentication.class);
                 given(authentication.getPrincipal()).willReturn(principal);

--- a/src/test/java/hotspot/user/auth/service/OnboardingServiceImplTest.java
+++ b/src/test/java/hotspot/user/auth/service/OnboardingServiceImplTest.java
@@ -90,6 +90,8 @@ class OnboardingServiceImplTest {
 
         // then
         assertThat(response.accessToken()).isEqualTo("at");
+        verify(memberRepository).save(any(Member.class));
+        verify(subscriptionRepository).save(any(Subscription.class));
         verify(issueTokenService).issue(any(Member.class), anyString(), any(FamilyRole.class), anyLong());
     }
 
@@ -129,6 +131,7 @@ class OnboardingServiceImplTest {
 
         // then
         assertThat(response.accessToken()).isEqualTo("at");
+        verify(socialAccountRepository).save(any(SocialAccount.class));
         verify(memberRepository).delete(pendingMember);
         verify(issueTokenService).issue(any(Member.class), anyString(), any(FamilyRole.class), anyLong());
     }

--- a/src/test/java/hotspot/user/auth/service/OnboardingServiceImplTest.java
+++ b/src/test/java/hotspot/user/auth/service/OnboardingServiceImplTest.java
@@ -3,10 +3,10 @@ package hotspot.user.auth.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import java.util.Optional;
@@ -24,6 +24,7 @@ import hotspot.user.auth.controller.response.TokenResponse;
 import hotspot.user.common.exception.ApplicationException;
 import hotspot.user.common.exception.code.MemberErrorCode;
 import hotspot.user.common.util.PhoneUtil;
+import hotspot.user.family.domain.Family;
 import hotspot.user.family.domain.FamilySubscription;
 import hotspot.user.family.service.port.FamilySubscriptionRepository;
 import hotspot.user.member.domain.FamilyRole;
@@ -60,14 +61,17 @@ class OnboardingServiceImplTest {
     void onboardingSuccessNewMember() {
         // given
         Long memberId = 1L;
+        Long familyId = 100L;
         String phoneNumber = "01012345678";
         String phoneHash = PhoneUtil.hashPhoneNumber(phoneNumber);
         OnboardingRequest request = new OnboardingRequest(memberId, "test@test.com", phoneNumber, "950101");
 
-        Member pendingMember = Member.builder().id(memberId).status(Status.PENDING).build();
+        Member pendingMember = Member.builder().id(memberId).name("test").status(Status.PENDING).build();
         SocialAccount socialAccount = SocialAccount.builder().memberId(memberId).email("test@test.com").build();
         Subscription subscription = Subscription.builder().id(100L).phoneHash(phoneHash).build();
-        FamilySubscription familySubscription = FamilySubscription.builder().familyRole(FamilyRole.CHILD).build();
+        Family family = Family.builder().id(familyId).build();
+        FamilySubscription familySubscription = FamilySubscription.builder()
+                .family(family).familyRole(FamilyRole.CHILD).build();
 
         given(subscriptionRepository.findByPhoneHash(phoneHash)).willReturn(Optional.of(subscription));
         given(memberRepository.findById(memberId)).willReturn(Optional.of(pendingMember));
@@ -77,9 +81,8 @@ class OnboardingServiceImplTest {
         given(memberRepository.save(any(Member.class))).willAnswer(invocation -> invocation.getArgument(0));
         given(subscriptionRepository.save(any(Subscription.class))).willAnswer(invocation -> invocation.getArgument(0));
 
-        // IssueTokenService 호출 시 성공 응답 설정
         TokenResponse expectedResponse = new TokenResponse("at", "rt");
-        given(issueTokenService.issue(any(Member.class), eq("test@test.com"), eq(FamilyRole.CHILD)))
+        given(issueTokenService.issue(any(Member.class), eq("test@test.com"), eq(FamilyRole.CHILD), eq(familyId)))
                 .willReturn(expectedResponse);
 
         // when
@@ -87,9 +90,7 @@ class OnboardingServiceImplTest {
 
         // then
         assertThat(response.accessToken()).isEqualTo("at");
-        verify(memberRepository).save(any(Member.class));
-        verify(subscriptionRepository).save(any(Subscription.class));
-        verify(issueTokenService).issue(any(Member.class), anyString(), any(FamilyRole.class));
+        verify(issueTokenService).issue(any(Member.class), anyString(), any(FamilyRole.class), anyLong());
     }
 
     @Test
@@ -98,6 +99,7 @@ class OnboardingServiceImplTest {
         // given
         Long pendingMemberId = 1L;
         Long existingMemberId = 2L;
+        Long familyId = 100L;
         String phoneNumber = "01012345678";
         String phoneHash = PhoneUtil.hashPhoneNumber(phoneNumber);
         OnboardingRequest request = new OnboardingRequest(pendingMemberId, "test@test.com", phoneNumber, "950101");
@@ -106,7 +108,9 @@ class OnboardingServiceImplTest {
         Member existingMember = Member.builder().id(existingMemberId).status(Status.APPROVED).build();
         SocialAccount socialAccount = SocialAccount.builder().memberId(pendingMemberId).email("test@test.com").build();
         Subscription subscription = Subscription.builder().id(100L).member(existingMember).phoneHash(phoneHash).build();
-        FamilySubscription familySubscription = FamilySubscription.builder().familyRole(FamilyRole.PARENT).build();
+        Family family = Family.builder().id(familyId).build();
+        FamilySubscription familySubscription = FamilySubscription.builder()
+                .family(family).familyRole(FamilyRole.PARENT).build();
 
         given(subscriptionRepository.findByPhoneHash(phoneHash)).willReturn(Optional.of(subscription));
         given(memberRepository.findById(pendingMemberId)).willReturn(Optional.of(pendingMember));
@@ -117,7 +121,7 @@ class OnboardingServiceImplTest {
                 .willAnswer(invocation -> invocation.getArgument(0));
 
         TokenResponse expectedResponse = new TokenResponse("at", "rt");
-        given(issueTokenService.issue(any(Member.class), eq("test@test.com"), eq(FamilyRole.PARENT)))
+        given(issueTokenService.issue(any(Member.class), eq("test@test.com"), eq(FamilyRole.PARENT), eq(familyId)))
                 .willReturn(expectedResponse);
 
         // when
@@ -126,8 +130,7 @@ class OnboardingServiceImplTest {
         // then
         assertThat(response.accessToken()).isEqualTo("at");
         verify(memberRepository).delete(pendingMember);
-        verify(socialAccountRepository).save(any(SocialAccount.class));
-        verify(memberRepository, never()).save(any(Member.class));
+        verify(issueTokenService).issue(any(Member.class), anyString(), any(FamilyRole.class), anyLong());
     }
 
     @Test

--- a/src/test/java/hotspot/user/auth/service/ReissueTokenServiceImplTest.java
+++ b/src/test/java/hotspot/user/auth/service/ReissueTokenServiceImplTest.java
@@ -49,7 +49,8 @@ class ReissueTokenServiceImplTest {
         TokenRequest request = new TokenRequest(oldRefreshToken);
         Long memberId = 1L;
 
-        PrincipalDetails principal = new PrincipalDetails(memberId, "test@test.com", FamilyRole.CHILD, Status.APPROVED);
+        PrincipalDetails principal = new PrincipalDetails(memberId, "test@test.com", 100L,
+                FamilyRole.CHILD, Status.APPROVED);
         Token savedToken = Token.builder()
                 .memberId(memberId)
                 .refreshToken(oldRefreshToken)
@@ -95,7 +96,8 @@ class ReissueTokenServiceImplTest {
         TokenRequest request = new TokenRequest(refreshToken);
         Long memberId = 1L;
 
-        PrincipalDetails principal = new PrincipalDetails(memberId, "test@test.com", FamilyRole.CHILD, Status.APPROVED);
+        PrincipalDetails principal = new PrincipalDetails(memberId, "test@test.com", 100L,
+                FamilyRole.CHILD, Status.APPROVED);
         Token savedToken = Token.builder()
                 .memberId(memberId)
                 .refreshToken("different-token")

--- a/src/test/java/hotspot/user/common/security/oauth/CustomOidcUserServiceTest.java
+++ b/src/test/java/hotspot/user/common/security/oauth/CustomOidcUserServiceTest.java
@@ -65,7 +65,8 @@ class CustomOidcUserServiceTest {
             1L,
             "test@google.com",
             Status.PENDING,
-            FamilyRole.CHILD
+            FamilyRole.CHILD,
+            100L
         );
         when(socialLoginService.login(any(CreateSocialAccountRequest.class))).thenReturn(loginResult);
 
@@ -79,5 +80,6 @@ class CustomOidcUserServiceTest {
         assertThat(principalDetails.getEmail()).isEqualTo(loginResult.email());
         assertThat(principalDetails.getStatus()).isEqualTo(loginResult.status());
         assertThat(principalDetails.getRole()).isEqualTo(loginResult.familyRole());
+        assertThat(principalDetails.getFamilyId()).isEqualTo(100L);
     }
 }

--- a/src/test/java/hotspot/user/family/infrastructure/FamilySubscriptionRepositoryImplTest.java
+++ b/src/test/java/hotspot/user/family/infrastructure/FamilySubscriptionRepositoryImplTest.java
@@ -3,6 +3,7 @@ package hotspot.user.family.infrastructure;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.junit.jupiter.api.DisplayName;
@@ -61,5 +62,53 @@ class FamilySubscriptionRepositoryImplTest {
         // then
         assertThat(result).isPresent();
         assertThat(result.get().getFamilyRole()).isEqualTo(FamilyRole.CHILD);
+    }
+
+    @Test
+    @DisplayName("가족 ID로 소속된 모든 구성원 정보 조회 성공")
+    void findByFamilyIdSuccess() {
+        // given
+        Long familyId = 1L;
+        FamilySubscriptionEntity entity = FamilySubscriptionEntity.builder()
+                .familySubId(1L)
+                .subscription(SubscriptionEntity.builder().subId(100L)
+                        .member(MemberEntity.builder().id(1L).build())
+                        .plan(PlanEntity.builder().planId(1L).build())
+                        .build())
+                .family(FamilyEntity.builder().familyId(familyId).build())
+                .familyRole(FamilyRole.CHILD)
+                .build();
+
+        given(familySubscriptionJpaRepository.findByFamilyFamilyId(familyId)).willReturn(List.of(entity));
+
+        // when
+        List<FamilySubscription> result = familySubscriptionRepository.findByFamilyId(familyId);
+
+        // then
+        assertThat(result).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("멤버 ID로 소속된 가족 매핑 정보 조회 성공")
+    void findByMemberIdSuccess() {
+        // given
+        Long memberId = 1L;
+        FamilySubscriptionEntity entity = FamilySubscriptionEntity.builder()
+                .familySubId(1L)
+                .subscription(SubscriptionEntity.builder().subId(100L)
+                        .member(MemberEntity.builder().id(memberId).build())
+                        .plan(PlanEntity.builder().planId(1L).build())
+                        .build())
+                .family(FamilyEntity.builder().familyId(1L).build())
+                .familyRole(FamilyRole.CHILD)
+                .build();
+
+        given(familySubscriptionJpaRepository.findBySubscriptionMemberId(memberId)).willReturn(Optional.of(entity));
+
+        // when
+        Optional<FamilySubscription> result = familySubscriptionRepository.findByMemberId(memberId);
+
+        // then
+        assertThat(result).isPresent();
     }
 }

--- a/src/test/java/hotspot/user/member/service/SocialLoginServiceImplTest.java
+++ b/src/test/java/hotspot/user/member/service/SocialLoginServiceImplTest.java
@@ -17,6 +17,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import hotspot.user.auth.controller.response.LoginResponse;
 import hotspot.user.common.exception.ApplicationException;
 import hotspot.user.common.exception.code.MemberErrorCode;
+import hotspot.user.family.domain.Family;
 import hotspot.user.family.domain.FamilySubscription;
 import hotspot.user.family.service.port.FamilySubscriptionRepository;
 import hotspot.user.member.controller.port.RegisterSocialMemberService;
@@ -76,6 +77,10 @@ class SocialLoginServiceImplTest {
                 .status(Status.APPROVED)
                 .build();
 
+        Family family = Family.builder()
+                .id(100L)
+                .build();
+
         Subscription subscription = Subscription.builder()
                 .id(10L)
                 .member(Member.builder().id(memberId).build()) // Corrected: use member() builder method
@@ -84,6 +89,7 @@ class SocialLoginServiceImplTest {
         FamilySubscription familySubscription = FamilySubscription.builder()
                 .id(100L)
                 .subscription(subscription) // Corrected: use subscription() builder method
+                .family(family)
                 .familyRole(FamilyRole.PARENT)
                 .build();
 
@@ -101,6 +107,7 @@ class SocialLoginServiceImplTest {
         assertThat(result.email()).isEqualTo(email);
         assertThat(result.status()).isEqualTo(Status.APPROVED);
         assertThat(result.familyRole()).isEqualTo(FamilyRole.PARENT);
+        assertThat(result.familyId()).isEqualTo(100L);
     }
 
     @Test
@@ -114,7 +121,8 @@ class SocialLoginServiceImplTest {
             2L,
             email,
             Status.PENDING,
-            FamilyRole.CHILD
+            FamilyRole.CHILD,
+            null
         );
 
         given(socialAccountRepository.findByEmail(email)).willReturn(Optional.empty());

--- a/src/test/java/hotspot/user/policy/controller/AppliedPolicyControllerTest.java
+++ b/src/test/java/hotspot/user/policy/controller/AppliedPolicyControllerTest.java
@@ -1,0 +1,147 @@
+package hotspot.user.policy.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.web.servlet.MockMvc;
+
+import hotspot.user.common.exception.ApplicationException;
+import hotspot.user.common.exception.code.AuthErrorCode;
+import hotspot.user.common.security.PrincipalDetails;
+import hotspot.user.common.security.jwt.JwtFilter;
+import hotspot.user.common.security.jwt.JwtProvider;
+import hotspot.user.member.domain.FamilyRole;
+import hotspot.user.member.domain.Status;
+import hotspot.user.policy.controller.port.FindFamilyAppliedPolicyService;
+import hotspot.user.policy.controller.port.FindMemberAppliedPolicyService;
+import hotspot.user.policy.controller.response.AppliedPolicyResponse;
+import hotspot.user.policy.controller.response.FamilyAppliedPolicyResponse;
+
+@WebMvcTest(AppliedPolicyController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class AppliedPolicyControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private FindMemberAppliedPolicyService findMemberAppliedPolicyService;
+
+    @MockBean
+    private FindFamilyAppliedPolicyService findFamilyAppliedPolicyService;
+
+    @MockBean
+    private JwtFilter jwtFilter;
+
+    @MockBean
+    private JwtProvider jwtProvider;
+
+    @MockBean
+    private JpaMetamodelMappingContext jpaMetamodelMappingContext;
+
+    private void setAuthentication(FamilyRole role) {
+        PrincipalDetails principal = PrincipalDetails.builder()
+                .id(1L)
+                .email("test@test.com")
+                .familyId(100L)
+                .role(role)
+                .status(Status.APPROVED)
+                .build();
+
+        UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(
+                principal, null, principal.getAuthorities());
+        SecurityContextHolder.getContext().setAuthentication(auth);
+    }
+
+    @Test
+    @DisplayName("본인 적용 정책 조회 성공: 역할에 상관없이 조회 가능하다")
+    void getAppliedPoliciesIndividualSuccess() throws Exception {
+        // given
+        setAuthentication(FamilyRole.CHILD);
+        AppliedPolicyResponse response = AppliedPolicyResponse.builder()
+                .memberId(1L)
+                .memberName("자녀")
+                .build();
+
+        given(findMemberAppliedPolicyService.findByMemberId(1L)).willReturn(response);
+
+        // when & then
+        mockMvc.perform(get("/api/v1/policies/applied")
+                        .param("isFamily", "false")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.memberName").value("자녀"));
+    }
+
+    @Test
+    @DisplayName("가족 전체 정책 조회 성공: PARENT 권한일 때")
+    void getAppliedPoliciesFamilySuccessByParent() throws Exception {
+        // given
+        setAuthentication(FamilyRole.PARENT);
+        FamilyAppliedPolicyResponse response = FamilyAppliedPolicyResponse.builder()
+                .familyId(100L)
+                .memberPolicies(List.of())
+                .build();
+
+        given(findFamilyAppliedPolicyService.findByFamilyId(100L)).willReturn(response);
+
+        // when & then
+        mockMvc.perform(get("/api/v1/policies/applied")
+                        .param("isFamily", "true")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.familyId").value(100L));
+    }
+
+    @Test
+    @DisplayName("가족 전체 정책 조회 실패: CHILD 권한일 때 (ACCESS_DENIED)")
+    void getAppliedPoliciesFamilyFailByChild() throws Exception {
+        // given
+        setAuthentication(FamilyRole.CHILD);
+
+        // when & then
+        mockMvc.perform(get("/api/v1/policies/applied")
+                        .param("isFamily", "true")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isForbidden())
+                .andExpect(result -> {
+                    assertThat(result.getResolvedException())
+                            .isInstanceOf(ApplicationException.class)
+                            .hasMessage(AuthErrorCode.ACCESS_DENIED.getMessage());
+                });
+    }
+
+    @Test
+    @DisplayName("임시 테스트 API 조회 성공: 파라미터 기반 조회 확인")
+    void getAppliedPoliciesTestApiSuccess() throws Exception {
+        // given
+        AppliedPolicyResponse response = AppliedPolicyResponse.builder()
+                .memberId(1L)
+                .memberName("테스트유저")
+                .build();
+        given(findMemberAppliedPolicyService.findByMemberId(1L)).willReturn(response);
+
+        // when & then
+        mockMvc.perform(get("/api/v1/policies/applied/test")
+                        .param("testMemberId", "1")
+                        .param("isFamily", "false")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.memberName").value("테스트유저"));
+    }
+}

--- a/src/test/java/hotspot/user/policy/infrastructure/BlockedServiceSubRepositoryImplTest.java
+++ b/src/test/java/hotspot/user/policy/infrastructure/BlockedServiceSubRepositoryImplTest.java
@@ -12,17 +12,12 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import hotspot.user.member.infrastructure.entity.MemberEntity;
+import hotspot.user.plan.infrastructure.entity.PlanEntity;
 import hotspot.user.policy.domain.BlockedServiceSub;
 import hotspot.user.policy.infrastructure.entity.AppBlockedServiceEntity;
 import hotspot.user.policy.infrastructure.entity.BlockedServiceSubEntity;
 import hotspot.user.subscription.infrastructure.entity.SubscriptionEntity;
-
-/**
- * 차단 서비스-회선 조회 매핑 Repository 단위 테스트
- */
-
-import hotspot.user.member.infrastructure.entity.MemberEntity;
-import hotspot.user.plan.infrastructure.entity.PlanEntity;
 
 @ExtendWith(MockitoExtension.class)
 class BlockedServiceSubRepositoryImplTest {

--- a/src/test/java/hotspot/user/policy/infrastructure/BlockedServiceSubRepositoryImplTest.java
+++ b/src/test/java/hotspot/user/policy/infrastructure/BlockedServiceSubRepositoryImplTest.java
@@ -1,0 +1,67 @@
+package hotspot.user.policy.infrastructure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import hotspot.user.policy.domain.BlockedServiceSub;
+import hotspot.user.policy.infrastructure.entity.AppBlockedServiceEntity;
+import hotspot.user.policy.infrastructure.entity.BlockedServiceSubEntity;
+import hotspot.user.subscription.infrastructure.entity.SubscriptionEntity;
+
+/**
+ * 차단 서비스-회선 조회 매핑 Repository 단위 테스트
+ */
+
+import hotspot.user.member.infrastructure.entity.MemberEntity;
+import hotspot.user.plan.infrastructure.entity.PlanEntity;
+
+@ExtendWith(MockitoExtension.class)
+class BlockedServiceSubRepositoryImplTest {
+
+    @Mock
+    private BlockedServiceSubJpaRepository jpaRepository;
+
+    @InjectMocks
+    private BlockedServiceSubRepositoryImpl repository;
+
+    @Test
+    @DisplayName("회선 ID로 차단된 앱 목록 조회 성공")
+    void findBySubIdSuccess() {
+        // given
+        Long subId = 100L;
+        SubscriptionEntity subEntity = SubscriptionEntity.builder()
+                .subId(subId)
+                .member(MemberEntity.builder().id(1L).build())
+                .plan(PlanEntity.builder().planId(1L).build())
+                .build();
+        AppBlockedServiceEntity appEntity = AppBlockedServiceEntity.builder()
+                .appBlockedServiceId(1L)
+                .blockedServiceName("YouTube")
+                .blockedServiceCode("YOUTUBE")
+                .build();
+
+        BlockedServiceSubEntity entity = BlockedServiceSubEntity.builder()
+                .blockedServiceSubId(10L)
+                .subscription(subEntity)
+                .appBlockedService(appEntity)
+                .build();
+
+        given(jpaRepository.findBySubscriptionSubId(subId)).willReturn(List.of(entity));
+
+        // when
+        List<BlockedServiceSub> result = repository.findBySubId(subId);
+
+        // then
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getAppBlockedService().getName()).isEqualTo("YouTube");
+    }
+}

--- a/src/test/java/hotspot/user/policy/infrastructure/PolicySubRepositoryImplTest.java
+++ b/src/test/java/hotspot/user/policy/infrastructure/PolicySubRepositoryImplTest.java
@@ -1,0 +1,68 @@
+package hotspot.user.policy.infrastructure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import hotspot.user.policy.domain.DateSnapshot;
+import hotspot.user.policy.domain.PolicySub;
+import hotspot.user.policy.infrastructure.entity.PolicySubEntity;
+import hotspot.user.subscription.infrastructure.entity.SubscriptionEntity;
+
+/**
+ * 정책-회선 조회 매핑 Repository 단위 테스트
+ */
+import hotspot.user.member.infrastructure.entity.MemberEntity;
+import hotspot.user.plan.infrastructure.entity.PlanEntity;
+
+/**
+ * 정책-회선 조회 매핑 Repository 단위 테스트
+ */
+
+@ExtendWith(MockitoExtension.class)
+class PolicySubRepositoryImplTest {
+
+    @Mock
+    private PolicySubJpaRepository jpaRepository;
+
+    @InjectMocks
+    private PolicySubRepositoryImpl repository;
+
+    @Test
+    @DisplayName("회선 ID로 적용된 시간 정책 목록 조회 성공")
+    void findBySubIdSuccess() {
+        // given
+        Long subId = 100L;
+        SubscriptionEntity subEntity = SubscriptionEntity.builder()
+                .subId(subId)
+                .member(MemberEntity.builder().id(1L).build())
+                .plan(PlanEntity.builder().planId(1L).build())
+                .build();
+        DateSnapshot snapshot = DateSnapshot.builder()
+                .policyName("수면 모드")
+                .build();
+
+        PolicySubEntity entity = PolicySubEntity.builder()
+                .policySubId(10L)
+                .subscription(subEntity)
+                .dateSnapshot(snapshot)
+                .build();
+
+        given(jpaRepository.findBySubscriptionSubId(subId)).willReturn(List.of(entity));
+
+        // when
+        List<PolicySub> result = repository.findBySubId(subId);
+
+        // then
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getDateSnapshot().getPolicyName()).isEqualTo("수면 모드");
+    }
+}

--- a/src/test/java/hotspot/user/policy/infrastructure/PolicySubRepositoryImplTest.java
+++ b/src/test/java/hotspot/user/policy/infrastructure/PolicySubRepositoryImplTest.java
@@ -12,16 +12,12 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import hotspot.user.member.infrastructure.entity.MemberEntity;
+import hotspot.user.plan.infrastructure.entity.PlanEntity;
 import hotspot.user.policy.domain.DateSnapshot;
 import hotspot.user.policy.domain.PolicySub;
 import hotspot.user.policy.infrastructure.entity.PolicySubEntity;
 import hotspot.user.subscription.infrastructure.entity.SubscriptionEntity;
-
-/**
- * 정책-회선 조회 매핑 Repository 단위 테스트
- */
-import hotspot.user.member.infrastructure.entity.MemberEntity;
-import hotspot.user.plan.infrastructure.entity.PlanEntity;
 
 /**
  * 정책-회선 조회 매핑 Repository 단위 테스트

--- a/src/test/java/hotspot/user/policy/service/FindFamilyAppliedPolicyServiceImplTest.java
+++ b/src/test/java/hotspot/user/policy/service/FindFamilyAppliedPolicyServiceImplTest.java
@@ -1,0 +1,79 @@
+package hotspot.user.policy.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import hotspot.user.family.domain.Family;
+import hotspot.user.family.domain.FamilySubscription;
+import hotspot.user.family.domain.PriorityType;
+import hotspot.user.family.service.port.FamilyRepository;
+import hotspot.user.family.service.port.FamilySubscriptionRepository;
+import hotspot.user.member.domain.Member;
+import hotspot.user.policy.controller.port.FindMemberAppliedPolicyService;
+import hotspot.user.policy.controller.response.AppliedPolicyResponse;
+import hotspot.user.policy.controller.response.FamilyAppliedPolicyResponse;
+import hotspot.user.subscription.domain.Subscription;
+
+/**
+ * 한 가족 구성원 전체 적용 정책 조회 Service 단위 테스트
+ */
+
+@ExtendWith(MockitoExtension.class)
+class FindFamilyAppliedPolicyServiceImplTest {
+
+    @Mock
+    private FamilyRepository familyRepository;
+    @Mock
+    private FamilySubscriptionRepository familySubscriptionRepository;
+    @Mock
+    private FindMemberAppliedPolicyService findMemberAppliedPolicyService;
+
+    @InjectMocks
+    private FindFamilyAppliedPolicyServiceImpl findFamilyAppliedPolicyService;
+
+    @Test
+    @DisplayName("가족 ID로 전체 구성원의 통합 정책을 조회한다")
+    void findFamilyAppliedPoliciesSuccess() {
+        // given
+        Long familyId = 1L;
+        Long memberId = 10L;
+
+        Family family = Family.builder()
+                .id(familyId)
+                .familyNum(2)
+                .familyDataAmount(100)
+                .priorityType(PriorityType.FIFO)
+                .build();
+
+        Member member = Member.builder().id(memberId).name("홍길동").build();
+        Subscription sub = Subscription.builder().id(100L).member(member).build();
+        FamilySubscription mapping = FamilySubscription.builder().subscription(sub).build();
+
+        AppliedPolicyResponse memberResponse = AppliedPolicyResponse.builder()
+                .memberId(memberId)
+                .memberName("홍길동")
+                .build();
+
+        given(familyRepository.findById(familyId)).willReturn(Optional.of(family));
+        given(familySubscriptionRepository.findByFamilyId(familyId)).willReturn(List.of(mapping));
+        given(findMemberAppliedPolicyService.findByMemberId(memberId)).willReturn(memberResponse);
+
+        // when
+        FamilyAppliedPolicyResponse response = findFamilyAppliedPolicyService.findByFamilyId(familyId);
+
+        // then
+        assertThat(response.familyId()).isEqualTo(familyId);
+        assertThat(response.memberPolicies()).hasSize(1);
+        assertThat(response.memberPolicies().get(0).memberName()).isEqualTo("홍길동");
+    }
+}

--- a/src/test/java/hotspot/user/policy/service/FindMemberAppliedPolicyServiceImplTest.java
+++ b/src/test/java/hotspot/user/policy/service/FindMemberAppliedPolicyServiceImplTest.java
@@ -1,0 +1,95 @@
+package hotspot.user.policy.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import hotspot.user.common.exception.ApplicationException;
+import hotspot.user.common.exception.code.MemberErrorCode;
+import hotspot.user.family.domain.FamilySubscription;
+import hotspot.user.family.service.port.FamilySubscriptionRepository;
+import hotspot.user.member.domain.Member;
+import hotspot.user.policy.controller.response.AppliedPolicyResponse;
+import hotspot.user.policy.domain.AppBlockedService;
+import hotspot.user.policy.domain.BlockedServiceSub;
+import hotspot.user.policy.domain.DateSnapshot;
+import hotspot.user.policy.domain.PolicySub;
+import hotspot.user.policy.service.port.BlockedServiceSubRepository;
+import hotspot.user.policy.service.port.PolicySubRepository;
+import hotspot.user.subscription.domain.Subscription;
+
+/**
+ * 구성원 1명 적용 정책 조회 Service 단위 테스트
+ */
+@ExtendWith(MockitoExtension.class)
+class FindMemberAppliedPolicyServiceImplTest {
+
+    @Mock
+    private FamilySubscriptionRepository familySubscriptionRepository;
+    @Mock
+    private PolicySubRepository policySubRepository;
+    @Mock
+    private BlockedServiceSubRepository blockedServiceSubRepository;
+
+    @InjectMocks
+    private FindMemberAppliedPolicyServiceImpl findMemberAppliedPolicyService;
+
+    @Test
+    @DisplayName("멤버 ID로 적용된 모든 정책 정보(시간+앱차단)를 통합 조회한다")
+    void findAppliedPoliciesSuccess() {
+        // given
+        Long memberId = 1L;
+        Long subId = 100L;
+
+        Member member = Member.builder().id(memberId).name("홍길동").build();
+        Subscription sub = Subscription.builder().id(subId).member(member).build();
+        FamilySubscription familySub = FamilySubscription.builder()
+                .subscription(sub)
+                .dataLimit(10)
+                .priority(1)
+                .build();
+
+        DateSnapshot snapshot = DateSnapshot.builder().policyName("수면 모드").build();
+        PolicySub policySub = PolicySub.builder().id(10L).dateSnapshot(snapshot).build();
+
+        AppBlockedService app = AppBlockedService.builder().name("YouTube").serviceCode("YOUTUBE").build();
+        BlockedServiceSub blockedSub = BlockedServiceSub.builder().id(20L).appBlockedService(app).build();
+
+        given(familySubscriptionRepository.findByMemberId(memberId)).willReturn(Optional.of(familySub));
+        given(policySubRepository.findBySubId(subId)).willReturn(List.of(policySub));
+        given(blockedServiceSubRepository.findBySubId(subId)).willReturn(List.of(blockedSub));
+
+        // when
+        AppliedPolicyResponse response = findMemberAppliedPolicyService.findByMemberId(memberId);
+
+        // then
+        assertThat(response.memberId()).isEqualTo(memberId);
+        assertThat(response.memberName()).isEqualTo("홍길동");
+        assertThat(response.blockPolicyResponseList()).hasSize(1);
+        assertThat(response.appBlockedServiceResponseList()).hasSize(1);
+        assertThat(response.blockPolicyResponseList().get(0).name()).isEqualTo("수면 모드");
+    }
+
+    @Test
+    @DisplayName("멤버 정보가 존재하지 않으면 예외가 발생한다")
+    void findAppliedPoliciesFail() {
+        // given
+        Long invalidId = 999L;
+        given(familySubscriptionRepository.findByMemberId(invalidId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> findMemberAppliedPolicyService.findByMemberId(invalidId))
+                .isExactlyInstanceOf(ApplicationException.class)
+                .hasMessageContaining(MemberErrorCode.MEMBER_NOT_FOUND.getMessage());
+    }
+}


### PR DESCRIPTION
## 🎫 지라 티켓

<!-- 지라 티켓을 작성해주세요 ex) HOTSPOT-123 -->
HOTSPOT-100

---

## 🔗 GitHub 이슈
<!-- 자동 close를 원하면 아래 형식으로 작성
예) Closes #12
-->
#21 

---


## ✅ 작업 사항

<!-- 작업한 부분을 설명해주세요. -->
  1. 가족 및 구성원별 적용 정책 통합 조회 API 구현

   * 통합 도메인 모델 설계:
       * DateSnapshot: JSONB 형태로 저장된 정책의 이름, 타입, 상세 시간 정보를 담는 통합 스냅샷 모델 구축
       * AppliedPolicyMapper: 복잡한 매핑 로직을 DTO와 분리하여 순환 참조를 방지하고 변환 책임을 중앙 집중화
   

   * 서비스 및 리포지토리 구현:
       * FindMemberAppliedPolicyService: 특정 멤버의 회선 정보를 기반으로 정책과 앱 차단 데이터를 조립
       * FindFamilyAppliedPolicyService: 가족 전체 구성원을 순회하며 각자의 정책 현황을 리스트업하는 유스케이스 구현


   * 권한 제어:
       * AppliedPolicyController에서 isFamily=true 요청 시, 현재 사용자가 OWNER 또는 PARENT 역할인지 검증하는 로직 적용
       * 자녀(CHILD) 권한의 사용자가 가족 전체 정보를 조회하려 할 경우 ACCESS_DENIED 예외 처리


---

 2. 인증 시스템 확장 및 familyId 도입
  성능 최적화 및 비즈니스 로직 편의성을 위해 토큰(JWT) 내부에 가족 식별자(familyId)를 포함하도록 구조 개선


---

## 📋 체크리스트

<!-- PR 제출 전 확인해주세요. 해당 항목에 [x]로 체크해주세요. -->

- [x] 코드가 정상적으로 빌드됩니다.
- [x] 관련 테스트 코드를 작성했습니다.
- [x] 기존 테스트가 모두 통과합니다.
- [x] 코드 스타일(Spotless, Checkstyle)을 준수합니다.
- [x] Jira 티켓 상태를 In Review / Done으로 변경했습니다.

---

## ⌨ 기타
auth, common 패키지의 변경 사항은 familyId 추가를 위한 공통 구조 변경이므로 가볍게 확인해 주시고
policy 패키지 내의 코드만 중점적으로 봐주시면 감사하겠습니다~

