### PR TITLE
[HOTSPOT-152] 알림 Kafka Consumer 구현

### DIFF
--- a/src/main/java/hotspot/user/kafka/consumer/UserAlertEventsConsumer.java
+++ b/src/main/java/hotspot/user/kafka/consumer/UserAlertEventsConsumer.java
@@ -1,0 +1,75 @@
+package hotspot.user.kafka.consumer;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import hotspot.user.common.exception.ApplicationException;
+import hotspot.user.common.exception.code.KafkaErrorCode;
+import hotspot.user.family.service.port.FamilySubscriptionRepository;
+import hotspot.user.kafka.dto.UserAlertEvent;
+import hotspot.user.kafka.event.UserAlertNotificationsPersistedEvent;
+import hotspot.user.kafka.mapper.UserAlertEventNotificationMapper;
+import hotspot.user.notification.domain.Notification;
+import hotspot.user.notification.service.port.NotificationRepository;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class UserAlertEventsConsumer {
+
+    private final UserAlertEventNotificationMapper mapper;
+    private final NotificationRepository notificationRepository;
+    private final FamilySubscriptionRepository familySubscriptionRepository;
+    private final ApplicationEventPublisher applicationEventPublisher;
+
+    @Transactional
+    @KafkaListener(
+            topics = "${app.topics.user-alert-events}",
+            containerFactory = "userAlertKafkaListenerContainerFactory"
+    )
+    // 이벤트를 수신해 대상별 저장 후 성공 건만 후속 이벤트로 전달한다.
+    public void consume(UserAlertEvent event, Acknowledgment acknowledgment) {
+        List<Long> targetSubIds = resolveTargetSubIds(event);
+
+        List<Notification> persistedNotifications = new ArrayList<>();
+        for (Long targetSubId : targetSubIds) {
+            Notification notification = mapper.toNotification(event, targetSubId);
+            if (notificationRepository.insertIfAbsent(notification)) {
+                persistedNotifications.add(notification);
+            }
+        }
+
+        if (!persistedNotifications.isEmpty()) {
+            applicationEventPublisher.publishEvent(
+                    new UserAlertNotificationsPersistedEvent(event, persistedNotifications)
+            );
+        }
+
+        acknowledgment.acknowledge();
+    }
+
+    // subId 우선, 없으면 familyId 기준으로 fan-out 대상 subId 목록을 만든다.
+    private List<Long> resolveTargetSubIds(UserAlertEvent event) {
+        if (event.subId() != null) {
+            return List.of(event.subId());
+        }
+
+        Long familyId = event.familyId();
+        if (familyId == null) {
+            throw new ApplicationException(KafkaErrorCode.KAFKA_SUB_ID_REQUIRED);
+        }
+
+        return familySubscriptionRepository.findByFamilyId(familyId).stream()
+                .map(familySubscription -> familySubscription.getSubscription().getId())
+                .filter(Objects::nonNull)
+                .distinct()
+                .toList();
+    }
+}

--- a/src/main/java/hotspot/user/kafka/event/UserAlertNotificationsPersistedEvent.java
+++ b/src/main/java/hotspot/user/kafka/event/UserAlertNotificationsPersistedEvent.java
@@ -1,0 +1,16 @@
+package hotspot.user.kafka.event;
+
+import java.util.List;
+
+import hotspot.user.kafka.dto.UserAlertEvent;
+import hotspot.user.notification.domain.Notification;
+
+public record UserAlertNotificationsPersistedEvent(
+        UserAlertEvent sourceEvent,
+        List<Notification> persistedNotifications
+) {
+    // 외부 변경을 막기 위해 저장 성공 목록을 불변 리스트로 고정한다.
+    public UserAlertNotificationsPersistedEvent {
+        persistedNotifications = List.copyOf(persistedNotifications);
+    }
+}

--- a/src/main/java/hotspot/user/kafka/mapper/UserAlertEventNotificationMapper.java
+++ b/src/main/java/hotspot/user/kafka/mapper/UserAlertEventNotificationMapper.java
@@ -22,7 +22,7 @@ public class UserAlertEventNotificationMapper {
 
     private static final Pattern NUMBER_PATTERN = Pattern.compile("\\d+");
 
-    // Kafka eventType에 따라 알림 매핑 메서드를 분기한다.
+    // Kafka 이벤트 타입에 따라 알림 매핑 분기를 수행한다.
     public AlertNotificationMappingResult map(UserAlertEvent event) {
         KafkaEventType eventType = KafkaEventType.from(normalize(event.eventType()));
         return switch (eventType) {
@@ -34,11 +34,16 @@ public class UserAlertEventNotificationMapper {
         };
     }
 
-    // 매핑 결과를 Notification 도메인 객체로 변환한다.
+    // 이벤트의 기본 대상 subId로 Notification 도메인을 만든다.
     public Notification toNotification(UserAlertEvent event) {
+        return toNotification(event, event.subId());
+    }
+
+    // 지정된 대상 subId로 Notification 도메인을 만든다.
+    public Notification toNotification(UserAlertEvent event, Long targetSubId) {
         AlertNotificationMappingResult mapping = map(event);
         return Notification.builder()
-                .subId(requireSubId(event.subId()))
+                .subId(requireSubId(targetSubId))
                 .eventId(resolveEventId(event))
                 .notificationType(mapping.notificationType().name())
                 .content(mapping.content().body())
@@ -85,22 +90,7 @@ public class UserAlertEventNotificationMapper {
         throw new ApplicationException(KafkaErrorCode.UNSUPPORTED_KAFKA_ALERT_TYPE);
     }
 
-    // 개인 요금제 잔여량 알림 타입인지 확인한다.
-    private boolean isSingleAlertType(String alertType) {
-        return "PLAN_REMAINING".equals(alertType);
-    }
-
-    // 가족 공유 풀 잔여량 알림 타입인지 확인한다.
-    private boolean isFamilyAlertType(String alertType) {
-        return "FAMILY_POOL_REMAINING".equals(alertType);
-    }
-
-    // 선물 데이터 잔여량 알림 타입인지 확인한다.
-    private boolean isGiftAlertType(String alertType) {
-        return "GIFT_REMAINING".equals(alertType);
-    }
-
-    // 시간 차단 정책 적용/해제 이벤트를 알림으로 변환한다.
+    // 시간 차단 정책 이벤트를 알림으로 변환한다.
     private AlertNotificationMappingResult mapTimeWindowPolicy(UserAlertEvent event) {
         String normalizedAlertType = normalize(event.alertType());
         String policyName = defaultIfBlank(event.policyName(), "정책");
@@ -120,7 +110,7 @@ public class UserAlertEventNotificationMapper {
         };
     }
 
-    // 즉시 차단 적용/해제 이벤트를 알림으로 변환한다.
+    // 즉시 차단 이벤트를 알림으로 변환한다.
     private AlertNotificationMappingResult mapImmediateBlock(UserAlertEvent event) {
         String normalizedAlertType = normalize(event.alertType());
 
@@ -139,7 +129,7 @@ public class UserAlertEventNotificationMapper {
         };
     }
 
-    // 서비스 차단 적용/해제 이벤트를 알림으로 변환한다.
+    // 서비스 접근 제어 이벤트를 알림으로 변환한다.
     private AlertNotificationMappingResult mapServiceAccess(UserAlertEvent event) {
         String normalizedAlertType = normalize(event.alertType());
         String serviceName = defaultIfBlank(event.serviceName(), "서비스");
@@ -171,7 +161,7 @@ public class UserAlertEventNotificationMapper {
         );
     }
 
-    // 공통 매핑 결과 객체를 생성한다.
+    // 공통 알림 매핑 결과 객체를 생성한다.
     private AlertNotificationMappingResult create(NotificationType notificationType, String title, String body) {
         return new AlertNotificationMappingResult(
                 notificationType,
@@ -179,7 +169,7 @@ public class UserAlertEventNotificationMapper {
         );
     }
 
-    // threshold 문자열 또는 remainingPct에서 임계치 값을 추출한다.
+    // threshold 또는 remainingPct에서 숫자 임계치를 추출한다.
     private int resolveThreshold(UserAlertEvent event) {
         String thresholdRaw = defaultIfBlank(event.threshold(), String.valueOf(event.remainingPct()));
         Matcher matcher = NUMBER_PATTERN.matcher(thresholdRaw);
@@ -189,7 +179,7 @@ public class UserAlertEventNotificationMapper {
         return Integer.parseInt(matcher.group());
     }
 
-    // sourceEventId 우선으로 알림 이벤트 ID를 결정한다.
+    // sourceEventId 우선으로 저장 이벤트 ID를 결정한다.
     private String resolveEventId(UserAlertEvent event) {
         String eventId = defaultIfBlank(event.sourceEventId(), event.alertId());
         if (eventId.isBlank()) {
@@ -198,7 +188,7 @@ public class UserAlertEventNotificationMapper {
         return eventId;
     }
 
-    // occurredAt을 UTC 기준 LocalDateTime으로 변환한다.
+    // 발생 시각을 UTC 기준 LocalDateTime으로 변환한다.
     private LocalDateTime resolveCreatedTime(UserAlertEvent event) {
         if (event.occurredAt() == null) {
             return LocalDateTime.now(ZoneOffset.UTC);
@@ -206,7 +196,7 @@ public class UserAlertEventNotificationMapper {
         return LocalDateTime.ofInstant(event.occurredAt(), ZoneOffset.UTC);
     }
 
-    // 대소문자/구분자 차이를 제거해 비교 가능한 문자열로 정규화한다.
+    // 문자열 비교를 위해 대소문자/구분자를 정규화한다.
     private static String normalize(String value) {
         if (value == null) {
             return "";
@@ -217,7 +207,7 @@ public class UserAlertEventNotificationMapper {
                 .toUpperCase(Locale.ROOT);
     }
 
-    // 문자열이 비어있으면 기본값을 반환한다.
+    // 값이 비어있으면 기본값으로 치환한다.
     private static String defaultIfBlank(String value, String fallback) {
         if (value == null || value.isBlank()) {
             return fallback;
@@ -225,7 +215,22 @@ public class UserAlertEventNotificationMapper {
         return value;
     }
 
-    // subId 필수값을 검증한다.
+    // 개인 요금제 잔여량 알림 타입인지 확인한다.
+    private boolean isSingleAlertType(String alertType) {
+        return "PLAN_REMAINING".equals(alertType);
+    }
+
+    // 가족 공유 잔여량 알림 타입인지 확인한다.
+    private boolean isFamilyAlertType(String alertType) {
+        return "FAMILY_POOL_REMAINING".equals(alertType);
+    }
+
+    // 선물 데이터 잔여량 알림 타입인지 확인한다.
+    private boolean isGiftAlertType(String alertType) {
+        return "GIFT_REMAINING".equals(alertType);
+    }
+
+    // 유효한 subId인지 검증한다.
     private static Long requireSubId(Long subId) {
         if (subId == null) {
             throw new ApplicationException(KafkaErrorCode.KAFKA_SUB_ID_REQUIRED);

--- a/src/test/java/hotspot/user/kafka/consumer/UserAlertEventsConsumerTest.java
+++ b/src/test/java/hotspot/user/kafka/consumer/UserAlertEventsConsumerTest.java
@@ -1,0 +1,183 @@
+package hotspot.user.kafka.consumer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.kafka.support.Acknowledgment;
+
+import hotspot.user.common.exception.ApplicationException;
+import hotspot.user.common.exception.code.KafkaErrorCode;
+import hotspot.user.family.domain.Family;
+import hotspot.user.family.domain.FamilySubscription;
+import hotspot.user.family.service.port.FamilySubscriptionRepository;
+import hotspot.user.kafka.dto.UserAlertEvent;
+import hotspot.user.kafka.event.UserAlertNotificationsPersistedEvent;
+import hotspot.user.kafka.mapper.UserAlertEventNotificationMapper;
+import hotspot.user.notification.domain.Notification;
+import hotspot.user.notification.service.port.NotificationRepository;
+import hotspot.user.subscription.domain.Subscription;
+
+@ExtendWith(MockitoExtension.class)
+class UserAlertEventsConsumerTest {
+
+    @Mock
+    private UserAlertEventNotificationMapper mapper;
+
+    @Mock
+    private NotificationRepository notificationRepository;
+
+    @Mock
+    private FamilySubscriptionRepository familySubscriptionRepository;
+
+    @Mock
+    private ApplicationEventPublisher applicationEventPublisher;
+
+    @Mock
+    private Acknowledgment acknowledgment;
+
+    @InjectMocks
+    private UserAlertEventsConsumer consumer;
+
+    @Test
+    @DisplayName("subId target: persist and publish only inserted notifications, then ack")
+    // subId 대상일 때 저장/발행/ack 흐름을 검증한다.
+    void consumeWithSubIdTarget() {
+        UserAlertEvent event = event(101L, null, "evt-sub");
+        Notification notification = notification(101L, "evt-sub");
+        given(mapper.toNotification(event, 101L)).willReturn(notification);
+        given(notificationRepository.insertIfAbsent(notification)).willReturn(true);
+
+        consumer.consume(event, acknowledgment);
+
+        then(mapper).should().toNotification(event, 101L);
+        then(notificationRepository).should().insertIfAbsent(notification);
+
+        ArgumentCaptor<UserAlertNotificationsPersistedEvent> eventCaptor =
+                ArgumentCaptor.forClass(UserAlertNotificationsPersistedEvent.class);
+        then(applicationEventPublisher).should().publishEvent(eventCaptor.capture());
+        assertThat(eventCaptor.getValue().sourceEvent()).isEqualTo(event);
+        assertThat(eventCaptor.getValue().persistedNotifications()).containsExactly(notification);
+
+        then(acknowledgment).should().acknowledge();
+    }
+
+    @Test
+    @DisplayName("familyId target: fan-out and publish only successfully inserted notifications")
+    // familyId 대상일 때 fan-out 저장과 성공 건 발행을 검증한다.
+    void consumeWithFamilyFanOut() {
+        UserAlertEvent event = event(null, 200L, "evt-family");
+        List<FamilySubscription> familySubscriptions = List.of(
+                familySubscription(11L, 200L),
+                familySubscription(22L, 200L)
+        );
+        given(familySubscriptionRepository.findByFamilyId(200L)).willReturn(familySubscriptions);
+
+        Notification first = notification(11L, "evt-family");
+        Notification second = notification(22L, "evt-family");
+        given(mapper.toNotification(event, 11L)).willReturn(first);
+        given(mapper.toNotification(event, 22L)).willReturn(second);
+        given(notificationRepository.insertIfAbsent(first)).willReturn(true);
+        given(notificationRepository.insertIfAbsent(second)).willReturn(false);
+
+        consumer.consume(event, acknowledgment);
+
+        then(familySubscriptionRepository).should().findByFamilyId(200L);
+        then(mapper).should().toNotification(event, 11L);
+        then(mapper).should().toNotification(event, 22L);
+        then(notificationRepository).should().insertIfAbsent(first);
+        then(notificationRepository).should().insertIfAbsent(second);
+
+        ArgumentCaptor<UserAlertNotificationsPersistedEvent> eventCaptor =
+                ArgumentCaptor.forClass(UserAlertNotificationsPersistedEvent.class);
+        then(applicationEventPublisher).should().publishEvent(eventCaptor.capture());
+        assertThat(eventCaptor.getValue().persistedNotifications()).containsExactly(first);
+
+        then(acknowledgment).should().acknowledge();
+    }
+
+    @Test
+    @DisplayName("does not publish follow-up event when every insert was skipped")
+    // 저장 성공이 없으면 후속 이벤트를 발행하지 않는지 검증한다.
+    void consumeWithoutInsertedRows() {
+        UserAlertEvent event = event(303L, null, "evt-dup");
+        Notification notification = notification(303L, "evt-dup");
+        given(mapper.toNotification(event, 303L)).willReturn(notification);
+        given(notificationRepository.insertIfAbsent(notification)).willReturn(false);
+
+        consumer.consume(event, acknowledgment);
+
+        then(applicationEventPublisher).shouldHaveNoInteractions();
+        then(acknowledgment).should().acknowledge();
+    }
+
+    @Test
+    @DisplayName("throws when neither subId nor familyId exists and does not ack")
+    // 대상 정보가 없으면 예외가 나고 ack가 호출되지 않는지 검증한다.
+    void consumeWithoutTarget() {
+        UserAlertEvent event = event(null, null, "evt-invalid");
+
+        assertThatThrownBy(() -> consumer.consume(event, acknowledgment))
+                .isInstanceOf(ApplicationException.class)
+                .hasMessage(KafkaErrorCode.KAFKA_SUB_ID_REQUIRED.getMessage());
+
+        then(acknowledgment).shouldHaveNoInteractions();
+        then(applicationEventPublisher).shouldHaveNoInteractions();
+        then(notificationRepository).shouldHaveNoInteractions();
+        then(mapper).shouldHaveNoInteractions();
+    }
+
+    // 테스트용 이벤트 객체를 생성한다.
+    private UserAlertEvent event(Long subId, Long familyId, String sourceEventId) {
+        return new UserAlertEvent(
+                "alert-1",
+                "USAGE_THRESHOLD",
+                "PLAN_REMAINING",
+                "30",
+                null,
+                null,
+                null,
+                null,
+                Instant.parse("2026-02-23T10:15:30Z"),
+                subId,
+                familyId,
+                null,
+                0L,
+                30,
+                sourceEventId
+        );
+    }
+
+    // 테스트용 Notification 객체를 생성한다.
+    private Notification notification(Long subId, String eventId) {
+        return Notification.builder()
+                .subId(subId)
+                .eventId(eventId)
+                .notificationType("SINGLE_USAGE_THRESHOLD_30")
+                .content("test")
+                .isRead(false)
+                .createdTime(LocalDateTime.of(2026, 2, 23, 10, 15, 30))
+                .build();
+    }
+
+    // 테스트용 FamilySubscription 객체를 생성한다.
+    private FamilySubscription familySubscription(Long subId, Long familyId) {
+        return FamilySubscription.builder()
+                .family(Family.builder().id(familyId).build())
+                .subscription(Subscription.builder().id(subId).build())
+                .build();
+    }
+}

--- a/src/test/java/hotspot/user/kafka/mapper/UserAlertEventNotificationMapperTest.java
+++ b/src/test/java/hotspot/user/kafka/mapper/UserAlertEventNotificationMapperTest.java
@@ -22,6 +22,7 @@ class UserAlertEventNotificationMapperTest {
 
     @Test
     @DisplayName("maps Lua usage threshold for plan remaining")
+    // 개인 요금제 임계치 매핑 결과를 검증한다.
     void mapLuaPlanRemaining() {
         UserAlertEvent event = event("USAGE_THRESHOLD", "PLAN_REMAINING", "50", null, null, null, null);
 
@@ -33,6 +34,7 @@ class UserAlertEventNotificationMapperTest {
 
     @Test
     @DisplayName("maps Lua usage threshold for family pool")
+    // 가족 공유 임계치 매핑 결과를 검증한다.
     void mapLuaFamilyPoolRemaining() {
         UserAlertEvent event = event("USAGE_THRESHOLD", "FAMILY_POOL_REMAINING", "0", null, null, null, null);
 
@@ -44,6 +46,7 @@ class UserAlertEventNotificationMapperTest {
 
     @Test
     @DisplayName("maps Lua usage threshold for gift remaining")
+    // 선물 데이터 임계치 매핑 결과를 검증한다.
     void mapLuaGiftRemaining() {
         UserAlertEvent event = event("USAGE_THRESHOLD", "GIFT_REMAINING", "10", null, null, null, null);
 
@@ -55,6 +58,7 @@ class UserAlertEventNotificationMapperTest {
 
     @Test
     @DisplayName("maps present data amount as-is")
+    // 선물 데이터 알림 문구에 용량이 반영되는지 검증한다.
     void mapPresentData() {
         UserAlertEvent event = event("PRESENT_DATA", null, null, null, null, "홍길동", "500MB");
 
@@ -66,6 +70,7 @@ class UserAlertEventNotificationMapperTest {
 
     @Test
     @DisplayName("maps policy and service events")
+    // 정책/서비스 이벤트 매핑 결과를 검증한다.
     void mapPolicyAndServiceEvents() {
         UserAlertEvent timeApplied = event("TIME_WINDOW_POLICY", "APPLIED", null, "야간 차단", null, null, null);
         UserAlertEvent immediateReleased = event("IMMEDIATE_BLOCK", "RELEASED", null, null, null, null, null);
@@ -83,6 +88,7 @@ class UserAlertEventNotificationMapperTest {
 
     @Test
     @DisplayName("same input always produces same output")
+    // 동일 입력에 대해 같은 매핑 결과가 나오는지 검증한다.
     void sameInputSameOutput() {
         UserAlertEvent event = event("USAGE_THRESHOLD", "GIFT_REMAINING", "10", null, null, null, null);
 
@@ -94,6 +100,7 @@ class UserAlertEventNotificationMapperTest {
 
     @Test
     @DisplayName("toNotification maps deterministic fields")
+    // Notification 변환 시 핵심 필드 매핑을 검증한다.
     void toNotificationSuccess() {
         Instant occurredAt = Instant.parse("2026-02-23T10:15:30Z");
         UserAlertEvent event = new UserAlertEvent(
@@ -126,6 +133,7 @@ class UserAlertEventNotificationMapperTest {
 
     @Test
     @DisplayName("throws common exception when event type is unsupported")
+    // 지원하지 않는 eventType이면 예외가 나는지 검증한다.
     void mapUnsupportedEventType() {
         UserAlertEvent event = event("UNKNOWN_EVENT", "ANY", "50", null, null, null, null);
 
@@ -136,6 +144,7 @@ class UserAlertEventNotificationMapperTest {
 
     @Test
     @DisplayName("throws common exception when alert type is unsupported")
+    // 지원하지 않는 alertType이면 예외가 나는지 검증한다.
     void mapUnsupportedAlertType() {
         UserAlertEvent event = event("USAGE_THRESHOLD", "UNKNOWN_ALERT", "50", null, null, null, null);
 
@@ -146,6 +155,7 @@ class UserAlertEventNotificationMapperTest {
 
     @Test
     @DisplayName("throws common exception when threshold is unsupported")
+    // 지원하지 않는 threshold이면 예외가 나는지 검증한다.
     void mapUnsupportedThreshold() {
         UserAlertEvent event = event("USAGE_THRESHOLD", "PLAN_REMAINING", "77", null, null, null, null);
 
@@ -156,6 +166,7 @@ class UserAlertEventNotificationMapperTest {
 
     @Test
     @DisplayName("throws common exception when subId is missing")
+    // subId가 없을 때 예외가 나는지 검증한다.
     void toNotificationWithoutSubId() {
         UserAlertEvent event = new UserAlertEvent(
                 "alert-1",
@@ -182,6 +193,7 @@ class UserAlertEventNotificationMapperTest {
 
     @Test
     @DisplayName("throws common exception when subId is invalid")
+    // subId가 0 이하일 때 예외가 나는지 검증한다.
     void toNotificationWithInvalidSubId() {
         UserAlertEvent event = new UserAlertEvent(
                 "alert-1",
@@ -206,6 +218,7 @@ class UserAlertEventNotificationMapperTest {
                 .hasMessage(KafkaErrorCode.KAFKA_SUB_ID_INVALID.getMessage());
     }
 
+    // 테스트용 UserAlertEvent 객체를 생성한다.
     private UserAlertEvent event(
             String eventType,
             String alertType,


### PR DESCRIPTION
## 🎫 지라 티켓

<!-- 지라 티켓을 작성해주세요 ex) HOTSPOT-123 -->
HOTSPOT-152

---

## 🔗 GitHub 이슈
<!-- 자동 close를 원하면 아래 형식으로 작성
예) Closes #12
-->
Closes #52 

---


## ✅ 작업 사항

<!-- 작업한 부분을 설명해주세요. -->
- Kafka 구독 설정 (@KafkaListener, topic/groupId, ack mode, error handler)
- UserAlertEvent 역직렬화/유효성 검증

- 대상 사용자 결정 로직
  - subId 직접 대상 처리
  - familyId 기반이면 가족 구성원 조회 후 fan-out 대상 리스트 생성

- Notification 저장(Repository)
  - idempotency 고려(이벤트ID 기반 중복 저장 방지 또는 unique key)
  - 저장 성공 건만 다음 단계로 전달

- ack 처리(모든 저장/발송 단계 완료 후 ack)
- 실패 처리 전략
  - 재시도/에러 핸들러 설정
  - 로그/메트릭(consume count, fail count) 추가

- 통합 테스트 1개(샘플 이벤트 → 저장/팬아웃 결과 검증)

---

## 📋 체크리스트

<!-- PR 제출 전 확인해주세요. 해당 항목에 [x]로 체크해주세요. -->

- [x] 코드가 정상적으로 빌드됩니다.
- [x] 관련 테스트 코드를 작성했습니다.
- [x] 기존 테스트가 모두 통과합니다.
- [x] 코드 스타일(Spotless, Checkstyle)을 준수합니다.
- [x] Jira 티켓 상태를 In Review / Done으로 변경했습니다.

---

## ⌨ 기타
