### PR TITLE
[HOTSPOT-100] 구성원별 정책 적용 API 구현

### DIFF
--- a/src/main/java/hotspot/user/common/exception/code/PolicyErrorCode.java
+++ b/src/main/java/hotspot/user/common/exception/code/PolicyErrorCode.java
@@ -1,8 +1,9 @@
 package hotspot.user.common.exception.code;
 
+import org.springframework.http.HttpStatus;
+
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 
 /**
  * 회선 도메인 관련 에러 코드

--- a/src/main/java/hotspot/user/common/exception/code/PolicyErrorCode.java
+++ b/src/main/java/hotspot/user/common/exception/code/PolicyErrorCode.java
@@ -1,0 +1,19 @@
+package hotspot.user.common.exception.code;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+/**
+ * 회선 도메인 관련 에러 코드
+ */
+@Getter
+@RequiredArgsConstructor
+public enum PolicyErrorCode implements BaseErrorCode {
+    POLICY_NOT_FOUND(HttpStatus.NOT_FOUND, "POLICY_001", "해당 정책을 찾을 수 없습니다."),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String customCode;
+    private final String message;
+}

--- a/src/main/java/hotspot/user/policy/controller/AppliedPolicyController.java
+++ b/src/main/java/hotspot/user/policy/controller/AppliedPolicyController.java
@@ -1,10 +1,7 @@
 package hotspot.user.policy.controller;
 
-import hotspot.user.policy.controller.port.UpdateBlockPolicyService;
-import hotspot.user.policy.controller.request.UpdateBlockPolicyRequest;
-import hotspot.user.policy.controller.response.UpdateBlockPolicyResponse;
-import hotspot.user.policy.controller.swagger.AppliedPolicyApi;
 import jakarta.validation.Valid;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -16,6 +13,10 @@ import hotspot.user.common.security.PrincipalDetails;
 import hotspot.user.member.domain.FamilyRole;
 import hotspot.user.policy.controller.port.FindFamilyAppliedPolicyService;
 import hotspot.user.policy.controller.port.FindMemberAppliedPolicyService;
+import hotspot.user.policy.controller.port.UpdateBlockPolicyService;
+import hotspot.user.policy.controller.request.UpdateBlockPolicyRequest;
+import hotspot.user.policy.controller.response.UpdateBlockPolicyResponse;
+import hotspot.user.policy.controller.swagger.AppliedPolicyApi;
 import lombok.RequiredArgsConstructor;
 
 /**

--- a/src/main/java/hotspot/user/policy/controller/AppliedPolicyController.java
+++ b/src/main/java/hotspot/user/policy/controller/AppliedPolicyController.java
@@ -1,11 +1,13 @@
 package hotspot.user.policy.controller;
 
+import hotspot.user.policy.controller.port.UpdateBlockPolicyService;
+import hotspot.user.policy.controller.request.UpdateBlockPolicyRequest;
+import hotspot.user.policy.controller.response.UpdateBlockPolicyResponse;
+import hotspot.user.policy.controller.swagger.AppliedPolicyApi;
+import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import hotspot.user.common.ApiResponse;
 import hotspot.user.common.exception.ApplicationException;
@@ -21,40 +23,19 @@ import lombok.RequiredArgsConstructor;
  */
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/policies/applied")
-public class AppliedPolicyController {
+@RequestMapping("/api/v1/policies")
+public class AppliedPolicyController implements AppliedPolicyApi {
 
     private final FindMemberAppliedPolicyService findMemberAppliedPolicyService; // 구성원별 적용 정책 조회
     private final FindFamilyAppliedPolicyService findFamilyAppliedPolicyService; // 가족 구성원 전체 적용 정책 조회
-
-    /**
-     * 적용된 정책 목록을 조회 Test API
-     * @param isFamily true일 경우 가족 전체의 정책을, false일 경우 본인의 정책만 조회
-     * 우리 정보로 만들어진 더미 데이터가 없기 때문에 파라미터로 memberId, familyId 전달할 수 있도록 한다.
-     * [To-Do] 더미 데이터 및 로그인 기능 최종 완료 시 삭제 예정
-     */
-    @GetMapping("/test")
-    public ResponseEntity<ApiResponse<Object>> getAppliedPoliciesTest(
-            @RequestParam(defaultValue = "false") boolean isFamily,
-            @RequestParam(required = false) Long testMemberId,
-            @RequestParam(required = false) Long testFamilyId
-    ) {
-        if (isFamily) {
-            return ResponseEntity.ok(ApiResponse.success(
-                    findFamilyAppliedPolicyService.findByFamilyId(testFamilyId)
-            ));
-        }
-
-        return ResponseEntity.ok(ApiResponse.success(
-                findMemberAppliedPolicyService.findByMemberId(testMemberId)
-        ));
-    }
+    private final UpdateBlockPolicyService updateBlockPolicyService; // 구성원 별 정책 업데이트 (적용)
 
     /**
      * 적용된 정책 목록을 조회 API
      * @param isFamily true일 경우 가족 전체의 정책을, false일 경우 본인의 정책만 조회
      */
-    @GetMapping
+    @Override
+    @GetMapping("/applied")
     public ResponseEntity<ApiResponse<Object>> getAppliedPolicies(
             @RequestParam(defaultValue = "false") boolean isFamily,
             @AuthenticationPrincipal PrincipalDetails principal
@@ -75,5 +56,24 @@ public class AppliedPolicyController {
         return ResponseEntity.ok(ApiResponse.success(
             findMemberAppliedPolicyService.findByMemberId(principal.getId())
         ));
+    }
+
+
+    // 구성원별 앱 차단 설정 업데이트
+    @Override
+    @PutMapping("/apply")
+    public ResponseEntity<ApiResponse<UpdateBlockPolicyResponse>> updateAppBlockedService(
+            @Valid @RequestBody UpdateBlockPolicyRequest request,
+            @AuthenticationPrincipal PrincipalDetails principalDetails
+            ) {
+
+        UpdateBlockPolicyResponse response = updateBlockPolicyService.updateBlockPolicy(
+                request,
+                principalDetails.getFamilyId(),
+                principalDetails.getRole()
+        );
+
+        return ResponseEntity.ok()
+                .body(ApiResponse.success(response));
     }
 }

--- a/src/main/java/hotspot/user/policy/controller/AppliedPolicyController.java
+++ b/src/main/java/hotspot/user/policy/controller/AppliedPolicyController.java
@@ -4,7 +4,12 @@ import jakarta.validation.Valid;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 import hotspot.user.common.ApiResponse;
 import hotspot.user.common.exception.ApplicationException;

--- a/src/main/java/hotspot/user/policy/controller/AppliedPolicyController.java
+++ b/src/main/java/hotspot/user/policy/controller/AppliedPolicyController.java
@@ -68,7 +68,7 @@ public class AppliedPolicyController implements AppliedPolicyApi {
     // 구성원별 앱 차단 설정 업데이트
     @Override
     @PutMapping("/apply")
-    public ResponseEntity<ApiResponse<UpdateBlockPolicyResponse>> updateAppBlockedService(
+    public ResponseEntity<ApiResponse<UpdateBlockPolicyResponse>> updateBlockPolicy(
             @Valid @RequestBody UpdateBlockPolicyRequest request,
             @AuthenticationPrincipal PrincipalDetails principalDetails
             ) {

--- a/src/main/java/hotspot/user/policy/controller/port/UpdateBlockPolicyService.java
+++ b/src/main/java/hotspot/user/policy/controller/port/UpdateBlockPolicyService.java
@@ -1,0 +1,15 @@
+package hotspot.user.policy.controller.port;
+
+import hotspot.user.member.domain.FamilyRole;
+import hotspot.user.policy.controller.request.UpdateBlockPolicyRequest;
+import hotspot.user.policy.controller.response.UpdateBlockPolicyResponse;
+
+/**
+ * 구성원별 정책 업데이트 서비스 코드
+ */
+public interface UpdateBlockPolicyService {
+    UpdateBlockPolicyResponse updateBlockPolicy(
+            UpdateBlockPolicyRequest request,
+            Long requesterFamilyId,
+            FamilyRole requesterRole);
+}

--- a/src/main/java/hotspot/user/policy/controller/request/UpdateBlockPolicyRequest.java
+++ b/src/main/java/hotspot/user/policy/controller/request/UpdateBlockPolicyRequest.java
@@ -1,0 +1,18 @@
+package hotspot.user.policy.controller.request;
+
+import jakarta.validation.constraints.NotNull;
+
+import java.util.List;
+
+/**
+ * 구성원별 정책 업데이트 request dto
+ * @param familyId
+ * @param subId
+ * @param blockPolicyIdList
+ */
+public record UpdateBlockPolicyRequest(
+        @NotNull Long familyId,
+        @NotNull Long subId,
+        @NotNull List<Long> blockPolicyIdList
+) {
+}

--- a/src/main/java/hotspot/user/policy/controller/request/UpdateBlockPolicyRequest.java
+++ b/src/main/java/hotspot/user/policy/controller/request/UpdateBlockPolicyRequest.java
@@ -1,8 +1,8 @@
 package hotspot.user.policy.controller.request;
 
-import jakarta.validation.constraints.NotNull;
-
 import java.util.List;
+
+import jakarta.validation.constraints.NotNull;
 
 /**
  * 구성원별 정책 업데이트 request dto

--- a/src/main/java/hotspot/user/policy/controller/response/UpdateBlockPolicyResponse.java
+++ b/src/main/java/hotspot/user/policy/controller/response/UpdateBlockPolicyResponse.java
@@ -1,8 +1,8 @@
 package hotspot.user.policy.controller.response;
 
-import lombok.Builder;
-
 import java.util.List;
+
+import lombok.Builder;
 
 /**
  * 구성원별 정책 업데이트 response dto

--- a/src/main/java/hotspot/user/policy/controller/response/UpdateBlockPolicyResponse.java
+++ b/src/main/java/hotspot/user/policy/controller/response/UpdateBlockPolicyResponse.java
@@ -8,13 +8,13 @@ import java.util.List;
  * 구성원별 정책 업데이트 response dto
  * @param familyId
  * @param subId
- * @param blockPolicyIdList
+ * @param blockedPolicyIdList
  */
 
 @Builder
 public record UpdateBlockPolicyResponse(
         Long familyId,
         Long subId,
-        List<Long> blockPolicyIdList
+        List<Long> blockedPolicyIdList
 ) {
 }

--- a/src/main/java/hotspot/user/policy/controller/response/UpdateBlockPolicyResponse.java
+++ b/src/main/java/hotspot/user/policy/controller/response/UpdateBlockPolicyResponse.java
@@ -1,0 +1,20 @@
+package hotspot.user.policy.controller.response;
+
+import lombok.Builder;
+
+import java.util.List;
+
+/**
+ * 구성원별 정책 업데이트 response dto
+ * @param familyId
+ * @param subId
+ * @param blockPolicyIdList
+ */
+
+@Builder
+public record UpdateBlockPolicyResponse(
+        Long familyId,
+        Long subId,
+        List<Long> blockPolicyIdList
+) {
+}

--- a/src/main/java/hotspot/user/policy/controller/swagger/AppliedPolicyApi.java
+++ b/src/main/java/hotspot/user/policy/controller/swagger/AppliedPolicyApi.java
@@ -1,5 +1,12 @@
 package hotspot.user.policy.controller.swagger;
 
+import jakarta.validation.Valid;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+
 import hotspot.user.common.ApiResponse;
 import hotspot.user.common.exception.ErrorResponse;
 import hotspot.user.common.security.PrincipalDetails;
@@ -11,11 +18,6 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.Valid;
-import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "Applied Policy", description = "적용된 정책(시간 정책 및 앱 차단) 관리 API")
 public interface AppliedPolicyApi {

--- a/src/main/java/hotspot/user/policy/controller/swagger/AppliedPolicyApi.java
+++ b/src/main/java/hotspot/user/policy/controller/swagger/AppliedPolicyApi.java
@@ -1,0 +1,59 @@
+package hotspot.user.policy.controller.swagger;
+
+import hotspot.user.common.ApiResponse;
+import hotspot.user.common.exception.ErrorResponse;
+import hotspot.user.common.security.PrincipalDetails;
+import hotspot.user.policy.controller.request.UpdateBlockPolicyRequest;
+import hotspot.user.policy.controller.response.UpdateBlockPolicyResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Tag(name = "Applied Policy", description = "적용된 정책(시간 정책 및 앱 차단) 관리 API")
+public interface AppliedPolicyApi {
+
+    @Operation(summary = "적용된 정책 목록 조회", description = "가족 전체의 적용 정책 또는 본인의 적용 정책을 조회합니다.")
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "권한 없음\n"
+                                         + "- AUTH_004: 가족 전체 조회는 OWNER/PARENT 권한 필요",
+                     content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    ResponseEntity<ApiResponse<Object>> getAppliedPolicies(
+            @Parameter(description = "true일 경우 가족 전체 조회, false일 경우 본인 정책 조회", example = "false")
+            @RequestParam(defaultValue = "false") boolean isFamily,
+
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal PrincipalDetails principal
+    );
+
+    @Operation(summary = "구성원별 정책 업데이트 (적용)",
+               description = "가족 OWNER가 특정 구성원(회선)에게 시간 정책 및 앱 차단 정책을 적용합니다. "
+                           + "활성화할 정책 ID 리스트를 전달하며, 빈 리스트를 보내면 모두 해제됩니다.")
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "정책 업데이트 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청\n"
+                                         + "- COMMON_002: 입력값 유효성 검증 실패",
+                     content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "권한 없음\n"
+                                         + "- AUTH_004: OWNER 권한이 아님\n"
+                                         + "- FAMILY_003: 동일 가족 구성원이 아님",
+                     content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "찾을 수 없음\n"
+                                         + "- FAMILY_002: 해당 회선 정보를 찾을 수 없음\n"
+                                         + "- POLICY_001: 정책 정보를 찾을 수 없음",
+                     content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    ResponseEntity<ApiResponse<UpdateBlockPolicyResponse>> updateAppBlockedService(
+            @Valid @RequestBody UpdateBlockPolicyRequest request,
+            @Parameter(hidden = true) @AuthenticationPrincipal PrincipalDetails principalDetails
+    );
+}

--- a/src/main/java/hotspot/user/policy/controller/swagger/AppliedPolicyApi.java
+++ b/src/main/java/hotspot/user/policy/controller/swagger/AppliedPolicyApi.java
@@ -54,7 +54,7 @@ public interface AppliedPolicyApi {
                                          + "- POLICY_001: 정책 정보를 찾을 수 없음",
                      content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
-    ResponseEntity<ApiResponse<UpdateBlockPolicyResponse>> updateAppBlockedService(
+    ResponseEntity<ApiResponse<UpdateBlockPolicyResponse>> updateBlockPolicy(
             @Valid @RequestBody UpdateBlockPolicyRequest request,
             @Parameter(hidden = true) @AuthenticationPrincipal PrincipalDetails principalDetails
     );

--- a/src/main/java/hotspot/user/policy/domain/PolicySub.java
+++ b/src/main/java/hotspot/user/policy/domain/PolicySub.java
@@ -15,7 +15,7 @@ public class PolicySub {
     private final Long policyId;
     private final Long subId;
     private final DateSnapshot dateSnapshot;
-    private Boolean isDeleted;
+    private boolean isDeleted;
 
     // 논리 삭제 메서드
     public void delete() {

--- a/src/main/java/hotspot/user/policy/domain/PolicySub.java
+++ b/src/main/java/hotspot/user/policy/domain/PolicySub.java
@@ -14,7 +14,12 @@ import lombok.Getter;
 public class PolicySub {
     private final Long id;
     private final Long policyId;
-    private final Subscription subscription;
+    private final Long subId;
     private final DateSnapshot dateSnapshot;
     private Boolean isDeleted;
+
+    // 논리 삭제 메서드
+    public void delete() {
+        isDeleted = true;
+    }
 }

--- a/src/main/java/hotspot/user/policy/domain/PolicySub.java
+++ b/src/main/java/hotspot/user/policy/domain/PolicySub.java
@@ -13,6 +13,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public class PolicySub {
     private final Long id;
+    private final Long policyId;
     private final Subscription subscription;
     private final DateSnapshot dateSnapshot;
 }

--- a/src/main/java/hotspot/user/policy/domain/PolicySub.java
+++ b/src/main/java/hotspot/user/policy/domain/PolicySub.java
@@ -1,6 +1,5 @@
 package hotspot.user.policy.domain;
 
-import hotspot.user.subscription.domain.Subscription;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/hotspot/user/policy/domain/PolicySub.java
+++ b/src/main/java/hotspot/user/policy/domain/PolicySub.java
@@ -16,4 +16,5 @@ public class PolicySub {
     private final Long policyId;
     private final Subscription subscription;
     private final DateSnapshot dateSnapshot;
+    private Boolean isDeleted;
 }

--- a/src/main/java/hotspot/user/policy/domain/mapper/BlockPolicyMapper.java
+++ b/src/main/java/hotspot/user/policy/domain/mapper/BlockPolicyMapper.java
@@ -1,12 +1,11 @@
 package hotspot.user.policy.domain.mapper;
 
-import hotspot.user.policy.controller.response.BlockPolicyResponse;
+import java.util.List;
 
+import hotspot.user.policy.controller.response.BlockPolicyResponse;
 import hotspot.user.policy.controller.response.UpdateBlockPolicyResponse;
 import hotspot.user.policy.domain.BlockPolicy;
 import hotspot.user.policy.domain.PolicySub;
-
-import java.util.List;
 
 /**
  * request -> 도메인

--- a/src/main/java/hotspot/user/policy/domain/mapper/BlockPolicyMapper.java
+++ b/src/main/java/hotspot/user/policy/domain/mapper/BlockPolicyMapper.java
@@ -1,8 +1,12 @@
 package hotspot.user.policy.domain.mapper;
 
 import hotspot.user.policy.controller.response.BlockPolicyResponse;
+
+import hotspot.user.policy.controller.response.UpdateBlockPolicyResponse;
 import hotspot.user.policy.domain.BlockPolicy;
 import hotspot.user.policy.domain.PolicySub;
+
+import java.util.List;
 
 /**
  * request -> 도메인
@@ -30,6 +34,16 @@ public class BlockPolicyMapper {
                 .name(policySub.getDateSnapshot().getPolicyName())
                 .policyType(policySub.getDateSnapshot().getPolicyType())
                 .policySnapshot(policySub.getDateSnapshot().getData())
+                .build();
+    }
+
+    // 구성원별 정책 업데이트response dto로 변환
+    public static UpdateBlockPolicyResponse toUpdateBlockPolicyResponse(
+            Long familyId, Long subId, List<Long> blockedPolicyIdList) {
+        return UpdateBlockPolicyResponse.builder()
+                .familyId(familyId)
+                .subId(subId)
+                .blockedPolicyIdList(blockedPolicyIdList)
                 .build();
     }
 }

--- a/src/main/java/hotspot/user/policy/infrastructure/BlockPolicyRepositoryImpl.java
+++ b/src/main/java/hotspot/user/policy/infrastructure/BlockPolicyRepositoryImpl.java
@@ -20,4 +20,12 @@ public class BlockPolicyRepositoryImpl implements BlockPolicyRepository {
                 .map(BlockPolicyEntity::entityToDomain)
                 .toList();
     }
+
+    // policyId에 해당하는 모든 정책 리턴
+    @Override
+    public List<BlockPolicy> findAllById(List<Long> idList) {
+        return blockPolicyJpaRepository.findAllById(idList).stream()
+                .map(BlockPolicyEntity::entityToDomain)
+                .toList();
+    }
 }

--- a/src/main/java/hotspot/user/policy/infrastructure/PolicySubJpaRepository.java
+++ b/src/main/java/hotspot/user/policy/infrastructure/PolicySubJpaRepository.java
@@ -5,7 +5,15 @@ import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import hotspot.user.policy.infrastructure.entity.PolicySubEntity;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface PolicySubJpaRepository extends JpaRepository<PolicySubEntity, Long> {
     List<PolicySubEntity> findBySubscriptionSubId(Long subId);
+
+    // N+1 SELECT를 방지하기 위한 벌크 UPDATE 쿼리
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE PolicySubEntity p SET p.isDeleted = true WHERE p.policySubId IN :ids")
+    void bulkSoftDelete(@Param("ids") List<Long> ids);
 }

--- a/src/main/java/hotspot/user/policy/infrastructure/PolicySubJpaRepository.java
+++ b/src/main/java/hotspot/user/policy/infrastructure/PolicySubJpaRepository.java
@@ -3,11 +3,11 @@ package hotspot.user.policy.infrastructure;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-
-import hotspot.user.policy.infrastructure.entity.PolicySubEntity;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+
+import hotspot.user.policy.infrastructure.entity.PolicySubEntity;
 
 public interface PolicySubJpaRepository extends JpaRepository<PolicySubEntity, Long> {
     List<PolicySubEntity> findBySubscriptionSubId(Long subId);

--- a/src/main/java/hotspot/user/policy/infrastructure/PolicySubRepositoryImpl.java
+++ b/src/main/java/hotspot/user/policy/infrastructure/PolicySubRepositoryImpl.java
@@ -27,32 +27,32 @@ public class PolicySubRepositoryImpl implements PolicySubRepository {
     // 새로운 INSERT, 기존 isDeleted=true 분리해서 진행 (N+1 방지)
     @Override
     public List<PolicySub> saveAll(List<PolicySub> policySubList) {
-        // 1. 신규 Insert 대상 (ID가 없는 도메인)
-        List<PolicySubEntity> entitiesToInsert = policySubList.stream()
-                .filter(domain -> domain.getId() == null)
-                .map(PolicySubEntity::domainToEntity)
-                .toList();
+        List<PolicySubEntity> entitiesToInsert = new ArrayList<>();
+        List<Long> idsToUpdate = new ArrayList<>();
 
-        // 2. 비활성화 Update 대상 (ID가 있는 도메인의 ID값만 추출)
-        List<Long> idsToUpdate = policySubList.stream()
-                .filter(domain -> domain.getId() != null && domain.getIsDeleted())
-                .map(PolicySub::getId)
-                .toList();
+        // 단 한 번의 순회로 Insert 대상과 Update(Delete) 대상을 분류
+        policySubList.forEach(domain -> {
+            if (domain.getId() == null) {
+                entitiesToInsert.add(PolicySubEntity.domainToEntity(domain));
+            } else if (domain.isDeleted()) {
+                idsToUpdate.add(domain.getId());
+            }
+        });
 
         List<PolicySubEntity> savedEntities = new ArrayList<>();
 
-        // 3. Insert 실행 (em.persist만 타므로 N+1 없음) => 무조건 새로운 row 보장 (id = null)
+        // 1. 신규 Insert 실행
         if (!entitiesToInsert.isEmpty()) {
             savedEntities = policySubJpaRepository.saveAll(entitiesToInsert);
         }
 
-        // 4. Update 실행 (벌크 연산으로 쿼리 1방에 처리, id만 전달)
+        // 2. 벌크 Soft Delete 실행
         if (!idsToUpdate.isEmpty()) {
             policySubJpaRepository.bulkSoftDelete(idsToUpdate);
         }
 
-        // 서비스 로직에서 리턴값이 따로 필요 없다면 파라미터 그대로 리턴
         return savedEntities.stream()
-                .map(PolicySubEntity::entityToDomain).toList();
+                .map(PolicySubEntity::entityToDomain)
+                .toList();
     }
 }

--- a/src/main/java/hotspot/user/policy/infrastructure/PolicySubRepositoryImpl.java
+++ b/src/main/java/hotspot/user/policy/infrastructure/PolicySubRepositoryImpl.java
@@ -1,5 +1,6 @@
 package hotspot.user.policy.infrastructure;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.springframework.stereotype.Repository;
@@ -19,5 +20,39 @@ public class PolicySubRepositoryImpl implements PolicySubRepository {
         return policySubJpaRepository.findBySubscriptionSubId(subId).stream()
                 .map(PolicySubEntity::entityToDomain)
                 .toList();
+    }
+
+
+    // 정책-회선 매핑 리스트 저장
+    // 새로운 INSERT, 기존 isDeleted=true 분리해서 진행 (N+1 방지)
+    @Override
+    public List<PolicySub> saveAll(List<PolicySub> policySubList) {
+        // 1. 신규 Insert 대상 (ID가 없는 도메인)
+        List<PolicySubEntity> entitiesToInsert = policySubList.stream()
+                .filter(domain -> domain.getId() == null)
+                .map(PolicySubEntity::domainToEntity)
+                .toList();
+
+        // 2. 비활성화 Update 대상 (ID가 있는 도메인의 ID값만 추출)
+        List<Long> idsToUpdate = policySubList.stream()
+                .filter(domain -> domain.getId() != null && domain.getIsDeleted())
+                .map(PolicySub::getId)
+                .toList();
+
+        List<PolicySubEntity> savedEntities = new ArrayList<>();
+
+        // 3. Insert 실행 (em.persist만 타므로 N+1 없음) => 무조건 새로운 row 보장 (id = null)
+        if (!entitiesToInsert.isEmpty()) {
+            savedEntities = policySubJpaRepository.saveAll(entitiesToInsert);
+        }
+
+        // 4. Update 실행 (벌크 연산으로 쿼리 1방에 처리, id만 전달)
+        if (!idsToUpdate.isEmpty()) {
+            policySubJpaRepository.bulkSoftDelete(idsToUpdate);
+        }
+
+        // 서비스 로직에서 리턴값이 따로 필요 없다면 파라미터 그대로 리턴
+        return savedEntities.stream()
+                .map(PolicySubEntity::entityToDomain).toList();
     }
 }

--- a/src/main/java/hotspot/user/policy/infrastructure/entity/PolicySubEntity.java
+++ b/src/main/java/hotspot/user/policy/infrastructure/entity/PolicySubEntity.java
@@ -62,6 +62,7 @@ public class PolicySubEntity extends BaseEntity {
                 .policyId(this.policyId)
                 .subscription(this.subscription.entityToDomain())
                 .dateSnapshot(this.dateSnapshot)
+                .isDeleted(this.isDeleted)
                 .build();
     }
 
@@ -71,6 +72,7 @@ public class PolicySubEntity extends BaseEntity {
                 .policyId(policySub.getPolicyId())
                 .subscription(SubscriptionEntity.domainToEntity(policySub.getSubscription()))
                 .dateSnapshot(policySub.getDateSnapshot())
+                .isDeleted(policySub.getIsDeleted())
                 .build();
     }
 }

--- a/src/main/java/hotspot/user/policy/infrastructure/entity/PolicySubEntity.java
+++ b/src/main/java/hotspot/user/policy/infrastructure/entity/PolicySubEntity.java
@@ -45,6 +45,9 @@ public class PolicySubEntity extends BaseEntity {
     @JoinColumn(name = "sub_id")
     private SubscriptionEntity subscription;
 
+    @Column(name = "policy_id")
+    private Long policyId;
+
     @JdbcTypeCode(SqlTypes.JSON)
     @Column(columnDefinition = "jsonb") // PostgreSQL
     private DateSnapshot dateSnapshot;
@@ -56,8 +59,18 @@ public class PolicySubEntity extends BaseEntity {
     public PolicySub entityToDomain() {
         return PolicySub.builder()
                 .id(this.policySubId)
+                .policyId(this.policyId)
                 .subscription(this.subscription.entityToDomain())
                 .dateSnapshot(this.dateSnapshot)
+                .build();
+    }
+
+    public static PolicySubEntity domainToEntity(PolicySub policySub) {
+        return PolicySubEntity.builder()
+                .policySubId(policySub.getId())
+                .policyId(policySub.getPolicyId())
+                .subscription(SubscriptionEntity.domainToEntity(policySub.getSubscription()))
+                .dateSnapshot(policySub.getDateSnapshot())
                 .build();
     }
 }

--- a/src/main/java/hotspot/user/policy/infrastructure/entity/PolicySubEntity.java
+++ b/src/main/java/hotspot/user/policy/infrastructure/entity/PolicySubEntity.java
@@ -54,7 +54,7 @@ public class PolicySubEntity extends BaseEntity {
 
     @Column(name = "is_deleted", nullable = false)
     @Builder.Default
-    private Boolean isDeleted = false;
+    private boolean isDeleted = false;
 
     public PolicySub entityToDomain() {
         return PolicySub.builder()
@@ -79,7 +79,7 @@ public class PolicySubEntity extends BaseEntity {
                 .policyId(policySub.getPolicyId())
                 .subscription(subscriptionProxy)
                 .dateSnapshot(policySub.getDateSnapshot())
-                .isDeleted(policySub.getIsDeleted())
+                .isDeleted(policySub.isDeleted())
                 .build();
     }
 }

--- a/src/main/java/hotspot/user/policy/infrastructure/entity/PolicySubEntity.java
+++ b/src/main/java/hotspot/user/policy/infrastructure/entity/PolicySubEntity.java
@@ -60,17 +60,24 @@ public class PolicySubEntity extends BaseEntity {
         return PolicySub.builder()
                 .id(this.policySubId)
                 .policyId(this.policyId)
-                .subscription(this.subscription.entityToDomain())
+                .subId(this.subscription.entityToDomain().getId())
                 .dateSnapshot(this.dateSnapshot)
                 .isDeleted(this.isDeleted)
                 .build();
     }
 
     public static PolicySubEntity domainToEntity(PolicySub policySub) {
+
+        // 연관관계(FK) 매핑을 위한 프록시(가짜) 엔티티 생성
+        // DB에서 전체 데이터를 읽어올 필요 없이, 외래키로 쓸 ID값만 세팅
+        SubscriptionEntity subscriptionProxy = SubscriptionEntity.builder()
+                .subId(policySub.getSubId()) // 도메인이 들고 있는 ID만 주입
+                .build();
+
         return PolicySubEntity.builder()
                 .policySubId(policySub.getId())
                 .policyId(policySub.getPolicyId())
-                .subscription(SubscriptionEntity.domainToEntity(policySub.getSubscription()))
+                .subscription(subscriptionProxy)
                 .dateSnapshot(policySub.getDateSnapshot())
                 .isDeleted(policySub.getIsDeleted())
                 .build();

--- a/src/main/java/hotspot/user/policy/infrastructure/entity/PolicySubEntity.java
+++ b/src/main/java/hotspot/user/policy/infrastructure/entity/PolicySubEntity.java
@@ -60,7 +60,7 @@ public class PolicySubEntity extends BaseEntity {
         return PolicySub.builder()
                 .id(this.policySubId)
                 .policyId(this.policyId)
-                .subId(this.subscription.entityToDomain().getId())
+                .subId(this.subscription != null ? this.subscription.getSubId() : null)
                 .dateSnapshot(this.dateSnapshot)
                 .isDeleted(this.isDeleted)
                 .build();

--- a/src/main/java/hotspot/user/policy/service/UpdateBlockPolicyServiceImpl.java
+++ b/src/main/java/hotspot/user/policy/service/UpdateBlockPolicyServiceImpl.java
@@ -1,5 +1,11 @@
 package hotspot.user.policy.service;
 
+import java.util.*;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import hotspot.user.common.exception.ApplicationException;
 import hotspot.user.common.exception.code.AuthErrorCode;
 import hotspot.user.common.exception.code.FamilyErrorCode;
@@ -7,29 +13,17 @@ import hotspot.user.common.exception.code.PolicyErrorCode;
 import hotspot.user.family.domain.FamilySubscription;
 import hotspot.user.family.service.port.FamilySubscriptionRepository;
 import hotspot.user.member.domain.FamilyRole;
-
 import hotspot.user.policy.controller.port.UpdateBlockPolicyService;
-
 import hotspot.user.policy.controller.request.UpdateBlockPolicyRequest;
-
 import hotspot.user.policy.controller.response.UpdateBlockPolicyResponse;
 import hotspot.user.policy.domain.BlockPolicy;
 import hotspot.user.policy.domain.DateSnapshot;
-import hotspot.user.policy.domain.PolicySnapshot;
 import hotspot.user.policy.domain.PolicySub;
-import hotspot.user.policy.domain.mapper.AppBlockedServiceMapper;
-
 import hotspot.user.policy.domain.mapper.BlockPolicyMapper;
 import hotspot.user.policy.service.port.BlockPolicyRepository;
-
 import hotspot.user.policy.service.port.PolicySubRepository;
 import hotspot.user.subscription.domain.Subscription;
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
-import java.util.*;
-import java.util.stream.Collectors;
 
 /**
  * 구성원별 정책 업데이트 서비스 코드 구현체

--- a/src/main/java/hotspot/user/policy/service/UpdateBlockPolicyServiceImpl.java
+++ b/src/main/java/hotspot/user/policy/service/UpdateBlockPolicyServiceImpl.java
@@ -77,10 +77,6 @@ public class UpdateBlockPolicyServiceImpl implements UpdateBlockPolicyService {
                 activeMap.remove(policy.getId()); // 처리 완료된 항목은 Map에서 제거
             }
 
-            Subscription subscription = Subscription.builder()
-                    .id(request.subId())
-                    .build();
-
             // 무조건 신규 도메인 객체 생성 (새로운 스냅샷으로 Insert)
             PolicySub newSub = PolicySub.builder()
                     .subId(request.subId())

--- a/src/main/java/hotspot/user/policy/service/UpdateBlockPolicyServiceImpl.java
+++ b/src/main/java/hotspot/user/policy/service/UpdateBlockPolicyServiceImpl.java
@@ -24,7 +24,6 @@ import hotspot.user.policy.domain.PolicySub;
 import hotspot.user.policy.domain.mapper.BlockPolicyMapper;
 import hotspot.user.policy.service.port.BlockPolicyRepository;
 import hotspot.user.policy.service.port.PolicySubRepository;
-import hotspot.user.subscription.domain.Subscription;
 import lombok.RequiredArgsConstructor;
 
 /**

--- a/src/main/java/hotspot/user/policy/service/UpdateBlockPolicyServiceImpl.java
+++ b/src/main/java/hotspot/user/policy/service/UpdateBlockPolicyServiceImpl.java
@@ -1,0 +1,137 @@
+package hotspot.user.policy.service;
+
+import hotspot.user.common.exception.ApplicationException;
+import hotspot.user.common.exception.code.AuthErrorCode;
+import hotspot.user.common.exception.code.FamilyErrorCode;
+import hotspot.user.common.exception.code.PolicyErrorCode;
+import hotspot.user.family.domain.FamilySubscription;
+import hotspot.user.family.service.port.FamilySubscriptionRepository;
+import hotspot.user.member.domain.FamilyRole;
+
+import hotspot.user.policy.controller.port.UpdateBlockPolicyService;
+
+import hotspot.user.policy.controller.request.UpdateBlockPolicyRequest;
+
+import hotspot.user.policy.controller.response.UpdateBlockPolicyResponse;
+import hotspot.user.policy.domain.BlockPolicy;
+import hotspot.user.policy.domain.DateSnapshot;
+import hotspot.user.policy.domain.PolicySnapshot;
+import hotspot.user.policy.domain.PolicySub;
+import hotspot.user.policy.domain.mapper.AppBlockedServiceMapper;
+
+import hotspot.user.policy.domain.mapper.BlockPolicyMapper;
+import hotspot.user.policy.service.port.BlockPolicyRepository;
+
+import hotspot.user.policy.service.port.PolicySubRepository;
+import hotspot.user.subscription.domain.Subscription;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * 구성원별 정책 업데이트 서비스 코드 구현체
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class UpdateBlockPolicyServiceImpl implements UpdateBlockPolicyService {
+
+    private final PolicySubRepository policySubRepository;
+    private final FamilySubscriptionRepository familySubscriptionRepository;
+    private final BlockPolicyRepository blockPolicyRepository;
+
+    @Override
+    public UpdateBlockPolicyResponse updateBlockPolicy(
+            UpdateBlockPolicyRequest request,
+            Long requesterFamilyId,
+            FamilyRole requesterRole) {
+
+        // 1. 권한 및 가족 매핑 검증
+        validateAuthorityAndFamily(request.subId(), requesterFamilyId, requesterRole);
+
+        List<Long> targetIdsList = request.blockPolicyIdList();
+
+        // 2. 요청된 원본 정책 전체 조회 & 예외 처리 로직
+        List<BlockPolicy> targetPolicies = blockPolicyRepository.findAllById(targetIdsList);
+        if (!targetIdsList.isEmpty() && targetPolicies.size() != targetIdsList.size()) {
+            throw new ApplicationException(PolicyErrorCode.POLICY_NOT_FOUND);
+        }
+
+        // 3. 기존 DB 상태 조회 (현재 '활성화된(isDeleted=false)' 데이터만 조회)
+        List<PolicySub> activeSubs = policySubRepository.findBySubId(request.subId());
+        Map<Long, PolicySub> activeMap = activeSubs.stream()
+                .collect(Collectors.toMap(PolicySub::getPolicyId, sub -> sub));
+
+        // 영속화(Save/Update) 대상 도메인 객체들을 담을 리스트
+        List<PolicySub> domainsToSave = new ArrayList<>();
+
+        // 4. 요청된 타겟 정책들 처리 (기존 비활성화 + 신규 Insert)
+        for (BlockPolicy policy : targetPolicies) {
+            DateSnapshot newSnapshot = createSnapshotFrom(policy);
+
+            // 해당 정책이 이미 활성화 상태라면, 기존 레코드를 비활성화(Delete) 처리
+            if (activeMap.containsKey(policy.getId())) {
+                PolicySub oldSub = activeMap.get(policy.getId());
+                oldSub.delete(); // isDeleted = true 로 상태 변경
+                domainsToSave.add(oldSub);
+
+                activeMap.remove(policy.getId()); // 처리 완료된 항목은 Map에서 제거
+            }
+
+            Subscription subscription = Subscription.builder()
+                    .id(request.subId())
+                    .build();
+
+            // 무조건 신규 도메인 객체 생성 (새로운 스냅샷으로 Insert)
+            PolicySub newSub = PolicySub.builder()
+                    .subId(request.subId())
+                    .policyId(policy.getId())
+                    .dateSnapshot(newSnapshot)
+                    .isDeleted(false) // 활성화 상태로 생성
+                    .build();
+            domainsToSave.add(newSub);
+        }
+
+        // 5. 요청 목록에 없는 나머지 기존 활성 정책들 처리 (순수 비활성화)
+        for (PolicySub remainingSub : activeMap.values()) {
+            remainingSub.delete();
+            domainsToSave.add(remainingSub);
+        }
+
+        // 6. 도메인 객체 리스트를 Port(어댑터)로 전달하여 일괄 영속화
+        policySubRepository.saveAll(domainsToSave);
+
+        // 7. 최종 결과 반환
+        return BlockPolicyMapper.toUpdateBlockPolicyResponse(
+                requesterFamilyId,
+                request.subId(),
+                targetIdsList
+        );
+    }
+
+    // 권한 및 같은 가족인지 검증
+    private void validateAuthorityAndFamily(Long subId, Long requesterFamilyId, FamilyRole requesterRole) {
+        if (requesterRole != FamilyRole.OWNER) {
+            throw new ApplicationException(AuthErrorCode.ACCESS_DENIED);
+        }
+
+        FamilySubscription familySub = familySubscriptionRepository.findBySubId(subId)
+                .orElseThrow(() -> new ApplicationException(FamilyErrorCode.FAMILY_SUBSCRIPTION_NOT_FOUND));
+
+        if (!familySub.getFamily().getId().equals(requesterFamilyId)) {
+            throw new ApplicationException(FamilyErrorCode.NOT_FAMILY_MEMBER);
+        }
+    }
+
+    // PolicySub에 저장할 DateSnapshot 조립하는 메서드
+    private DateSnapshot createSnapshotFrom(BlockPolicy policy) {
+        return DateSnapshot.builder()
+                .policyName(policy.getName())
+                .policyType(policy.getPolicyType())
+                .data(policy.getPolicySnapshot())
+                .build();
+    }
+}

--- a/src/main/java/hotspot/user/policy/service/UpdateBlockPolicyServiceImpl.java
+++ b/src/main/java/hotspot/user/policy/service/UpdateBlockPolicyServiceImpl.java
@@ -1,6 +1,8 @@
 package hotspot.user.policy.service;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;

--- a/src/main/java/hotspot/user/policy/service/port/BlockPolicyRepository.java
+++ b/src/main/java/hotspot/user/policy/service/port/BlockPolicyRepository.java
@@ -9,4 +9,5 @@ import hotspot.user.policy.domain.BlockPolicy;
  */
 public interface BlockPolicyRepository {
     List<BlockPolicy> findAll();
+    List<BlockPolicy> findAllById(List<Long> idList);
 }

--- a/src/main/java/hotspot/user/policy/service/port/PolicySubRepository.java
+++ b/src/main/java/hotspot/user/policy/service/port/PolicySubRepository.java
@@ -9,4 +9,5 @@ import hotspot.user.policy.domain.PolicySub;
  */
 public interface PolicySubRepository {
     List<PolicySub> findBySubId(Long subId);
+    List<PolicySub> saveAll(List<PolicySub> policySubList);
 }

--- a/src/main/java/hotspot/user/subscription/infrastructure/entity/SubscriptionEntity.java
+++ b/src/main/java/hotspot/user/subscription/infrastructure/entity/SubscriptionEntity.java
@@ -79,8 +79,8 @@ public class SubscriptionEntity extends BaseEntity {
     public Subscription entityToDomain() {
         return Subscription.builder()
                 .id(this.subId)
-                .member(this.member.entityToDomain())
-                .plan(this.plan.entityToDomain())
+                .member(this.member != null ? this.member.entityToDomain() : null)
+                .plan(this.plan != null ? this.plan.entityToDomain() : null)
                 .phoneEnc(this.phoneEnc)
                 .phoneHash(this.phoneHash)
                 .isLocked(this.isLocked)

--- a/src/test/java/hotspot/user/policy/controller/AppliedPolicyControllerTest.java
+++ b/src/test/java/hotspot/user/policy/controller/AppliedPolicyControllerTest.java
@@ -8,6 +8,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import java.util.List;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -29,8 +30,15 @@ import hotspot.user.member.domain.FamilyRole;
 import hotspot.user.member.domain.Status;
 import hotspot.user.policy.controller.port.FindFamilyAppliedPolicyService;
 import hotspot.user.policy.controller.port.FindMemberAppliedPolicyService;
+import hotspot.user.policy.controller.port.UpdateBlockPolicyService;
+import hotspot.user.policy.controller.request.UpdateBlockPolicyRequest;
 import hotspot.user.policy.controller.response.AppliedPolicyResponse;
 import hotspot.user.policy.controller.response.FamilyAppliedPolicyResponse;
+import hotspot.user.policy.controller.response.UpdateBlockPolicyResponse;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 
 @WebMvcTest(AppliedPolicyController.class)
 @AutoConfigureMockMvc(addFilters = false)
@@ -39,11 +47,17 @@ class AppliedPolicyControllerTest {
     @Autowired
     private MockMvc mockMvc;
 
+    @Autowired
+    private ObjectMapper objectMapper;
+
     @MockBean
     private FindMemberAppliedPolicyService findMemberAppliedPolicyService;
 
     @MockBean
     private FindFamilyAppliedPolicyService findFamilyAppliedPolicyService;
+
+    @MockBean
+    private UpdateBlockPolicyService updateBlockPolicyService;
 
     @MockBean
     private JwtFilter jwtFilter;
@@ -127,21 +141,29 @@ class AppliedPolicyControllerTest {
     }
 
     @Test
-    @DisplayName("임시 테스트 API 조회 성공: 파라미터 기반 조회 확인")
-    void getAppliedPoliciesTestApiSuccess() throws Exception {
+    @DisplayName("구성원별 정책 업데이트 성공: OWNER 권한일 때")
+    void updateBlockPolicySuccess() throws Exception {
         // given
-        AppliedPolicyResponse response = AppliedPolicyResponse.builder()
-                .memberId(1L)
-                .memberName("테스트유저")
+        setAuthentication(FamilyRole.OWNER);
+        UpdateBlockPolicyRequest request = new UpdateBlockPolicyRequest(100L, 1L, List.of(1L, 2L));
+        UpdateBlockPolicyResponse response = UpdateBlockPolicyResponse.builder()
+                .familyId(100L)
+                .subId(1L)
+                .blockedPolicyIdList(List.of(1L, 2L))
                 .build();
-        given(findMemberAppliedPolicyService.findByMemberId(1L)).willReturn(response);
+
+        given(updateBlockPolicyService.updateBlockPolicy(
+                any(UpdateBlockPolicyRequest.class),
+                eq(100L),
+                eq(FamilyRole.OWNER)))
+                .willReturn(response);
 
         // when & then
-        mockMvc.perform(get("/api/v1/policies/applied/test")
-                        .param("testMemberId", "1")
-                        .param("isFamily", "false")
-                        .contentType(MediaType.APPLICATION_JSON))
+        mockMvc.perform(put("/api/v1/policies/apply")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.memberName").value("테스트유저"));
+                .andExpect(jsonPath("$.data.familyId").value(100L))
+                .andExpect(jsonPath("$.data.blockedPolicyIdList[0]").value(1L));
     }
 }

--- a/src/test/java/hotspot/user/policy/controller/AppliedPolicyControllerTest.java
+++ b/src/test/java/hotspot/user/policy/controller/AppliedPolicyControllerTest.java
@@ -1,14 +1,16 @@
 package hotspot.user.policy.controller;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.util.List;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -20,6 +22,8 @@ import org.springframework.http.MediaType;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import hotspot.user.common.exception.ApplicationException;
 import hotspot.user.common.exception.code.AuthErrorCode;
@@ -35,10 +39,6 @@ import hotspot.user.policy.controller.request.UpdateBlockPolicyRequest;
 import hotspot.user.policy.controller.response.AppliedPolicyResponse;
 import hotspot.user.policy.controller.response.FamilyAppliedPolicyResponse;
 import hotspot.user.policy.controller.response.UpdateBlockPolicyResponse;
-
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 
 @WebMvcTest(AppliedPolicyController.class)
 @AutoConfigureMockMvc(addFilters = false)

--- a/src/test/java/hotspot/user/policy/domain/PolicySubTest.java
+++ b/src/test/java/hotspot/user/policy/domain/PolicySubTest.java
@@ -1,8 +1,9 @@
 package hotspot.user.policy.domain;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import static org.assertj.core.api.Assertions.assertThat;
 
 class PolicySubTest {
     @Test

--- a/src/test/java/hotspot/user/policy/domain/PolicySubTest.java
+++ b/src/test/java/hotspot/user/policy/domain/PolicySubTest.java
@@ -1,0 +1,23 @@
+package hotspot.user.policy.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PolicySubTest {
+    @Test
+    @DisplayName("성공: PolicySub 논리 삭제 시 isDeleted 필드가 true가 된다")
+    void deleteSuccess() {
+        // given
+        PolicySub policySub = PolicySub.builder()
+                .id(1L)
+                .isDeleted(false)
+                .build();
+
+        // when
+        policySub.delete();
+
+        // then
+        assertThat(policySub.getIsDeleted()).isTrue();
+    }
+}

--- a/src/test/java/hotspot/user/policy/domain/PolicySubTest.java
+++ b/src/test/java/hotspot/user/policy/domain/PolicySubTest.java
@@ -19,6 +19,6 @@ class PolicySubTest {
         policySub.delete();
 
         // then
-        assertThat(policySub.getIsDeleted()).isTrue();
+        assertThat(policySub.isDeleted()).isTrue();
     }
 }

--- a/src/test/java/hotspot/user/policy/infrastructure/BlockPolicyRepositoryImplTest.java
+++ b/src/test/java/hotspot/user/policy/infrastructure/BlockPolicyRepositoryImplTest.java
@@ -1,6 +1,7 @@
 package hotspot.user.policy.infrastructure;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.BDDMockito.given;
 
 import java.util.List;
@@ -50,5 +51,21 @@ class BlockPolicyRepositoryImplTest {
         assertThat(result).hasSize(1);
         assertThat(result.get(0).getName()).isEqualTo("기본 차단");
         assertThat(result.get(0).getPolicyType()).isEqualTo(PolicyType.SCHEDULED);
+    }
+
+    @Test
+    @DisplayName("성공: ID 리스트로 정책들을 일괄 조회한다")
+    void findAllByIdSuccess() {
+        // given
+        BlockPolicyEntity entity1 = BlockPolicyEntity.builder().blockPolicyId(1L).policyName("P1").build();
+        BlockPolicyEntity entity2 = BlockPolicyEntity.builder().blockPolicyId(2L).policyName("P2").build();
+        given(blockPolicyJpaRepository.findAllById(anyList())).willReturn(List.of(entity1, entity2));
+
+        // when
+        List<BlockPolicy> result = blockPolicyRepository.findAllById(List.of(1L, 2L));
+
+        // then
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).getId()).isEqualTo(1L);
     }
 }

--- a/src/test/java/hotspot/user/policy/infrastructure/PolicySubRepositoryImplTest.java
+++ b/src/test/java/hotspot/user/policy/infrastructure/PolicySubRepositoryImplTest.java
@@ -1,9 +1,8 @@
 package hotspot.user.policy.infrastructure;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.BDDMockito.given;
-
 import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 

--- a/src/test/java/hotspot/user/policy/infrastructure/PolicySubRepositoryImplTest.java
+++ b/src/test/java/hotspot/user/policy/infrastructure/PolicySubRepositoryImplTest.java
@@ -3,6 +3,10 @@ package hotspot.user.policy.infrastructure;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
 import java.util.List;
 
 import org.junit.jupiter.api.DisplayName;
@@ -60,5 +64,35 @@ class PolicySubRepositoryImplTest {
         // then
         assertThat(result).hasSize(1);
         assertThat(result.get(0).getDateSnapshot().getPolicyName()).isEqualTo("수면 모드");
+    }
+
+    @Test
+    @DisplayName("성공: 신규 PolicySub 정보를 저장한다")
+    void saveAllSuccessWithNewEntities() {
+        // given
+        PolicySub domain = PolicySub.builder().id(null).subId(1L).policyId(1L).build();
+        PolicySubEntity entity = PolicySubEntity.builder().policySubId(1L).build();
+        given(jpaRepository.saveAll(anyList())).willReturn(List.of(entity));
+
+        // when
+        List<PolicySub> result = repository.saveAll(List.of(domain));
+
+        // then
+        assertThat(result).hasSize(1);
+        verify(jpaRepository, times(1)).saveAll(anyList());
+    }
+
+    @Test
+    @DisplayName("성공: 기존 PoliySub row를 논리 삭제(업데이트)한다")
+    void saveAllSuccessWithUpdateEntities() {
+        // given
+        PolicySub domain = PolicySub.builder().id(10L).subId(1L).policyId(1L).isDeleted(true).build();
+
+        // when
+        List<PolicySub> result = repository.saveAll(List.of(domain));
+
+        // then
+        assertThat(result).isEmpty();
+        verify(jpaRepository, times(1)).bulkSoftDelete(anyList());
     }
 }

--- a/src/test/java/hotspot/user/policy/service/UpdateBlockPolicyServiceImplTest.java
+++ b/src/test/java/hotspot/user/policy/service/UpdateBlockPolicyServiceImplTest.java
@@ -98,7 +98,7 @@ class UpdateBlockPolicyServiceImplTest {
 
         // then
         assertThat(response.blockedPolicyIdList()).containsExactly(2L);
-        assertThat(existingSub.getIsDeleted()).isTrue(); // 기존 정책은 삭제됨
+        assertThat(existingSub.isDeleted()).isTrue(); // 기존 정책은 삭제됨
         verify(policySubRepository, times(1)).saveAll(anyList());
     }
 
@@ -120,7 +120,7 @@ class UpdateBlockPolicyServiceImplTest {
         updateBlockPolicyService.updateBlockPolicy(request, familyId, FamilyRole.OWNER);
 
         // then
-        assertThat(existingSub.getIsDeleted()).isTrue();
+        assertThat(existingSub.isDeleted()).isTrue();
         verify(policySubRepository, times(1)).saveAll(anyList());
     }
 

--- a/src/test/java/hotspot/user/policy/service/UpdateBlockPolicyServiceImplTest.java
+++ b/src/test/java/hotspot/user/policy/service/UpdateBlockPolicyServiceImplTest.java
@@ -1,0 +1,152 @@
+package hotspot.user.policy.service;
+
+import hotspot.user.common.exception.ApplicationException;
+import hotspot.user.common.exception.code.AuthErrorCode;
+import hotspot.user.common.exception.code.FamilyErrorCode;
+import hotspot.user.common.exception.code.PolicyErrorCode;
+import hotspot.user.family.domain.Family;
+import hotspot.user.family.domain.FamilySubscription;
+import hotspot.user.family.service.port.FamilySubscriptionRepository;
+import hotspot.user.member.domain.FamilyRole;
+import hotspot.user.policy.controller.request.UpdateBlockPolicyRequest;
+import hotspot.user.policy.controller.response.UpdateBlockPolicyResponse;
+import hotspot.user.policy.domain.BlockPolicy;
+import hotspot.user.policy.domain.DateSnapshot;
+import hotspot.user.policy.domain.PolicySub;
+import hotspot.user.policy.service.port.BlockPolicyRepository;
+import hotspot.user.policy.service.port.PolicySubRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class UpdateBlockPolicyServiceImplTest {
+
+    @InjectMocks
+    private UpdateBlockPolicyServiceImpl updateBlockPolicyService;
+
+    @Mock
+    private PolicySubRepository policySubRepository;
+
+    @Mock
+    private FamilySubscriptionRepository familySubscriptionRepository;
+
+    @Mock
+    private BlockPolicyRepository blockPolicyRepository;
+
+    @Test
+    @DisplayName("성공: 유효한 요청일 경우 구성원에게 적용된 정책이 업데이트된다")
+    void updateBlockPolicySuccess() {
+        // given
+        Long familyId = 100L;
+        Long subId = 1L;
+        UpdateBlockPolicyRequest request = new UpdateBlockPolicyRequest(familyId, subId, List.of(1L));
+
+        setAuthMock(familyId, subId);
+        
+        BlockPolicy policy = BlockPolicy.builder().id(1L).name("Test Policy").build();
+        given(blockPolicyRepository.findAllById(anyList())).willReturn(List.of(policy));
+        given(policySubRepository.findBySubId(subId)).willReturn(new ArrayList<>());
+
+        // when
+        UpdateBlockPolicyResponse response = updateBlockPolicyService.updateBlockPolicy(request, familyId, FamilyRole.OWNER);
+
+        // then
+        assertThat(response.subId()).isEqualTo(subId);
+        verify(policySubRepository, times(1)).saveAll(anyList());
+    }
+
+    @Test
+    @DisplayName("성공: 기존 정책이 교체되고 새로운 정책이 추가된다")
+    void updateBlockPolicySuccessWithReplacement() {
+        // given
+        Long familyId = 100L;
+        Long subId = 1L;
+        UpdateBlockPolicyRequest request = new UpdateBlockPolicyRequest(familyId, subId, List.of(2L));
+
+        setAuthMock(familyId, subId);
+
+        // 기존에 활성화된 정책 (ID: 1L)
+        PolicySub existingSub = PolicySub.builder().id(10L).policyId(1L).isDeleted(false).build();
+        given(policySubRepository.findBySubId(subId)).willReturn(new ArrayList<>(List.of(existingSub)));
+
+        // 요청된 새로운 정책 (ID: 2L)
+        BlockPolicy newPolicy = BlockPolicy.builder().id(2L).name("New Policy").build();
+        given(blockPolicyRepository.findAllById(anyList())).willReturn(List.of(newPolicy));
+
+        // when
+        UpdateBlockPolicyResponse response = updateBlockPolicyService.updateBlockPolicy(request, familyId, FamilyRole.OWNER);
+
+        // then
+        assertThat(response.blockedPolicyIdList()).containsExactly(2L);
+        assertThat(existingSub.getIsDeleted()).isTrue(); // 기존 정책은 삭제됨
+        verify(policySubRepository, times(1)).saveAll(anyList());
+    }
+
+    @Test
+    @DisplayName("성공: 요청 목록에 없는 기존 정책은 삭제된다")
+    void updateBlockPolicySuccessWithDeletion() {
+        // given
+        Long familyId = 100L;
+        Long subId = 1L;
+        UpdateBlockPolicyRequest request = new UpdateBlockPolicyRequest(familyId, subId, List.of()); // 요청은 비어있음
+
+        setAuthMock(familyId, subId);
+
+        PolicySub existingSub = PolicySub.builder().id(10L).policyId(1L).isDeleted(false).build();
+        given(policySubRepository.findBySubId(subId)).willReturn(new ArrayList<>(List.of(existingSub)));
+        given(blockPolicyRepository.findAllById(anyList())).willReturn(List.of());
+
+        // when
+        updateBlockPolicyService.updateBlockPolicy(request, familyId, FamilyRole.OWNER);
+
+        // then
+        assertThat(existingSub.getIsDeleted()).isTrue();
+        verify(policySubRepository, times(1)).saveAll(anyList());
+    }
+
+    @Test
+    @DisplayName("실패: OWNER 권한이 아닌 경우 예외가 발생한다")
+    void updateBlockPolicyFailByRole() {
+        // given
+        UpdateBlockPolicyRequest request = new UpdateBlockPolicyRequest(100L, 1L, List.of(1L));
+        
+        // when & then
+        assertThatThrownBy(() -> updateBlockPolicyService.updateBlockPolicy(request, 100L, FamilyRole.CHILD))
+                .isInstanceOf(ApplicationException.class)
+                .hasMessage(AuthErrorCode.ACCESS_DENIED.getMessage());
+    }
+
+    @Test
+    @DisplayName("실패: 요청한 정책 중 일부가 존재하지 않으면 예외가 발생한다")
+    void updateBlockPolicyFailByPolicyNotFound() {
+        // given
+        UpdateBlockPolicyRequest request = new UpdateBlockPolicyRequest(100L, 1L, List.of(1L, 2L));
+        setAuthMock(100L, 1L);
+        given(blockPolicyRepository.findAllById(anyList())).willReturn(List.of(BlockPolicy.builder().id(1L).build()));
+
+        // when & then
+        assertThatThrownBy(() -> updateBlockPolicyService.updateBlockPolicy(request, 100L, FamilyRole.OWNER))
+                .isInstanceOf(ApplicationException.class)
+                .hasMessage(PolicyErrorCode.POLICY_NOT_FOUND.getMessage());
+    }
+
+    private void setAuthMock(Long familyId, Long subId) {
+        Family family = Family.builder().id(familyId).build();
+        FamilySubscription familySub = FamilySubscription.builder().family(family).build();
+        given(familySubscriptionRepository.findBySubId(subId)).willReturn(Optional.of(familySub));
+    }
+}

--- a/src/test/java/hotspot/user/policy/service/UpdateBlockPolicyServiceImplTest.java
+++ b/src/test/java/hotspot/user/policy/service/UpdateBlockPolicyServiceImplTest.java
@@ -1,8 +1,25 @@
 package hotspot.user.policy.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
 import hotspot.user.common.exception.ApplicationException;
 import hotspot.user.common.exception.code.AuthErrorCode;
-import hotspot.user.common.exception.code.FamilyErrorCode;
 import hotspot.user.common.exception.code.PolicyErrorCode;
 import hotspot.user.family.domain.Family;
 import hotspot.user.family.domain.FamilySubscription;
@@ -11,26 +28,9 @@ import hotspot.user.member.domain.FamilyRole;
 import hotspot.user.policy.controller.request.UpdateBlockPolicyRequest;
 import hotspot.user.policy.controller.response.UpdateBlockPolicyResponse;
 import hotspot.user.policy.domain.BlockPolicy;
-import hotspot.user.policy.domain.DateSnapshot;
 import hotspot.user.policy.domain.PolicySub;
 import hotspot.user.policy.service.port.BlockPolicyRepository;
 import hotspot.user.policy.service.port.PolicySubRepository;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.anyList;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class UpdateBlockPolicyServiceImplTest {
@@ -56,13 +56,16 @@ class UpdateBlockPolicyServiceImplTest {
         UpdateBlockPolicyRequest request = new UpdateBlockPolicyRequest(familyId, subId, List.of(1L));
 
         setAuthMock(familyId, subId);
-        
+
         BlockPolicy policy = BlockPolicy.builder().id(1L).name("Test Policy").build();
         given(blockPolicyRepository.findAllById(anyList())).willReturn(List.of(policy));
         given(policySubRepository.findBySubId(subId)).willReturn(new ArrayList<>());
 
         // when
-        UpdateBlockPolicyResponse response = updateBlockPolicyService.updateBlockPolicy(request, familyId, FamilyRole.OWNER);
+        UpdateBlockPolicyResponse response = updateBlockPolicyService.updateBlockPolicy(
+                request,
+                familyId,
+                FamilyRole.OWNER);
 
         // then
         assertThat(response.subId()).isEqualTo(subId);
@@ -88,7 +91,10 @@ class UpdateBlockPolicyServiceImplTest {
         given(blockPolicyRepository.findAllById(anyList())).willReturn(List.of(newPolicy));
 
         // when
-        UpdateBlockPolicyResponse response = updateBlockPolicyService.updateBlockPolicy(request, familyId, FamilyRole.OWNER);
+        UpdateBlockPolicyResponse response = updateBlockPolicyService.updateBlockPolicy(
+                request,
+                familyId,
+                FamilyRole.OWNER);
 
         // then
         assertThat(response.blockedPolicyIdList()).containsExactly(2L);
@@ -123,7 +129,7 @@ class UpdateBlockPolicyServiceImplTest {
     void updateBlockPolicyFailByRole() {
         // given
         UpdateBlockPolicyRequest request = new UpdateBlockPolicyRequest(100L, 1L, List.of(1L));
-        
+
         // when & then
         assertThatThrownBy(() -> updateBlockPolicyService.updateBlockPolicy(request, 100L, FamilyRole.CHILD))
                 .isInstanceOf(ApplicationException.class)


### PR DESCRIPTION
## 🎫 지라 티켓

<!-- 지라 티켓을 작성해주세요 ex) HOTSPOT-123 -->
HOTSPOT-100

---

## 🔗 GitHub 이슈
<!-- 자동 close를 원하면 아래 형식으로 작성
예) Closes #12
-->
Closes #21 

---


## ✅ 작업 사항

<!-- 작업한 부분을 설명해주세요. -->


가족 내 특정 구성원(회선)에 대해 차단 정책을 업데이트 (적용 & 해제) 기능을 구현

<br/>


  1. Service & Domain 레이어
   - `UpdateBlockPolicyServiceImpl`: 정책 업데이트(Delete-then-Insert) 로직 구현, 기존 활성 정책은 논리 삭제 처리하고 요청된 정책은 새로운 스냅샷으로 생성
   - `PolicySub` 도메인: policyId, isDeleted 필드 추가 및 논리 삭제(delete()) 메서드 구현

<br/>

  2. Infrastructure 레이어 (Persistence)
   - `BlockPolicyRepositoryImpl`: findAllById를 구현하여 여러 정책 마스터 데이터를 IN 절로 일괄 조회하도록 최적화
   - `PolicySubRepositoryImpl`: saveAll을 구현하여 `INSERT` - 벌크 업데이트(bulkSoftDelete)를 분리 처리함으로써 N+1 문제를 방지
   - NPE 방어 로직: `SubscriptionEntity`, `PolicySubEntity`의 `entityToDomain` 변환 시 연관 엔티티가 null인 경우에 대한 방어 코드를 추가

<br/>

  3. API & Swagger
   - `AppliedPolicyController`: `PUT /api/v1/policies/apply` 엔드포인트 구현
   - `AppliedPolicyApi`: Swagger 명세를 작성하여 API 문서화 및 권한(OWNER/PARENT) 정보 명시

---

## 📋 체크리스트

<!-- PR 제출 전 확인해주세요. 해당 항목에 [x]로 체크해주세요. -->

- [x] 코드가 정상적으로 빌드됩니다.
- [x] 관련 테스트 코드를 작성했습니다.
- [x] 기존 테스트가 모두 통과합니다.
- [x] 코드 스타일(Spotless, Checkstyle)을 준수합니다.
- [x] Jira 티켓 상태를 In Review / Done으로 변경했습니다.

---

## ⌨ 기타
