### PR TITLE
[HOTPOST-144] 가족 정보 조회 API 구현

### DIFF
--- a/src/main/java/hotspot/user/family/controller/FamilyController.java
+++ b/src/main/java/hotspot/user/family/controller/FamilyController.java
@@ -18,7 +18,7 @@ import lombok.RequiredArgsConstructor;
  */
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/families/")
+@RequestMapping("/api/v1/families")
 public class FamilyController implements FamilyApi {
 
     private final FindFamilyInfoService findFamilyInfoService;
@@ -29,8 +29,6 @@ public class FamilyController implements FamilyApi {
             @AuthenticationPrincipal PrincipalDetails principal) {
 
         FamilyInfoResponse response = findFamilyInfoService.findFamilyInfoById(principal.getFamilyId());
-        return ResponseEntity.ok(
-                ApiResponse.success(response));
-
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 }

--- a/src/main/java/hotspot/user/family/controller/FamilyController.java
+++ b/src/main/java/hotspot/user/family/controller/FamilyController.java
@@ -2,6 +2,7 @@ package hotspot.user.family.controller;
 
 import hotspot.user.common.ApiResponse;
 import hotspot.user.common.security.PrincipalDetails;
+import hotspot.user.family.controller.port.FindFamilyInfoService;
 import hotspot.user.family.controller.response.FamilyInfoResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -18,10 +19,15 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1/families/")
 public class FamilyController {
 
+    private final FindFamilyInfoService findFamilyInfoService;
+
     @GetMapping
     public ResponseEntity<ApiResponse<FamilyInfoResponse>> getFamilyInfo(
             @AuthenticationPrincipal PrincipalDetails principal) {
-            return null;
+
+        FamilyInfoResponse response = findFamilyInfoService.findFamilyInfoById(principal.getFamilyId());
+        return ResponseEntity.ok(
+                ApiResponse.success(response));
 
     }
 }

--- a/src/main/java/hotspot/user/family/controller/FamilyController.java
+++ b/src/main/java/hotspot/user/family/controller/FamilyController.java
@@ -1,0 +1,27 @@
+package hotspot.user.family.controller;
+
+import hotspot.user.common.ApiResponse;
+import hotspot.user.common.security.PrincipalDetails;
+import hotspot.user.family.controller.response.FamilyInfoResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Family 관련 컨트롤러
+ */
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/families/")
+public class FamilyController {
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<FamilyInfoResponse>> getFamilyInfo(
+            @AuthenticationPrincipal PrincipalDetails principal) {
+            return null;
+
+    }
+}

--- a/src/main/java/hotspot/user/family/controller/FamilyController.java
+++ b/src/main/java/hotspot/user/family/controller/FamilyController.java
@@ -4,6 +4,7 @@ import hotspot.user.common.ApiResponse;
 import hotspot.user.common.security.PrincipalDetails;
 import hotspot.user.family.controller.port.FindFamilyInfoService;
 import hotspot.user.family.controller.response.FamilyInfoResponse;
+import hotspot.user.family.controller.swagger.FamilyApi;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -17,10 +18,11 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/families/")
-public class FamilyController {
+public class FamilyController implements FamilyApi {
 
     private final FindFamilyInfoService findFamilyInfoService;
 
+    @Override
     @GetMapping
     public ResponseEntity<ApiResponse<FamilyInfoResponse>> getFamilyInfo(
             @AuthenticationPrincipal PrincipalDetails principal) {

--- a/src/main/java/hotspot/user/family/controller/FamilyController.java
+++ b/src/main/java/hotspot/user/family/controller/FamilyController.java
@@ -1,16 +1,17 @@
 package hotspot.user.family.controller;
 
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
 import hotspot.user.common.ApiResponse;
 import hotspot.user.common.security.PrincipalDetails;
 import hotspot.user.family.controller.port.FindFamilyInfoService;
 import hotspot.user.family.controller.response.FamilyInfoResponse;
 import hotspot.user.family.controller.swagger.FamilyApi;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
 
 /**
  * Family 관련 컨트롤러

--- a/src/main/java/hotspot/user/family/controller/port/FindFamilyInfoService.java
+++ b/src/main/java/hotspot/user/family/controller/port/FindFamilyInfoService.java
@@ -1,8 +1,7 @@
 package hotspot.user.family.controller.port;
 
-import hotspot.user.family.controller.response.FamilyInfoResponse;
 
-import java.util.Optional;
+import hotspot.user.family.controller.response.FamilyInfoResponse;
 
 /**
  * 가족 정보 및 전체 구성원 정보 조회 서비스

--- a/src/main/java/hotspot/user/family/controller/port/FindFamilyInfoService.java
+++ b/src/main/java/hotspot/user/family/controller/port/FindFamilyInfoService.java
@@ -1,0 +1,12 @@
+package hotspot.user.family.controller.port;
+
+import hotspot.user.family.controller.response.FamilyInfoResponse;
+
+import java.util.Optional;
+
+/**
+ * 가족 정보 및 전체 구성원 정보 조회 서비스
+ */
+public interface FindFamilyInfoService {
+    FamilyInfoResponse findFamilyInfoById(Long id);
+}

--- a/src/main/java/hotspot/user/family/controller/response/FamilyInfoResponse.java
+++ b/src/main/java/hotspot/user/family/controller/response/FamilyInfoResponse.java
@@ -1,9 +1,9 @@
 package hotspot.user.family.controller.response;
 
+import java.util.List;
+
 import hotspot.user.member.controller.response.MemberResponse;
 import lombok.Builder;
-
-import java.util.List;
 
 /**
  * 가족 정보 조회 응답 Dto

--- a/src/main/java/hotspot/user/family/controller/response/FamilyInfoResponse.java
+++ b/src/main/java/hotspot/user/family/controller/response/FamilyInfoResponse.java
@@ -1,16 +1,17 @@
 package hotspot.user.family.controller.response;
 
 import hotspot.user.member.controller.response.MemberResponse;
+import lombok.Builder;
 
 import java.util.List;
 
 /**
  * 가족 정보 조회 응답 Dto
  */
+@Builder
 public record FamilyInfoResponse(
         Long familyId,
         int familyNum,
-        int familyDataAmount,
         List<MemberResponse> memberInfoList
 ) {
 }

--- a/src/main/java/hotspot/user/family/controller/response/FamilyInfoResponse.java
+++ b/src/main/java/hotspot/user/family/controller/response/FamilyInfoResponse.java
@@ -1,0 +1,16 @@
+package hotspot.user.family.controller.response;
+
+import hotspot.user.member.controller.response.MemberResponse;
+
+import java.util.List;
+
+/**
+ * 가족 정보 조회 응답 Dto
+ */
+public record FamilyInfoResponse(
+        Long familyId,
+        int familyNum,
+        int familyDataAmount,
+        List<MemberResponse> memberInfoList
+) {
+}

--- a/src/main/java/hotspot/user/family/controller/swagger/FamilyApi.java
+++ b/src/main/java/hotspot/user/family/controller/swagger/FamilyApi.java
@@ -1,0 +1,28 @@
+package hotspot.user.family.controller.swagger;
+
+import hotspot.user.common.ApiResponse;
+import hotspot.user.common.exception.ErrorResponse;
+import hotspot.user.common.security.PrincipalDetails;
+import hotspot.user.family.controller.response.FamilyInfoResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+@Tag(name = "Family", description = "가족 정보 관리 API")
+public interface FamilyApi {
+
+    @Operation(summary = "가족 및 전체 구성원 정보 조회", description = "현재 로그인한 사용자가 속한 가족의 정보와 모든 구성원의 상세 정보를 조회합니다.")
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "가족 정보를 찾을 수 없음",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    ResponseEntity<ApiResponse<FamilyInfoResponse>> getFamilyInfo(
+            @Parameter(hidden = true) @AuthenticationPrincipal PrincipalDetails principal
+    );
+}

--- a/src/main/java/hotspot/user/family/controller/swagger/FamilyApi.java
+++ b/src/main/java/hotspot/user/family/controller/swagger/FamilyApi.java
@@ -1,5 +1,8 @@
 package hotspot.user.family.controller.swagger;
 
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
 import hotspot.user.common.ApiResponse;
 import hotspot.user.common.exception.ErrorResponse;
 import hotspot.user.common.security.PrincipalDetails;
@@ -10,8 +13,6 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 
 @Tag(name = "Family", description = "가족 정보 관리 API")
 public interface FamilyApi {

--- a/src/main/java/hotspot/user/family/domain/FamilyDetailInfo.java
+++ b/src/main/java/hotspot/user/family/domain/FamilyDetailInfo.java
@@ -1,10 +1,10 @@
 package hotspot.user.family.domain;
 
+import java.util.List;
+
 import hotspot.user.member.domain.MemberDetailInfo;
 import lombok.Builder;
 import lombok.Getter;
-
-import java.util.List;
 
 /**
  * 가족 전체 상세 정보를 담는 통합 도메인 모델 (Read Model)

--- a/src/main/java/hotspot/user/family/domain/FamilyDetailInfo.java
+++ b/src/main/java/hotspot/user/family/domain/FamilyDetailInfo.java
@@ -1,0 +1,18 @@
+package hotspot.user.family.domain;
+
+import hotspot.user.member.domain.MemberDetailInfo;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+/**
+ * 가족 전체 상세 정보를 담는 통합 도메인 모델 (Read Model)
+ */
+@Getter
+@Builder
+public class FamilyDetailInfo {
+    private final Long familyId;
+    private final int familyNum;
+    private final List<MemberDetailInfo> memberDetailInfoList;
+}

--- a/src/main/java/hotspot/user/family/domain/mapper/FamilyMapper.java
+++ b/src/main/java/hotspot/user/family/domain/mapper/FamilyMapper.java
@@ -2,11 +2,14 @@ package hotspot.user.family.domain.mapper;
 
 import java.util.List;
 
+import hotspot.user.family.controller.response.FamilyInfoResponse;
 import hotspot.user.family.controller.response.FamilyResponse;
 import hotspot.user.family.controller.response.MemberPriorityResponse;
 import hotspot.user.family.controller.response.UpdateFamilyPriorityResponse;
 import hotspot.user.family.domain.Family;
+import hotspot.user.family.domain.FamilyDetailInfo;
 import hotspot.user.family.domain.FamilySubscription;
+import hotspot.user.member.domain.mapper.MemberMapper;
 
 /**
  * request Dto -> 도메인
@@ -41,5 +44,15 @@ public class FamilyMapper {
                         .priority(sub.getPriority())
                         .build())
                 .toList();
+    }
+
+    public static FamilyInfoResponse toFamilyInfoResponse(FamilyDetailInfo detailInfo) {
+        return FamilyInfoResponse.builder()
+                .familyId(detailInfo.getFamilyId())
+                .familyNum(detailInfo.getFamilyNum())
+                .memberInfoList(detailInfo.getMemberDetailInfoList().stream()
+                        .map(MemberMapper::toMemberResponse)
+                        .toList())
+                .build();
     }
 }

--- a/src/main/java/hotspot/user/family/infrastructure/FamilyJpaRepository.java
+++ b/src/main/java/hotspot/user/family/infrastructure/FamilyJpaRepository.java
@@ -1,6 +1,7 @@
 package hotspot.user.family.infrastructure;
 
 import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;

--- a/src/main/java/hotspot/user/family/infrastructure/FamilyJpaRepository.java
+++ b/src/main/java/hotspot/user/family/infrastructure/FamilyJpaRepository.java
@@ -1,11 +1,29 @@
 package hotspot.user.family.infrastructure;
 
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import hotspot.user.family.infrastructure.entity.FamilyDetailInfoDto;
 import hotspot.user.family.infrastructure.entity.FamilyEntity;
 
 /**
  * 가족 DB에 실제로 저장하는 JpaRepository
  */
 public interface FamilyJpaRepository extends JpaRepository<FamilyEntity, Long> {
+
+    @Query("""
+           SELECT DISTINCT new hotspot.user.family.infrastructure.entity.FamilyDetailInfoDto(
+               f, m, sa.email, s.phoneEnc, s.subId, fs.familyRole
+           )
+           FROM FamilyEntity f
+           JOIN FamilySubscriptionEntity fs ON fs.family = f
+           JOIN SubscriptionEntity s ON fs.subscription = s
+           JOIN MemberEntity m ON s.member = m
+           LEFT JOIN SocialAccountEntity sa ON sa.member = m
+           WHERE f.familyId = :familyId
+           """)
+    List<FamilyDetailInfoDto> findFamilyDetailQueryResult(
+            @Param("familyId") Long familyId);
 }

--- a/src/main/java/hotspot/user/family/infrastructure/FamilyJpaRepository.java
+++ b/src/main/java/hotspot/user/family/infrastructure/FamilyJpaRepository.java
@@ -19,9 +19,9 @@ public interface FamilyJpaRepository extends JpaRepository<FamilyEntity, Long> {
                f, m, sa.email, s.phoneEnc, s.subId, fs.familyRole
            )
            FROM FamilyEntity f
-           JOIN FamilySubscriptionEntity fs ON fs.family = f
-           JOIN SubscriptionEntity s ON fs.subscription = s
-           JOIN MemberEntity m ON s.member = m
+           LEFT JOIN FamilySubscriptionEntity fs ON fs.family = f
+           LEFT JOIN SubscriptionEntity s ON fs.subscription = s
+           LEFT JOIN MemberEntity m ON s.member = m
            LEFT JOIN SocialAccountEntity sa ON sa.member = m
            WHERE f.familyId = :familyId
            """)

--- a/src/main/java/hotspot/user/family/infrastructure/FamilyRepositoryImpl.java
+++ b/src/main/java/hotspot/user/family/infrastructure/FamilyRepositoryImpl.java
@@ -40,17 +40,17 @@ public class FamilyRepositoryImpl implements FamilyRepository {
             return Optional.empty();
         }
 
-        // 2. 첫 번째 행에서 가족 공통 정보 추출 (결과가 1개 이상임은 위에서 보장됨)
-        FamilyDetailInfoDto first = results.get(0);
-        FamilyEntity familyEntity = first.familyEntity();
+        // 2. 첫 번째 행에서 가족 공통 정보 추출
+        FamilyEntity familyEntity = results.get(0).familyEntity();
 
-        // 3. 멤버 데이터 조립 (방어 로직 추가)
+        // 3. 멤버 매핑
+        // [To-Do] 지금은 1대1이라고 생각해서 개발해서 나중에 수정 필요
         List<MemberDetailInfo> members = results.stream()
-                // LEFT JOIN으로 인해 멤버 정보가 null인 빈 행은 무시
+                // LEFT JOIN 방어: 멤버가 없는(0명인) 가족일 경우 이 필터에서 걸러짐
                 .filter(dto -> dto.memberEntity() != null)
                 .map(dto -> MemberDetailInfo.builder()
                         .member(dto.memberEntity().entityToDomain())
-                        .email(dto.email())
+                        .email(dto.email()) // LEFT JOIN이라 null일 수 있음 (소셜 연동 안한 유저)
                         .phone(dto.phone())
                         .subId(dto.subId())
                         .role(dto.role())

--- a/src/main/java/hotspot/user/family/infrastructure/FamilyRepositoryImpl.java
+++ b/src/main/java/hotspot/user/family/infrastructure/FamilyRepositoryImpl.java
@@ -3,14 +3,14 @@ package hotspot.user.family.infrastructure;
 import java.util.List;
 import java.util.Optional;
 
-import hotspot.user.family.domain.FamilyDetailInfo;
-import hotspot.user.family.infrastructure.entity.FamilyDetailInfoDto;
-import hotspot.user.member.domain.MemberDetailInfo;
 import org.springframework.stereotype.Repository;
 
 import hotspot.user.family.domain.Family;
+import hotspot.user.family.domain.FamilyDetailInfo;
+import hotspot.user.family.infrastructure.entity.FamilyDetailInfoDto;
 import hotspot.user.family.infrastructure.entity.FamilyEntity;
 import hotspot.user.family.service.port.FamilyRepository;
+import hotspot.user.member.domain.MemberDetailInfo;
 import lombok.RequiredArgsConstructor;
 
 @Repository

--- a/src/main/java/hotspot/user/family/infrastructure/FamilyRepositoryImpl.java
+++ b/src/main/java/hotspot/user/family/infrastructure/FamilyRepositoryImpl.java
@@ -1,7 +1,11 @@
 package hotspot.user.family.infrastructure;
 
+import java.util.List;
 import java.util.Optional;
 
+import hotspot.user.family.domain.FamilyDetailInfo;
+import hotspot.user.family.infrastructure.entity.FamilyDetailInfoDto;
+import hotspot.user.member.domain.MemberDetailInfo;
 import org.springframework.stereotype.Repository;
 
 import hotspot.user.family.domain.Family;
@@ -25,5 +29,40 @@ public class FamilyRepositoryImpl implements FamilyRepository {
         FamilyEntity entity = FamilyEntity.domainToEntity(family);
         FamilyEntity savedEntity = familyJpaRepository.save(entity);
         return savedEntity.entityToDomain();
+    }
+
+    @Override
+    public Optional<FamilyDetailInfo> findInfoById(Long id) {
+        List<FamilyDetailInfoDto> results = familyJpaRepository.findFamilyDetailQueryResult(id);
+
+        // 1. 해당 ID의 가족 자체가 없는 경우
+        if (results.isEmpty()) {
+            return Optional.empty();
+        }
+
+        // 2. 첫 번째 행에서 가족 공통 정보 추출 (결과가 1개 이상임은 위에서 보장됨)
+        FamilyDetailInfoDto first = results.get(0);
+        FamilyEntity familyEntity = first.familyEntity();
+
+        // 3. 멤버 데이터 조립 (방어 로직 추가)
+        List<MemberDetailInfo> members = results.stream()
+                // LEFT JOIN으로 인해 멤버 정보가 null인 빈 행은 무시
+                .filter(dto -> dto.memberEntity() != null)
+                .map(dto -> MemberDetailInfo.builder()
+                        .member(dto.memberEntity().entityToDomain())
+                        .email(dto.email())
+                        .phone(dto.phone())
+                        .subId(dto.subId())
+                        .role(dto.role())
+                        .familyId(familyEntity.getFamilyId())
+                        .build())
+                .toList();
+
+        // 4. 최종 가족 도메인 객체 반환
+        return Optional.of(FamilyDetailInfo.builder()
+                .familyId(familyEntity.getFamilyId())
+                .familyNum(familyEntity.getFamilyNum())
+                .memberDetailInfoList(members)
+                .build());
     }
 }

--- a/src/main/java/hotspot/user/family/infrastructure/entity/FamilyDetailInfoDto.java
+++ b/src/main/java/hotspot/user/family/infrastructure/entity/FamilyDetailInfoDto.java
@@ -1,0 +1,17 @@
+package hotspot.user.family.infrastructure.entity;
+
+import hotspot.user.member.domain.FamilyRole;
+import hotspot.user.member.infrastructure.entity.MemberEntity;
+
+/**
+ * 가족 전체 구성원 조회를 위한 JPA Projection용 DTO (Infrastructure 계층 전용)
+ */
+public record FamilyDetailInfoDto(
+        FamilyEntity familyEntity,
+        MemberEntity memberEntity,
+        String email,
+        String phone,
+        Long subId,
+        FamilyRole role
+) {
+}

--- a/src/main/java/hotspot/user/family/service/FindFamilyInfoServiceImpl.java
+++ b/src/main/java/hotspot/user/family/service/FindFamilyInfoServiceImpl.java
@@ -1,0 +1,34 @@
+package hotspot.user.family.service;
+
+import hotspot.user.common.exception.ApplicationException;
+import hotspot.user.common.exception.code.FamilyErrorCode;
+import hotspot.user.common.exception.code.MemberErrorCode;
+import hotspot.user.family.controller.port.FindFamilyInfoService;
+import hotspot.user.family.controller.response.FamilyInfoResponse;
+import hotspot.user.family.domain.FamilyDetailInfo;
+import hotspot.user.family.domain.mapper.FamilyMapper;
+import hotspot.user.family.service.port.FamilyRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 가족 정보 및 전체 구성원 정보 조회 서비스 구현체
+ */
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class FindFamilyInfoServiceImpl implements FindFamilyInfoService {
+
+    private final FamilyRepository familyRepository;
+
+    @Override
+    public FamilyInfoResponse findFamilyInfoById(Long id) {
+        // 통합 조회
+        FamilyDetailInfo detailInfo = familyRepository.findInfoById(id)
+                .orElseThrow(() -> new ApplicationException(FamilyErrorCode.FAMILY_NOT_FOUND));
+
+        return FamilyMapper.toFamilyInfoResponse(detailInfo);
+    }
+}

--- a/src/main/java/hotspot/user/family/service/FindFamilyInfoServiceImpl.java
+++ b/src/main/java/hotspot/user/family/service/FindFamilyInfoServiceImpl.java
@@ -1,16 +1,16 @@
 package hotspot.user.family.service;
 
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import hotspot.user.common.exception.ApplicationException;
 import hotspot.user.common.exception.code.FamilyErrorCode;
-import hotspot.user.common.exception.code.MemberErrorCode;
 import hotspot.user.family.controller.port.FindFamilyInfoService;
 import hotspot.user.family.controller.response.FamilyInfoResponse;
 import hotspot.user.family.domain.FamilyDetailInfo;
 import hotspot.user.family.domain.mapper.FamilyMapper;
 import hotspot.user.family.service.port.FamilyRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 /**
  * 가족 정보 및 전체 구성원 정보 조회 서비스 구현체

--- a/src/main/java/hotspot/user/family/service/port/FamilyRepository.java
+++ b/src/main/java/hotspot/user/family/service/port/FamilyRepository.java
@@ -3,6 +3,7 @@ package hotspot.user.family.service.port;
 import java.util.Optional;
 
 import hotspot.user.family.domain.Family;
+import hotspot.user.family.domain.FamilyDetailInfo;
 
 /**
  * 가족 도메인에 저장하는 Repository
@@ -10,4 +11,5 @@ import hotspot.user.family.domain.Family;
 public interface FamilyRepository {
     Optional<Family> findById(Long id);
     Family save(Family family);
+    Optional<FamilyDetailInfo> findInfoById(Long id);
 }

--- a/src/test/java/hotspot/user/family/controller/FamilyControllerTest.java
+++ b/src/test/java/hotspot/user/family/controller/FamilyControllerTest.java
@@ -7,6 +7,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import java.util.List;
 
+import hotspot.user.member.controller.response.MemberResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -70,7 +71,7 @@ class FamilyControllerTest {
         Long familyId = 100L;
         setAuthentication(familyId);
 
-        hotspot.user.member.controller.response.MemberResponse member1 = hotspot.user.member.controller.response.MemberResponse.builder()
+        MemberResponse member1 = MemberResponse.builder()
                 .id(1L)
                 .name("홍길동")
                 .email("test@test.com")
@@ -80,7 +81,7 @@ class FamilyControllerTest {
                 .status(Status.APPROVED)
                 .build();
 
-        hotspot.user.member.controller.response.MemberResponse member2 = hotspot.user.member.controller.response.MemberResponse.builder()
+        MemberResponse member2 = MemberResponse.builder()
                 .id(2L)
                 .name("김철수")
                 .email("chulsoo@test.com")

--- a/src/test/java/hotspot/user/family/controller/FamilyControllerTest.java
+++ b/src/test/java/hotspot/user/family/controller/FamilyControllerTest.java
@@ -1,0 +1,115 @@
+package hotspot.user.family.controller;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.web.servlet.MockMvc;
+
+import hotspot.user.common.security.PrincipalDetails;
+import hotspot.user.common.security.jwt.JwtFilter;
+import hotspot.user.common.security.jwt.JwtProvider;
+import hotspot.user.family.controller.port.FindFamilyInfoService;
+import hotspot.user.family.controller.response.FamilyInfoResponse;
+import hotspot.user.member.domain.FamilyRole;
+import hotspot.user.member.domain.Status;
+
+/**
+ * Family Controller 단위 테스트
+ */
+@WebMvcTest(FamilyController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class FamilyControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private FindFamilyInfoService findFamilyInfoService;
+
+    @MockBean
+    private JwtFilter jwtFilter;
+
+    @MockBean
+    private JwtProvider jwtProvider;
+
+    @MockBean
+    private JpaMetamodelMappingContext jpaMetamodelMappingContext;
+
+    private void setAuthentication(Long familyId) {
+        PrincipalDetails principal = PrincipalDetails.builder()
+                .id(1L)
+                .email("test@test.com")
+                .familyId(familyId)
+                .role(FamilyRole.OWNER)
+                .status(Status.APPROVED)
+                .build();
+
+        UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(
+                principal, null, principal.getAuthorities());
+        SecurityContextHolder.getContext().setAuthentication(auth);
+    }
+
+    @Test
+    @DisplayName("성공: 가족 정보 조회 API 호출 시 200 OK와 가족 구성원 정보를 반환한다")
+    void getFamilyInfoSuccess() throws Exception {
+        // given
+        Long familyId = 100L;
+        setAuthentication(familyId);
+
+        hotspot.user.member.controller.response.MemberResponse member1 = hotspot.user.member.controller.response.MemberResponse.builder()
+                .id(1L)
+                .name("홍길동")
+                .email("test@test.com")
+                .familyRole(FamilyRole.OWNER)
+                .familyId(familyId)
+                .subId(10L)
+                .status(Status.APPROVED)
+                .build();
+
+        hotspot.user.member.controller.response.MemberResponse member2 = hotspot.user.member.controller.response.MemberResponse.builder()
+                .id(2L)
+                .name("김철수")
+                .email("chulsoo@test.com")
+                .familyRole(FamilyRole.CHILD)
+                .familyId(familyId)
+                .subId(11L)
+                .status(Status.APPROVED)
+                .build();
+
+        FamilyInfoResponse response = FamilyInfoResponse.builder()
+                .familyId(familyId)
+                .familyNum(2)
+                .memberInfoList(List.of(member1, member2))
+                .build();
+
+        given(findFamilyInfoService.findFamilyInfoById(familyId)).willReturn(response);
+
+        // when & then
+        mockMvc.perform(get("/api/v1/families")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("200"))
+                .andExpect(jsonPath("$.data.familyId").value(familyId))
+                .andExpect(jsonPath("$.data.familyNum").value(2))
+                .andExpect(jsonPath("$.data.memberInfoList[0].id").value(1L))
+                .andExpect(jsonPath("$.data.memberInfoList[0].name").value("홍길동"))
+                .andExpect(jsonPath("$.data.memberInfoList[0].familyRole").value("OWNER"))
+                .andExpect(jsonPath("$.data.memberInfoList[1].id").value(2L))
+                .andExpect(jsonPath("$.data.memberInfoList[1].name").value("김철수"))
+                .andExpect(jsonPath("$.data.memberInfoList[1].familyRole").value("CHILD"));
+    }
+}

--- a/src/test/java/hotspot/user/family/controller/FamilyControllerTest.java
+++ b/src/test/java/hotspot/user/family/controller/FamilyControllerTest.java
@@ -7,7 +7,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import java.util.List;
 
-import hotspot.user.member.controller.response.MemberResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -25,6 +24,7 @@ import hotspot.user.common.security.jwt.JwtFilter;
 import hotspot.user.common.security.jwt.JwtProvider;
 import hotspot.user.family.controller.port.FindFamilyInfoService;
 import hotspot.user.family.controller.response.FamilyInfoResponse;
+import hotspot.user.member.controller.response.MemberResponse;
 import hotspot.user.member.domain.FamilyRole;
 import hotspot.user.member.domain.Status;
 

--- a/src/test/java/hotspot/user/family/infrastructure/FamilyRepositoryImplTest.java
+++ b/src/test/java/hotspot/user/family/infrastructure/FamilyRepositoryImplTest.java
@@ -3,8 +3,14 @@ package hotspot.user.family.infrastructure;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 
+import java.util.List;
 import java.util.Optional;
 
+import hotspot.user.family.domain.FamilyDetailInfo;
+import hotspot.user.family.infrastructure.entity.FamilyDetailInfoDto;
+import hotspot.user.member.domain.FamilyRole;
+import hotspot.user.member.domain.Status;
+import hotspot.user.member.infrastructure.entity.MemberEntity;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -74,5 +80,59 @@ class FamilyRepositoryImplTest {
         // then
         assertThat(result.getId()).isEqualTo(1L);
         assertThat(result.getPriorityType()).isEqualTo(PriorityType.PRIORITY);
+    }
+
+    @Test
+    @DisplayName("가족 상세 정보 통합 조회 성공")
+    void findInfoByIdSuccess() {
+        // given
+        Long familyId = 1L;
+        FamilyEntity familyEntity = FamilyEntity.builder()
+                .familyId(familyId)
+                .familyNum(2)
+                .familyDataAmount(5000)
+                .build();
+
+        MemberEntity memberEntity = MemberEntity.builder()
+                .id(10L)
+                .name("멤버1")
+                .status(Status.APPROVED)
+                .build();
+
+        FamilyDetailInfoDto dto = new FamilyDetailInfoDto(
+                familyEntity,
+                memberEntity,
+                "test@email.com",
+                "010-1111-2222",
+                100L,
+                FamilyRole.OWNER
+        );
+
+        given(familyJpaRepository.findFamilyDetailQueryResult(familyId)).willReturn(List.of(dto));
+
+        // when
+        Optional<FamilyDetailInfo> result = familyRepository.findInfoById(familyId);
+
+        // then
+        assertThat(result).isPresent();
+        FamilyDetailInfo info = result.get();
+        assertThat(info.getFamilyId()).isEqualTo(familyId);
+        assertThat(info.getFamilyNum()).isEqualTo(2);
+        assertThat(info.getMemberDetailInfoList()).hasSize(1);
+        assertThat(info.getMemberDetailInfoList().get(0).getEmail()).isEqualTo("test@email.com");
+    }
+
+    @Test
+    @DisplayName("가족 상세 정보 조회 실패: 결과가 없는 경우")
+    void findInfoByIdNotFound() {
+        // given
+        Long familyId = 999L;
+        given(familyJpaRepository.findFamilyDetailQueryResult(familyId)).willReturn(List.of());
+
+        // when
+        Optional<FamilyDetailInfo> result = familyRepository.findInfoById(familyId);
+
+        // then
+        assertThat(result).isEmpty();
     }
 }

--- a/src/test/java/hotspot/user/family/infrastructure/FamilyRepositoryImplTest.java
+++ b/src/test/java/hotspot/user/family/infrastructure/FamilyRepositoryImplTest.java
@@ -6,11 +6,6 @@ import static org.mockito.BDDMockito.given;
 import java.util.List;
 import java.util.Optional;
 
-import hotspot.user.family.domain.FamilyDetailInfo;
-import hotspot.user.family.infrastructure.entity.FamilyDetailInfoDto;
-import hotspot.user.member.domain.FamilyRole;
-import hotspot.user.member.domain.Status;
-import hotspot.user.member.infrastructure.entity.MemberEntity;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -20,8 +15,13 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import hotspot.user.family.domain.Family;
+import hotspot.user.family.domain.FamilyDetailInfo;
 import hotspot.user.family.domain.PriorityType;
+import hotspot.user.family.infrastructure.entity.FamilyDetailInfoDto;
 import hotspot.user.family.infrastructure.entity.FamilyEntity;
+import hotspot.user.member.domain.FamilyRole;
+import hotspot.user.member.domain.Status;
+import hotspot.user.member.infrastructure.entity.MemberEntity;
 
 /**
  * 가족 Repository 단위 테스트

--- a/src/test/java/hotspot/user/family/service/FindFamilyInfoServiceImplTest.java
+++ b/src/test/java/hotspot/user/family/service/FindFamilyInfoServiceImplTest.java
@@ -1,0 +1,76 @@
+package hotspot.user.family.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import hotspot.user.common.exception.ApplicationException;
+import hotspot.user.common.exception.code.FamilyErrorCode;
+import hotspot.user.family.controller.response.FamilyInfoResponse;
+import hotspot.user.family.domain.FamilyDetailInfo;
+import hotspot.user.family.service.port.FamilyRepository;
+import hotspot.user.member.domain.Member;
+import hotspot.user.member.domain.MemberDetailInfo;
+import hotspot.user.member.domain.Status;
+
+@ExtendWith(MockitoExtension.class)
+class FindFamilyInfoServiceImplTest {
+
+    @Mock
+    private FamilyRepository familyRepository;
+
+    @InjectMocks
+    private FindFamilyInfoServiceImpl findFamilyInfoService;
+
+    @Test
+    @DisplayName("성공: 가족 ID로 가족 및 구성원 전체 정보를 조회한다")
+    void findFamilyInfoByIdSuccess() {
+        // given
+        Long familyId = 1L;
+        Member member = Member.builder().id(10L).name("멤버1").status(Status.APPROVED).build();
+        MemberDetailInfo memberInfo = MemberDetailInfo.builder()
+                .member(member)
+                .email("test@test.com")
+                .build();
+
+        FamilyDetailInfo detailInfo = FamilyDetailInfo.builder()
+                .familyId(familyId)
+                .familyNum(1)
+                .memberDetailInfoList(List.of(memberInfo))
+                .build();
+
+        given(familyRepository.findInfoById(familyId)).willReturn(Optional.of(detailInfo));
+
+        // when
+        FamilyInfoResponse response = findFamilyInfoService.findFamilyInfoById(familyId);
+
+        // then
+        assertThat(response.familyId()).isEqualTo(familyId);
+        assertThat(response.familyNum()).isEqualTo(1);
+        assertThat(response.memberInfoList()).hasSize(1);
+        assertThat(response.memberInfoList().get(0).email()).isEqualTo("test@test.com");
+    }
+
+    @Test
+    @DisplayName("실패: 존재하지 않는 가족 ID로 조회 시 예외가 발생한다")
+    void findFamilyInfoByIdFail() {
+        // given
+        Long familyId = 999L;
+        given(familyRepository.findInfoById(familyId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> findFamilyInfoService.findFamilyInfoById(familyId))
+                .isInstanceOf(ApplicationException.class)
+                .hasMessage(FamilyErrorCode.FAMILY_NOT_FOUND.getMessage());
+    }
+}


### PR DESCRIPTION
## 🎫 지라 티켓

<!-- 지라 티켓을 작성해주세요 ex) HOTSPOT-123 -->
HOTSPOT-144

---

## 🔗 GitHub 이슈
<!-- 자동 close를 원하면 아래 형식으로 작성
예) Closes #12
-->
Closes #41 

---


## ✅ 작업 사항

<!-- 작업한 부분을 설명해주세요. -->

가족 구성원의 상세 정보 조회 API 구현

응답
- 가족 ID
- 가족 명수
- [구성원 정보]
- ...

---
  

1. Controller
   - `FamilyController`: `GET /api/v1/families` 엔드포인트를 구현해 사용자 소속 가족의 통합 정보를 반환

<br/>

2. Service
   - `FindFamilyInfoService` & `ServiceImpl`: 가족 정보 조회 비즈니스 로직을 구현
   - `FamilyMapper`: 조회 전용 도메인(FamilyDetailInfo)을 API 응답 DTO(FamilyInfoResponse)로 변환하는 매퍼를 추가

<br/>

3. Repository
   - `FamilyJpaRepository`: Family, FamilySubscription, Member, SocialAccount 등 4개 이상의 테이블을 LEFT JOIN하여 단 1회의 쿼리로 모든 정보를 긁어오는 통합 쿼리를 작성
   - `FamilyDetailInfoDto`: JPA Projection 결과를 타입 안전하게 받기 위한 인프라 계층 전용 DTO를 정의
   - `FamilyRepositoryImpl`: 쿼리 결과인 평면적인 리스트 데이터를 그룹화(Grouping)하여 계층 구조를 가진 도메인 모델로 조립하는 로직 구현

---

## 📋 체크리스트

<!-- PR 제출 전 확인해주세요. 해당 항목에 [x]로 체크해주세요. -->

- [x] 코드가 정상적으로 빌드됩니다.
- [x] 관련 테스트 코드를 작성했습니다.
- [x] 기존 테스트가 모두 통과합니다.
- [x] 코드 스타일(Spotless, Checkstyle)을 준수합니다.
- [x] Jira 티켓 상태를 In Review / Done으로 변경했습니다.

---

## ⌨ 기타
