### PR TITLE
[HOTSPOT-143] 구성원별 정보 조회 API 구현

### DIFF
--- a/src/main/java/hotspot/user/member/controller/MemberController.java
+++ b/src/main/java/hotspot/user/member/controller/MemberController.java
@@ -1,0 +1,31 @@
+package hotspot.user.member.controller;
+
+import hotspot.user.common.ApiResponse;
+import hotspot.user.common.security.PrincipalDetails;
+import hotspot.user.member.controller.port.FindMemberService;
+import hotspot.user.member.controller.response.MemberResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/members")
+public class MemberController {
+
+    private final FindMemberService findMemberService;
+
+    // 내 정보 조회
+    // [To-Do] 구성원 별 정보 조회는 전체 가족 조회할 때 모두 포함되는 값이라서 따로 API로 만들진 않았는데 추후 필요하면 추가하기
+    @GetMapping("/me")
+    public ResponseEntity<ApiResponse<MemberResponse>> getMemberInfo(
+            @AuthenticationPrincipal PrincipalDetails principal) {
+
+        MemberResponse result = findMemberService.findById(principal.getId());
+
+        return ResponseEntity.ok(ApiResponse.success(null));
+    }
+}

--- a/src/main/java/hotspot/user/member/controller/MemberController.java
+++ b/src/main/java/hotspot/user/member/controller/MemberController.java
@@ -1,16 +1,16 @@
 package hotspot.user.member.controller;
 
-import hotspot.user.common.ApiResponse;
-import hotspot.user.common.security.PrincipalDetails;
-import hotspot.user.member.controller.port.FindMemberService;
-import hotspot.user.member.controller.response.MemberResponse;
-
-import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import hotspot.user.common.ApiResponse;
+import hotspot.user.common.security.PrincipalDetails;
+import hotspot.user.member.controller.port.FindMemberService;
+import hotspot.user.member.controller.response.MemberResponse;
+import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor

--- a/src/main/java/hotspot/user/member/controller/MemberController.java
+++ b/src/main/java/hotspot/user/member/controller/MemberController.java
@@ -10,17 +10,19 @@ import hotspot.user.common.ApiResponse;
 import hotspot.user.common.security.PrincipalDetails;
 import hotspot.user.member.controller.port.FindMemberService;
 import hotspot.user.member.controller.response.MemberResponse;
+import hotspot.user.member.controller.swagger.MemberApi;
 import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/members")
-public class MemberController {
+public class MemberController implements MemberApi {
 
     private final FindMemberService findMemberService;
 
     // 내 정보 조회
     // [To-Do] 구성원 별 정보 조회는 전체 가족 조회할 때 모두 포함되는 값이라서 따로 API로 만들진 않았는데 추후 필요하면 추가하기
+    @Override
     @GetMapping("/me")
     public ResponseEntity<ApiResponse<MemberResponse>> getMemberInfo(
             @AuthenticationPrincipal PrincipalDetails principal) {

--- a/src/main/java/hotspot/user/member/controller/MemberController.java
+++ b/src/main/java/hotspot/user/member/controller/MemberController.java
@@ -4,6 +4,7 @@ import hotspot.user.common.ApiResponse;
 import hotspot.user.common.security.PrincipalDetails;
 import hotspot.user.member.controller.port.FindMemberService;
 import hotspot.user.member.controller.response.MemberResponse;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -26,6 +27,6 @@ public class MemberController {
 
         MemberResponse result = findMemberService.findById(principal.getId());
 
-        return ResponseEntity.ok(ApiResponse.success(null));
+        return ResponseEntity.ok(ApiResponse.success(result));
     }
 }

--- a/src/main/java/hotspot/user/member/controller/MemberController.java
+++ b/src/main/java/hotspot/user/member/controller/MemberController.java
@@ -27,7 +27,7 @@ public class MemberController implements MemberApi {
     public ResponseEntity<ApiResponse<MemberResponse>> getMemberInfo(
             @AuthenticationPrincipal PrincipalDetails principal) {
 
-        MemberResponse result = findMemberService.findById(principal.getId());
+        MemberResponse result = findMemberService.findByIdAndEmail(principal.getId(), principal.getEmail());
 
         return ResponseEntity.ok(ApiResponse.success(result));
     }

--- a/src/main/java/hotspot/user/member/controller/port/FindMemberService.java
+++ b/src/main/java/hotspot/user/member/controller/port/FindMemberService.java
@@ -7,5 +7,5 @@ import hotspot.user.member.controller.response.MemberResponse;
  * 회원 조회 서비스 인터페이스
  */
 public interface FindMemberService {
-    MemberResponse findById(Long id);
+    MemberResponse findByIdAndEmail(Long id, String email);
 }

--- a/src/main/java/hotspot/user/member/controller/response/MemberResponse.java
+++ b/src/main/java/hotspot/user/member/controller/response/MemberResponse.java
@@ -13,16 +13,8 @@ public record MemberResponse(
         String email,
         String phone,
         FamilyRole familyRole,
+        Long familyId,
+        Long subId,
         Status status
 ) {
-    public static MemberResponse of(Member member, String email, String phone, FamilyRole familyRole) {
-        return new MemberResponse(
-                member.getId(),
-                member.getName(),
-                email,
-                phone,
-                familyRole,
-                member.getStatus()
-        );
-    }
 }

--- a/src/main/java/hotspot/user/member/controller/response/MemberResponse.java
+++ b/src/main/java/hotspot/user/member/controller/response/MemberResponse.java
@@ -1,12 +1,15 @@
 package hotspot.user.member.controller.response;
 
 import hotspot.user.member.domain.FamilyRole;
-import hotspot.user.member.domain.Member;
+
 import hotspot.user.member.domain.Status;
+import lombok.Builder;
+
 
 /**
  * 회원 정보 응답 DTO
  */
+@Builder
 public record MemberResponse(
         Long id,
         String name,

--- a/src/main/java/hotspot/user/member/controller/response/MemberResponse.java
+++ b/src/main/java/hotspot/user/member/controller/response/MemberResponse.java
@@ -1,7 +1,6 @@
 package hotspot.user.member.controller.response;
 
 import hotspot.user.member.domain.FamilyRole;
-
 import hotspot.user.member.domain.Status;
 import lombok.Builder;
 

--- a/src/main/java/hotspot/user/member/controller/swagger/MemberApi.java
+++ b/src/main/java/hotspot/user/member/controller/swagger/MemberApi.java
@@ -1,0 +1,29 @@
+package hotspot.user.member.controller.swagger;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+import hotspot.user.common.ApiResponse;
+import hotspot.user.common.exception.ErrorResponse;
+import hotspot.user.common.security.PrincipalDetails;
+import hotspot.user.member.controller.response.MemberResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "Member", description = "구성원(회원) 관련 API")
+public interface MemberApi {
+
+    @Operation(summary = "내 정보 조회", description = "현재 로그인한 사용자의 상세 정보(이름, 이메일, 전화번호, 가족 역할 등)를 조회합니다.")
+    @ApiResponses(value = {
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "회원 정보를 찾을 수 없음",
+                     content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    ResponseEntity<ApiResponse<MemberResponse>> getMemberInfo(
+            @Parameter(hidden = true) @AuthenticationPrincipal PrincipalDetails principal
+    );
+}

--- a/src/main/java/hotspot/user/member/domain/MemberDetailInfo.java
+++ b/src/main/java/hotspot/user/member/domain/MemberDetailInfo.java
@@ -1,0 +1,18 @@
+package hotspot.user.member.domain;
+
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 회원 상세 정보 조회를 위한 통합 도메인 모델
+ */
+@Getter
+@Builder
+public class MemberDetailInfo {
+    private final Member member;
+    private final String email;
+    private final String phone;      // Subscription 정보
+    private final Long subId;        // Subscription 식별자
+    private final FamilyRole role;   // FamilySubscription 정보
+    private final Long familyId;     // 소속 가족 식별자
+}

--- a/src/main/java/hotspot/user/member/domain/MemberDetailInfoDto.java
+++ b/src/main/java/hotspot/user/member/domain/MemberDetailInfoDto.java
@@ -1,0 +1,18 @@
+package hotspot.user.member.domain;
+
+import hotspot.user.member.infrastructure.entity.MemberEntity;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 회원 상세 정보 조회를 위한 통합 도메인 모델
+ */
+@Builder
+public record MemberDetailInfoDto(
+        MemberEntity memberEntity,
+        String email,
+        String phone,
+        Long subId,
+        FamilyRole role,
+        Long familyId
+) { }

--- a/src/main/java/hotspot/user/member/domain/mapper/MemberMapper.java
+++ b/src/main/java/hotspot/user/member/domain/mapper/MemberMapper.java
@@ -2,8 +2,9 @@ package hotspot.user.member.domain.mapper;
 
 import hotspot.user.member.controller.request.CreateSocialAccountRequest;
 import hotspot.user.member.controller.response.MemberResponse;
-import hotspot.user.member.domain.*;
-import hotspot.user.subscription.domain.Subscription;
+import hotspot.user.member.domain.Member;
+import hotspot.user.member.domain.MemberDetailInfo;
+import hotspot.user.member.domain.Status;
 
 /**
  * Member 도메인과 DTO 간의 변환을 담당하는 매퍼

--- a/src/main/java/hotspot/user/member/domain/mapper/MemberMapper.java
+++ b/src/main/java/hotspot/user/member/domain/mapper/MemberMapper.java
@@ -2,10 +2,7 @@ package hotspot.user.member.domain.mapper;
 
 import hotspot.user.member.controller.request.CreateSocialAccountRequest;
 import hotspot.user.member.controller.response.MemberResponse;
-import hotspot.user.member.domain.FamilyRole;
-import hotspot.user.member.domain.Member;
-import hotspot.user.member.domain.SocialAccount;
-import hotspot.user.member.domain.Status;
+import hotspot.user.member.domain.*;
 import hotspot.user.subscription.domain.Subscription;
 
 /**
@@ -21,25 +18,18 @@ public class MemberMapper {
                 .build();
     }
 
-    // Domain -> Response (회원 정보 조회 시 조립)
-    public static MemberResponse toMemberResponse(Member member,
-                                            SocialAccount socialAccount,
-                                            Subscription subscription,
-                                            FamilyRole familyRole,
-                                            Long familyId) {
-        String email = (socialAccount != null) ? socialAccount.getEmail() : null;
-        String phone = (subscription != null) ? subscription.getPhoneEnc() : null;
-        Long subId = (subscription != null) ? subscription.getId() : null;
-
+    // Domain -> Response
+    public static MemberResponse toMemberResponse(MemberDetailInfo info) {
         return MemberResponse.builder()
-                .id(member.getId())
-                .name(member.getName())
-                .email(email)
-                .phone(phone)
-                .familyRole(familyRole)
-                .familyId(familyId)
-                .subId(subId)
-                .status(member.getStatus())
-                .build();
+             .id(info.getMember().getId())
+             .name(info.getMember().getName())
+             .email(info.getEmail())
+             .phone(info.getPhone())
+             .familyRole(info.getRole())
+             .familyId(info.getFamilyId())
+             .subId(info.getSubId())
+             .status(info.getMember().getStatus())
+             .build();
     }
+
 }

--- a/src/main/java/hotspot/user/member/domain/mapper/MemberMapper.java
+++ b/src/main/java/hotspot/user/member/domain/mapper/MemberMapper.java
@@ -22,13 +22,24 @@ public class MemberMapper {
     }
 
     // Domain -> Response (회원 정보 조회 시 조립)
-    public static MemberResponse toResponse(Member member,
+    public static MemberResponse toMemberResponse(Member member,
                                             SocialAccount socialAccount,
                                             Subscription subscription,
-                                            FamilyRole familyRole) {
+                                            FamilyRole familyRole,
+                                            Long familyId) {
         String email = (socialAccount != null) ? socialAccount.getEmail() : null;
         String phone = (subscription != null) ? subscription.getPhoneEnc() : null;
+        Long subId = (subscription != null) ? subscription.getId() : null;
 
-        return MemberResponse.of(member, email, phone, familyRole);
+        return MemberResponse.builder()
+                .id(member.getId())
+                .name(member.getName())
+                .email(email)
+                .phone(phone)
+                .familyRole(familyRole)
+                .familyId(familyId)
+                .subId(subId)
+                .status(member.getStatus())
+                .build();
     }
 }

--- a/src/main/java/hotspot/user/member/infrastructure/MemberJpaRepository.java
+++ b/src/main/java/hotspot/user/member/infrastructure/MemberJpaRepository.java
@@ -1,10 +1,28 @@
 package hotspot.user.member.infrastructure;
 
+import java.util.List;
+import java.util.Optional;
+
+import hotspot.user.member.domain.MemberDetailInfoDto;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import hotspot.user.member.infrastructure.entity.MemberEntity;
 
+
 @Repository
 public interface MemberJpaRepository extends JpaRepository<MemberEntity, Long> {
+
+    // MemberId로 여러 테이블 JOIN 해서 한 번에 조회
+    @Query("""
+           SELECT m, sa.email, s.phoneEnc, s.subId, fs.familyRole, fs.family.familyId
+           FROM MemberEntity m
+           LEFT JOIN SocialAccountEntity sa ON sa.member = m
+           LEFT JOIN SubscriptionEntity s ON s.member = m
+           LEFT JOIN FamilySubscriptionEntity fs ON fs.subscription = s
+           WHERE m.id = :memberId
+           """)
+    Optional<MemberDetailInfoDto> findDetailQueryResult(@Param("memberId") Long memberId);
 }

--- a/src/main/java/hotspot/user/member/infrastructure/MemberJpaRepository.java
+++ b/src/main/java/hotspot/user/member/infrastructure/MemberJpaRepository.java
@@ -1,9 +1,8 @@
 package hotspot.user.member.infrastructure;
 
-import java.util.List;
 import java.util.Optional;
 
-import hotspot.user.member.domain.MemberDetailInfoDto;
+import hotspot.user.member.infrastructure.entity.MemberDetailInfoDto;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;

--- a/src/main/java/hotspot/user/member/infrastructure/MemberJpaRepository.java
+++ b/src/main/java/hotspot/user/member/infrastructure/MemberJpaRepository.java
@@ -2,12 +2,12 @@ package hotspot.user.member.infrastructure;
 
 import java.util.Optional;
 
-import hotspot.user.member.infrastructure.entity.MemberDetailInfoDto;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import hotspot.user.member.infrastructure.entity.MemberDetailInfoDto;
 import hotspot.user.member.infrastructure.entity.MemberEntity;
 
 

--- a/src/main/java/hotspot/user/member/infrastructure/MemberJpaRepository.java
+++ b/src/main/java/hotspot/user/member/infrastructure/MemberJpaRepository.java
@@ -14,17 +14,19 @@ import hotspot.user.member.infrastructure.entity.MemberEntity;
 @Repository
 public interface MemberJpaRepository extends JpaRepository<MemberEntity, Long> {
 
-    // MemberId로 여러 테이블 JOIN 해서 한 번에 조회
+    // MemberId와 현재 로그인한 Email로 여러 테이블 JOIN 해서 한 번에 조회
     // MemberDetailInfoDto로 바로 변환해야함 But, Builder는 JPQL에서 불가능
+    // [To-Do] 1:N 관계(다중 회선) 발생 시 중복 행 문제 해결 필요
+    // - Subscription: 현재는 1:1로 가정하나, 다중 회선 확장 시 최신/대표 회선 필터링 조건 추가 필요
     @Query("""
-           SELECT new hotspot.user.member.infrastructure.entity.MemberDetailInfoDto(
+           SELECT DISTINCT new hotspot.user.member.infrastructure.entity.MemberDetailInfoDto(
                m, sa.email, s.phoneEnc, s.subId, fs.familyRole, fs.family.familyId
            )
            FROM MemberEntity m
-           LEFT JOIN SocialAccountEntity sa ON sa.member = m
+           LEFT JOIN SocialAccountEntity sa ON sa.member = m AND sa.email = :email
            LEFT JOIN SubscriptionEntity s ON s.member = m
            LEFT JOIN FamilySubscriptionEntity fs ON fs.subscription = s
            WHERE m.id = :memberId
            """)
-    Optional<MemberDetailInfoDto> findDetailQueryResult(@Param("memberId") Long memberId);
+    Optional<MemberDetailInfoDto> findDetailQueryResult(@Param("memberId") Long memberId, @Param("email") String email);
 }

--- a/src/main/java/hotspot/user/member/infrastructure/MemberJpaRepository.java
+++ b/src/main/java/hotspot/user/member/infrastructure/MemberJpaRepository.java
@@ -15,8 +15,11 @@ import hotspot.user.member.infrastructure.entity.MemberEntity;
 public interface MemberJpaRepository extends JpaRepository<MemberEntity, Long> {
 
     // MemberId로 여러 테이블 JOIN 해서 한 번에 조회
+    // MemberDetailInfoDto로 바로 변환해야함 But, Builder는 JPQL에서 불가능
     @Query("""
-           SELECT m, sa.email, s.phoneEnc, s.subId, fs.familyRole, fs.family.familyId
+           SELECT new hotspot.user.member.infrastructure.entity.MemberDetailInfoDto(
+               m, sa.email, s.phoneEnc, s.subId, fs.familyRole, fs.family.familyId
+           )
            FROM MemberEntity m
            LEFT JOIN SocialAccountEntity sa ON sa.member = m
            LEFT JOIN SubscriptionEntity s ON s.member = m

--- a/src/main/java/hotspot/user/member/infrastructure/MemberRepositoryImpl.java
+++ b/src/main/java/hotspot/user/member/infrastructure/MemberRepositoryImpl.java
@@ -30,9 +30,9 @@ public class MemberRepositoryImpl implements MemberRepository {
     }
 
     @Override
-    public Optional<MemberDetailInfo> findDetailById(Long id) {
+    public Optional<MemberDetailInfo> findDetailByIdAndEmail(Long id, String email) {
         // 쿼리 결과를 DTO로 받고, 안전하게 도메인 객체(MemberDetailInfo)로 변환
-        return memberJpaRepository.findDetailQueryResult(id)
+        return memberJpaRepository.findDetailQueryResult(id, email)
                 .map(dto -> MemberDetailInfo.builder()
                         .member(dto.memberEntity().entityToDomain())
                         .email(dto.email())

--- a/src/main/java/hotspot/user/member/infrastructure/MemberRepositoryImpl.java
+++ b/src/main/java/hotspot/user/member/infrastructure/MemberRepositoryImpl.java
@@ -4,7 +4,6 @@ import java.util.Optional;
 
 import org.springframework.stereotype.Repository;
 
-
 import hotspot.user.member.domain.Member;
 import hotspot.user.member.domain.MemberDetailInfo;
 import hotspot.user.member.infrastructure.entity.MemberEntity;

--- a/src/main/java/hotspot/user/member/infrastructure/MemberRepositoryImpl.java
+++ b/src/main/java/hotspot/user/member/infrastructure/MemberRepositoryImpl.java
@@ -4,7 +4,9 @@ import java.util.Optional;
 
 import org.springframework.stereotype.Repository;
 
+
 import hotspot.user.member.domain.Member;
+import hotspot.user.member.domain.MemberDetailInfo;
 import hotspot.user.member.infrastructure.entity.MemberEntity;
 import hotspot.user.member.service.port.MemberRepository;
 import lombok.RequiredArgsConstructor;
@@ -26,6 +28,21 @@ public class MemberRepositoryImpl implements MemberRepository {
     public Optional<Member> findById(Long id) {
         return memberJpaRepository.findById(id)
                 .map(MemberEntity::entityToDomain);
+    }
+
+    @Override
+    public Optional<MemberDetailInfo> findDetailById(Long id) {
+        // 쿼리 결과를 DTO로 받고, 안전하게 도메인 객체(MemberDetailInfo)로 변환
+        return memberJpaRepository.findDetailQueryResult(id)
+                .map(dto -> MemberDetailInfo.builder()
+                        .member(dto.memberEntity().entityToDomain())
+                        .email(dto.email())
+                        .phone(dto.phone())
+                        .subId(dto.subId())
+                        .role(dto.role())
+                        .familyId(dto.familyId())
+                        .build()
+                );
     }
 
     @Override

--- a/src/main/java/hotspot/user/member/infrastructure/entity/MemberDetailInfoDto.java
+++ b/src/main/java/hotspot/user/member/infrastructure/entity/MemberDetailInfoDto.java
@@ -1,8 +1,7 @@
-package hotspot.user.member.domain;
+package hotspot.user.member.infrastructure.entity;
 
-import hotspot.user.member.infrastructure.entity.MemberEntity;
+import hotspot.user.member.domain.FamilyRole;
 import lombok.Builder;
-import lombok.Getter;
 
 /**
  * 회원 상세 정보 조회를 위한 통합 도메인 모델

--- a/src/main/java/hotspot/user/member/service/FindMemberServiceImpl.java
+++ b/src/main/java/hotspot/user/member/service/FindMemberServiceImpl.java
@@ -1,22 +1,19 @@
 package hotspot.user.member.service;
 
+
+import hotspot.user.member.domain.MemberDetailInfo;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import hotspot.user.common.exception.ApplicationException;
 import hotspot.user.common.exception.code.MemberErrorCode;
-import hotspot.user.family.domain.FamilySubscription;
-import hotspot.user.family.service.port.FamilySubscriptionRepository;
+
 import hotspot.user.member.controller.port.FindMemberService;
 import hotspot.user.member.controller.response.MemberResponse;
-import hotspot.user.member.domain.FamilyRole;
-import hotspot.user.member.domain.Member;
-import hotspot.user.member.domain.SocialAccount;
+
 import hotspot.user.member.domain.mapper.MemberMapper;
 import hotspot.user.member.service.port.MemberRepository;
-import hotspot.user.member.service.port.SocialAccountRepository;
-import hotspot.user.subscription.domain.Subscription;
-import hotspot.user.subscription.service.port.SubscriptionRepository;
+
 import lombok.RequiredArgsConstructor;
 
 /**
@@ -28,26 +25,15 @@ import lombok.RequiredArgsConstructor;
 public class FindMemberServiceImpl implements FindMemberService {
 
     private final MemberRepository memberRepository;
-    private final SocialAccountRepository socialAccountRepository;
-    private final SubscriptionRepository subscriptionRepository;
-    private final FamilySubscriptionRepository familySubscriptionRepository;
 
     @Override
     public MemberResponse findById(Long id) {
-        Member member = memberRepository.findById(id)
+         // 1. 통합 조회 (JOIN 쿼리 실행)
+        MemberDetailInfo detailInfo = memberRepository.findDetailById(id)
                 .orElseThrow(() -> new ApplicationException(MemberErrorCode.MEMBER_NOT_FOUND));
 
-        // Optional 처리: 없으면 null
-        SocialAccount socialAccount = socialAccountRepository.findByMemberId(id).orElse(null);
-        Subscription subscription = subscriptionRepository.findByMemberId(id).orElse(null);
-
-        FamilyRole familyRole = null;
-        if (subscription != null) {
-            familyRole = familySubscriptionRepository.findBySubId(subscription.getId())
-                    .map(FamilySubscription::getFamilyRole)
-                    .orElse(null);
-        }
-
-        return MemberMapper.toResponse(member, socialAccount, subscription, familyRole);
+        // 2. 매퍼를 통해 응답 DTO로 변환
+        return MemberMapper.toMemberResponse(detailInfo);
     }
+
 }

--- a/src/main/java/hotspot/user/member/service/FindMemberServiceImpl.java
+++ b/src/main/java/hotspot/user/member/service/FindMemberServiceImpl.java
@@ -1,19 +1,16 @@
 package hotspot.user.member.service;
 
 
-import hotspot.user.member.domain.MemberDetailInfo;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import hotspot.user.common.exception.ApplicationException;
 import hotspot.user.common.exception.code.MemberErrorCode;
-
 import hotspot.user.member.controller.port.FindMemberService;
 import hotspot.user.member.controller.response.MemberResponse;
-
+import hotspot.user.member.domain.MemberDetailInfo;
 import hotspot.user.member.domain.mapper.MemberMapper;
 import hotspot.user.member.service.port.MemberRepository;
-
 import lombok.RequiredArgsConstructor;
 
 /**

--- a/src/main/java/hotspot/user/member/service/FindMemberServiceImpl.java
+++ b/src/main/java/hotspot/user/member/service/FindMemberServiceImpl.java
@@ -24,9 +24,9 @@ public class FindMemberServiceImpl implements FindMemberService {
     private final MemberRepository memberRepository;
 
     @Override
-    public MemberResponse findById(Long id) {
+    public MemberResponse findByIdAndEmail(Long id, String email) {
          // 1. 통합 조회 (JOIN 쿼리 실행)
-        MemberDetailInfo detailInfo = memberRepository.findDetailById(id)
+        MemberDetailInfo detailInfo = memberRepository.findDetailByIdAndEmail(id, email)
                 .orElseThrow(() -> new ApplicationException(MemberErrorCode.MEMBER_NOT_FOUND));
 
         // 2. 매퍼를 통해 응답 DTO로 변환

--- a/src/main/java/hotspot/user/member/service/port/MemberRepository.java
+++ b/src/main/java/hotspot/user/member/service/port/MemberRepository.java
@@ -8,7 +8,8 @@ import hotspot.user.member.domain.MemberDetailInfo;
 public interface MemberRepository {
     Member save(Member member);
     Optional<Member> findById(Long id);
-    Optional<MemberDetailInfo> findDetailById(Long id); // 멤버 상세 정보 조회할 떄 JOIN으로 가져오기
+    Optional<MemberDetailInfo> findDetailByIdAndEmail(Long id, String email); // 소셜 계정 여러 개인걸 감안해서 email도 전달
+     // 멤버 상세 정보 조회할 떄 JOIN으로 가져오기
     void delete(Member member);
     void deleteById(Long id);
 }

--- a/src/main/java/hotspot/user/member/service/port/MemberRepository.java
+++ b/src/main/java/hotspot/user/member/service/port/MemberRepository.java
@@ -3,10 +3,12 @@ package hotspot.user.member.service.port;
 import java.util.Optional;
 
 import hotspot.user.member.domain.Member;
+import hotspot.user.member.domain.MemberDetailInfo;
 
 public interface MemberRepository {
     Member save(Member member);
     Optional<Member> findById(Long id);
+    Optional<MemberDetailInfo> findDetailById(Long id); // 멤버 상세 정보 조회할 떄 JOIN으로 가져오기
     void delete(Member member);
     void deleteById(Long id);
 }

--- a/src/test/java/hotspot/user/member/controller/MemberControllerTest.java
+++ b/src/test/java/hotspot/user/member/controller/MemberControllerTest.java
@@ -75,7 +75,7 @@ class MemberControllerTest {
                 .status(Status.APPROVED)
                 .build();
 
-        given(findMemberService.findById(memberId)).willReturn(response);
+        given(findMemberService.findByIdAndEmail(memberId, "test@test.com")).willReturn(response);
 
         // when & then
         mockMvc.perform(get("/api/v1/members/me")

--- a/src/test/java/hotspot/user/member/controller/MemberControllerTest.java
+++ b/src/test/java/hotspot/user/member/controller/MemberControllerTest.java
@@ -1,0 +1,88 @@
+package hotspot.user.member.controller;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.web.servlet.MockMvc;
+
+import hotspot.user.common.security.PrincipalDetails;
+import hotspot.user.common.security.jwt.JwtFilter;
+import hotspot.user.common.security.jwt.JwtProvider;
+import hotspot.user.member.controller.port.FindMemberService;
+import hotspot.user.member.controller.response.MemberResponse;
+import hotspot.user.member.domain.FamilyRole;
+import hotspot.user.member.domain.Status;
+
+/**
+ * Member Controller 단위 테스트
+ */
+@WebMvcTest(MemberController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class MemberControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private FindMemberService findMemberService;
+
+    @MockBean
+    private JwtFilter jwtFilter;
+
+    @MockBean
+    private JwtProvider jwtProvider;
+
+    @MockBean
+    private JpaMetamodelMappingContext jpaMetamodelMappingContext;
+
+    private void setAuthentication(Long memberId) {
+        PrincipalDetails principal = PrincipalDetails.builder()
+                .id(memberId)
+                .email("test@test.com")
+                .role(FamilyRole.OWNER)
+                .status(Status.APPROVED)
+                .build();
+
+        UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(
+                principal, null, principal.getAuthorities());
+        SecurityContextHolder.getContext().setAuthentication(auth);
+    }
+
+    @Test
+    @DisplayName("성공: 내 정보 조회 API 호출 시 200 OK와 사용자 정보를 반환한다")
+    void getMemberInfoSuccess() throws Exception {
+        // given
+        Long memberId = 1L;
+        setAuthentication(memberId);
+
+        MemberResponse response = MemberResponse.builder()
+                .id(memberId)
+                .name("홍길동")
+                .email("test@test.com")
+                .familyRole(FamilyRole.OWNER)
+                .status(Status.APPROVED)
+                .build();
+
+        given(findMemberService.findById(memberId)).willReturn(response);
+
+        // when & then
+        mockMvc.perform(get("/api/v1/members/me")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("200"))
+                .andExpect(jsonPath("$.data.name").value("홍길동"))
+                .andExpect(jsonPath("$.data.email").value("test@test.com"));
+    }
+}

--- a/src/test/java/hotspot/user/member/infrastructure/MemberRepositoryImplTest.java
+++ b/src/test/java/hotspot/user/member/infrastructure/MemberRepositoryImplTest.java
@@ -14,8 +14,11 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import hotspot.user.member.domain.FamilyRole;
 import hotspot.user.member.domain.Member;
+import hotspot.user.member.domain.MemberDetailInfo;
 import hotspot.user.member.domain.Status;
+import hotspot.user.member.infrastructure.entity.MemberDetailInfoDto;
 import hotspot.user.member.infrastructure.entity.MemberEntity;
 
 /**
@@ -61,6 +64,51 @@ class MemberRepositoryImplTest {
         // then
         assertThat(result).isPresent();
         assertThat(result.get().getId()).isEqualTo(memberId);
+    }
+
+    @Test
+    @DisplayName("멤버 상세 정보 조회 성공: JOIN 쿼리 결과를 도메인 객체로 변환한다")
+    void findDetailByIdSuccess() {
+        // given
+        Long memberId = 1L;
+        MemberEntity entity = MemberEntity.builder().id(memberId).name("홍길동").status(Status.APPROVED).build();
+        MemberDetailInfoDto dto = MemberDetailInfoDto.builder()
+                .memberEntity(entity)
+                .email("test@email.com")
+                .phone("010-1234-5678")
+                .subId(10L)
+                .role(FamilyRole.OWNER)
+                .familyId(100L)
+                .build();
+
+        given(memberJpaRepository.findDetailQueryResult(memberId)).willReturn(Optional.of(dto));
+
+        // when
+        Optional<MemberDetailInfo> result = memberRepository.findDetailById(memberId);
+
+        // then
+        assertThat(result).isPresent();
+        MemberDetailInfo info = result.get();
+        assertThat(info.getMember().getId()).isEqualTo(memberId);
+        assertThat(info.getEmail()).isEqualTo("test@email.com");
+        assertThat(info.getPhone()).isEqualTo("010-1234-5678");
+        assertThat(info.getRole()).isEqualTo(FamilyRole.OWNER);
+        assertThat(info.getFamilyId()).isEqualTo(100L);
+        assertThat(info.getSubId()).isEqualTo(10L);
+    }
+
+    @Test
+    @DisplayName("멤버 상세 정보 조회 실패: 존재하지 않는 회원")
+    void findDetailByIdNotFound() {
+        // given
+        Long memberId = 999L;
+        given(memberJpaRepository.findDetailQueryResult(memberId)).willReturn(Optional.empty());
+
+        // when
+        Optional<MemberDetailInfo> result = memberRepository.findDetailById(memberId);
+
+        // then
+        assertThat(result).isEmpty();
     }
 
     @Test

--- a/src/test/java/hotspot/user/member/infrastructure/MemberRepositoryImplTest.java
+++ b/src/test/java/hotspot/user/member/infrastructure/MemberRepositoryImplTest.java
@@ -71,26 +71,27 @@ class MemberRepositoryImplTest {
     void findDetailByIdSuccess() {
         // given
         Long memberId = 1L;
+        String email = "test@email.com";
         MemberEntity entity = MemberEntity.builder().id(memberId).name("홍길동").status(Status.APPROVED).build();
         MemberDetailInfoDto dto = MemberDetailInfoDto.builder()
                 .memberEntity(entity)
-                .email("test@email.com")
+                .email(email)
                 .phone("010-1234-5678")
                 .subId(10L)
                 .role(FamilyRole.OWNER)
                 .familyId(100L)
                 .build();
 
-        given(memberJpaRepository.findDetailQueryResult(memberId)).willReturn(Optional.of(dto));
+        given(memberJpaRepository.findDetailQueryResult(memberId, email)).willReturn(Optional.of(dto));
 
         // when
-        Optional<MemberDetailInfo> result = memberRepository.findDetailById(memberId);
+        Optional<MemberDetailInfo> result = memberRepository.findDetailByIdAndEmail(memberId, email);
 
         // then
         assertThat(result).isPresent();
         MemberDetailInfo info = result.get();
         assertThat(info.getMember().getId()).isEqualTo(memberId);
-        assertThat(info.getEmail()).isEqualTo("test@email.com");
+        assertThat(info.getEmail()).isEqualTo(email);
         assertThat(info.getPhone()).isEqualTo("010-1234-5678");
         assertThat(info.getRole()).isEqualTo(FamilyRole.OWNER);
         assertThat(info.getFamilyId()).isEqualTo(100L);
@@ -102,10 +103,11 @@ class MemberRepositoryImplTest {
     void findDetailByIdNotFound() {
         // given
         Long memberId = 999L;
-        given(memberJpaRepository.findDetailQueryResult(memberId)).willReturn(Optional.empty());
+        String email = "notfound@email.com";
+        given(memberJpaRepository.findDetailQueryResult(memberId, email)).willReturn(Optional.empty());
 
         // when
-        Optional<MemberDetailInfo> result = memberRepository.findDetailById(memberId);
+        Optional<MemberDetailInfo> result = memberRepository.findDetailByIdAndEmail(memberId, email);
 
         // then
         assertThat(result).isEmpty();

--- a/src/test/java/hotspot/user/member/service/FindMemberServiceImplTest.java
+++ b/src/test/java/hotspot/user/member/service/FindMemberServiceImplTest.java
@@ -39,6 +39,7 @@ class FindMemberServiceImplTest {
     void findByIdSuccessAllInfo() {
         // given
         Long memberId = 1L;
+        String email = "test@email.com";
         Long subId = 10L;
 
         Member member = Member.builder()
@@ -49,21 +50,21 @@ class FindMemberServiceImplTest {
 
         MemberDetailInfo detailInfo = MemberDetailInfo.builder()
                 .member(member)
-                .email("test@email.com")
+                .email(email)
                 .phone("010-1234-5678")
                 .subId(subId)
                 .role(FamilyRole.PARENT)
                 .familyId(100L)
                 .build();
 
-        given(memberRepository.findDetailById(memberId)).willReturn(Optional.of(detailInfo));
+        given(memberRepository.findDetailByIdAndEmail(memberId, email)).willReturn(Optional.of(detailInfo));
 
         // when
-        MemberResponse response = findMemberService.findById(memberId);
+        MemberResponse response = findMemberService.findById(memberId, email);
 
         // then
         assertThat(response.id()).isEqualTo(memberId);
-        assertThat(response.email()).isEqualTo("test@email.com");
+        assertThat(response.email()).isEqualTo(email);
         assertThat(response.phone()).isEqualTo("010-1234-5678");
         assertThat(response.familyRole()).isEqualTo(FamilyRole.PARENT);
         assertThat(response.familyId()).isEqualTo(100L);
@@ -75,10 +76,11 @@ class FindMemberServiceImplTest {
     void findByIdFailMemberNotFound() {
         // given
         Long memberId = 999L;
-        given(memberRepository.findDetailById(memberId)).willReturn(Optional.empty());
+        String email = "notfound@email.com";
+        given(memberRepository.findDetailByIdAndEmail(memberId, email)).willReturn(Optional.empty());
 
         // when & then
-        assertThatThrownBy(() -> findMemberService.findById(memberId))
+        assertThatThrownBy(() -> findMemberService.findById(memberId, email))
                 .isInstanceOf(ApplicationException.class)
                 .hasMessage(MemberErrorCode.MEMBER_NOT_FOUND.getMessage());
     }

--- a/src/test/java/hotspot/user/member/service/FindMemberServiceImplTest.java
+++ b/src/test/java/hotspot/user/member/service/FindMemberServiceImplTest.java
@@ -60,7 +60,7 @@ class FindMemberServiceImplTest {
         given(memberRepository.findDetailByIdAndEmail(memberId, email)).willReturn(Optional.of(detailInfo));
 
         // when
-        MemberResponse response = findMemberService.findById(memberId, email);
+        MemberResponse response = findMemberService.findByIdAndEmail(memberId, email);
 
         // then
         assertThat(response.id()).isEqualTo(memberId);
@@ -80,7 +80,7 @@ class FindMemberServiceImplTest {
         given(memberRepository.findDetailByIdAndEmail(memberId, email)).willReturn(Optional.empty());
 
         // when & then
-        assertThatThrownBy(() -> findMemberService.findById(memberId, email))
+        assertThatThrownBy(() -> findMemberService.findByIdAndEmail(memberId, email))
                 .isInstanceOf(ApplicationException.class)
                 .hasMessage(MemberErrorCode.MEMBER_NOT_FOUND.getMessage());
     }

--- a/src/test/java/hotspot/user/member/service/FindMemberServiceImplTest.java
+++ b/src/test/java/hotspot/user/member/service/FindMemberServiceImplTest.java
@@ -15,17 +15,12 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import hotspot.user.common.exception.ApplicationException;
 import hotspot.user.common.exception.code.MemberErrorCode;
-import hotspot.user.family.domain.FamilySubscription;
-import hotspot.user.family.service.port.FamilySubscriptionRepository;
 import hotspot.user.member.controller.response.MemberResponse;
 import hotspot.user.member.domain.FamilyRole;
 import hotspot.user.member.domain.Member;
-import hotspot.user.member.domain.SocialAccount;
+import hotspot.user.member.domain.MemberDetailInfo;
 import hotspot.user.member.domain.Status;
 import hotspot.user.member.service.port.MemberRepository;
-import hotspot.user.member.service.port.SocialAccountRepository;
-import hotspot.user.subscription.domain.Subscription;
-import hotspot.user.subscription.service.port.SubscriptionRepository;
 
 /**
  * 회원 조회 서비스 단위 테스트
@@ -35,12 +30,6 @@ class FindMemberServiceImplTest {
 
     @Mock
     private MemberRepository memberRepository;
-    @Mock
-    private SocialAccountRepository socialAccountRepository;
-    @Mock
-    private SubscriptionRepository subscriptionRepository;
-    @Mock
-    private FamilySubscriptionRepository familySubscriptionRepository;
 
     @InjectMocks
     private FindMemberServiceImpl findMemberService;
@@ -55,26 +44,19 @@ class FindMemberServiceImplTest {
         Member member = Member.builder()
                 .id(memberId)
                 .name("홍길동")
-                .status(Status.APPROVED).build();
+                .status(Status.APPROVED)
+                .build();
 
-        SocialAccount socialAccount = SocialAccount.builder()
+        MemberDetailInfo detailInfo = MemberDetailInfo.builder()
+                .member(member)
                 .email("test@email.com")
+                .phone("010-1234-5678")
+                .subId(subId)
+                .role(FamilyRole.PARENT)
+                .familyId(100L)
                 .build();
 
-        Subscription subscription = Subscription
-                .builder()
-                .id(subId)
-                .phoneEnc("010-1234-5678")
-                .build();
-
-        FamilySubscription familySubscription = FamilySubscription.builder()
-                .familyRole(FamilyRole.PARENT)
-                .build();
-
-        given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
-        given(socialAccountRepository.findByMemberId(memberId)).willReturn(Optional.of(socialAccount));
-        given(subscriptionRepository.findByMemberId(memberId)).willReturn(Optional.of(subscription));
-        given(familySubscriptionRepository.findBySubId(subId)).willReturn(Optional.of(familySubscription));
+        given(memberRepository.findDetailById(memberId)).willReturn(Optional.of(detailInfo));
 
         // when
         MemberResponse response = findMemberService.findById(memberId);
@@ -84,6 +66,8 @@ class FindMemberServiceImplTest {
         assertThat(response.email()).isEqualTo("test@email.com");
         assertThat(response.phone()).isEqualTo("010-1234-5678");
         assertThat(response.familyRole()).isEqualTo(FamilyRole.PARENT);
+        assertThat(response.familyId()).isEqualTo(100L);
+        assertThat(response.subId()).isEqualTo(subId);
     }
 
     @Test
@@ -91,7 +75,7 @@ class FindMemberServiceImplTest {
     void findByIdFailMemberNotFound() {
         // given
         Long memberId = 999L;
-        given(memberRepository.findById(memberId)).willReturn(Optional.empty());
+        given(memberRepository.findDetailById(memberId)).willReturn(Optional.empty());
 
         // when & then
         assertThatThrownBy(() -> findMemberService.findById(memberId))


### PR DESCRIPTION
## 🎫 지라 티켓

<!-- 지라 티켓을 작성해주세요 ex) HOTSPOT-123 -->
HOTSPOT-143

---

## 🔗 GitHub 이슈
<!-- 자동 close를 원하면 아래 형식으로 작성
예) Closes #12
-->
Closes #35 

---


## ✅ 작업 사항

<!-- 작업한 부분을 설명해주세요. -->
로그인한 사용자의 상세 정보 조회 API 구현 `GET /api/v1/members/me`
=> 원래 구성원의 id를 넘겨서 구성원의 상세 정보 조회로 하려고 했는데 사용자 입장에서 다른 구성원 한 명의 정보를 조회할 일은 없음
=> 가족 전체 구성원의 정보를 조회할 때 포함되므로 일단 '나'의 상세 정보 조회로 구현함

상세 정보
- 이름
- 이메일
- 전화번호
- 가족 내 역할
- 가족 id
- 회선 id

-> 여러 테이블을 참조해서 LEFT JOIN 하는 거라서 전용 Entity가 없음
-> 따라서, Entity에서만 사용할 MemberDetailInfoDto를 만들어서 Entity에서 직접 리턴하도록 한다.
-> 도메인도 없기 때문에 MemberDetailInfo라는 걸 만들어 Entity Domain -> domain으로 변환한다.


---

## 📋 체크리스트

<!-- PR 제출 전 확인해주세요. 해당 항목에 [x]로 체크해주세요. -->

- [x] 코드가 정상적으로 빌드됩니다.
- [x] 관련 테스트 코드를 작성했습니다.
- [x] 기존 테스트가 모두 통과합니다.
- [x] 코드 스타일(Spotless, Checkstyle)을 준수합니다.
- [x] Jira 티켓 상태를 In Review / Done으로 변경했습니다.

---

## ⌨ 기타
