### PR TITLE
[HOTSPOT-153] SSE 구독 및 실시간 발송 구현

### DIFF
--- a/src/main/java/hotspot/user/UserApplication.java
+++ b/src/main/java/hotspot/user/UserApplication.java
@@ -4,10 +4,12 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableJpaAuditing
 @ConfigurationPropertiesScan
+@EnableScheduling
 public class UserApplication {
 
   public static void main(String[] args) {

--- a/src/main/java/hotspot/user/dispatch/controller/SseController.java
+++ b/src/main/java/hotspot/user/dispatch/controller/SseController.java
@@ -1,0 +1,32 @@
+package hotspot.user.dispatch.controller;
+
+import org.springframework.http.MediaType;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import hotspot.user.common.security.PrincipalDetails;
+import hotspot.user.dispatch.controller.port.SubscribeSseService;
+import hotspot.user.dispatch.controller.swagger.SseApi;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/sse")
+public class SseController implements SseApi {
+
+    private final SubscribeSseService subscribeSseService;
+
+    @GetMapping(value = "/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    @Override
+    // 인증된 사용자의 SSE 구독을 시작하고, 마지막 이벤트 ID를 전달해 스트림을 연결한다.
+    public SseEmitter subscribe(
+            @AuthenticationPrincipal PrincipalDetails details,
+            @RequestHeader(value = "Last-Event-ID", required = false) String lastEventId
+    ) {
+        return subscribeSseService.subscribe(details.getId(), lastEventId);
+    }
+}

--- a/src/main/java/hotspot/user/dispatch/controller/port/SubscribeSseService.java
+++ b/src/main/java/hotspot/user/dispatch/controller/port/SubscribeSseService.java
@@ -1,0 +1,8 @@
+package hotspot.user.dispatch.controller.port;
+
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+public interface SubscribeSseService {
+
+    SseEmitter subscribe(Long memberId, String lastEventId);
+}

--- a/src/main/java/hotspot/user/dispatch/controller/swagger/SseApi.java
+++ b/src/main/java/hotspot/user/dispatch/controller/swagger/SseApi.java
@@ -1,0 +1,41 @@
+package hotspot.user.dispatch.controller.swagger;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import hotspot.user.common.exception.ErrorResponse;
+import hotspot.user.common.security.PrincipalDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "Dispatch", description = "Notification SSE subscription API")
+public interface SseApi {
+
+    @Operation(
+            summary = "Subscribe SSE stream",
+            description = "Subscribe to notification SSE stream via /api/v1/sse/subscribe."
+    )
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Subscribed"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "Authentication failed (AUTH_002: invalid token)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "Subscription target not found (NOTI_001)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            )
+    })
+    SseEmitter subscribe(
+            @Parameter(hidden = true) @AuthenticationPrincipal PrincipalDetails details,
+            @Parameter(description = "Last SSE event id for reconnect", example = "10", required = false)
+            @RequestHeader(value = "Last-Event-ID", required = false) String lastEventId
+    );
+}

--- a/src/main/java/hotspot/user/dispatch/domain/SseConnectedPayload.java
+++ b/src/main/java/hotspot/user/dispatch/domain/SseConnectedPayload.java
@@ -1,0 +1,15 @@
+package hotspot.user.dispatch.domain;
+
+import java.time.LocalDateTime;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+
+import lombok.Builder;
+
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
+@Builder
+public class SseConnectedPayload {
+    private Long subId;
+    private String lastEventId;
+    private LocalDateTime connectedAt;
+}

--- a/src/main/java/hotspot/user/dispatch/domain/SseConnectedPayload.java
+++ b/src/main/java/hotspot/user/dispatch/domain/SseConnectedPayload.java
@@ -11,5 +11,5 @@ import lombok.Builder;
 public class SseConnectedPayload {
     private Long subId;
     private String lastEventId;
-    private LocalDateTime connectedAt;
+    private LocalDateTime connectedTime;
 }

--- a/src/main/java/hotspot/user/dispatch/domain/SsePayload.java
+++ b/src/main/java/hotspot/user/dispatch/domain/SsePayload.java
@@ -13,6 +13,6 @@ public class SsePayload {
     private String notificationType;
     private String title;
     private String content;
-    private LocalDateTime createdAt;
+    private LocalDateTime createdTime;
     private Long unreadCount;
 }

--- a/src/main/java/hotspot/user/dispatch/domain/SsePayload.java
+++ b/src/main/java/hotspot/user/dispatch/domain/SsePayload.java
@@ -1,0 +1,18 @@
+package hotspot.user.dispatch.domain;
+
+import java.time.LocalDateTime;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+
+import lombok.Builder;
+
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
+@Builder
+public class SsePayload {
+    private Long notificationId;
+    private String notificationType;
+    private String title;
+    private String content;
+    private LocalDateTime createdAt;
+    private Long unreadCount;
+}

--- a/src/main/java/hotspot/user/dispatch/registry/SseEmitterRegistry.java
+++ b/src/main/java/hotspot/user/dispatch/registry/SseEmitterRegistry.java
@@ -1,0 +1,86 @@
+package hotspot.user.dispatch.registry;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@Component
+public class SseEmitterRegistry {
+
+    private final ConcurrentMap<Long, ConcurrentMap<String, SseEmitter>> emittersBySubId = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, SseEmitter> emittersByEmitterId = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, Long> subIdsByEmitterId = new ConcurrentHashMap<>();
+
+    // 새 SSE 연결을 subId 기준으로 저장하고 emitterId를 발급한다.
+    public String register(Long subId, SseEmitter emitter) {
+        String emitterId = UUID.randomUUID().toString();
+        emittersBySubId.computeIfAbsent(subId, key -> new ConcurrentHashMap<>()).put(emitterId, emitter);
+        emittersByEmitterId.put(emitterId, emitter);
+        subIdsByEmitterId.put(emitterId, subId);
+        return emitterId;
+    }
+
+    // emitterId로 연결을 찾아 레지스트리에서 완전히 제거한다.
+    public void remove(String emitterId) {
+        emittersByEmitterId.remove(emitterId);
+        Long subId = subIdsByEmitterId.remove(emitterId);
+        if (subId == null) {
+            return;
+        }
+
+        removeFromBucket(emittersBySubId, subId, emitterId);
+    }
+
+    // 특정 subId에 연결된 모든 SSE 연결을 조회한다.
+    public List<RegisteredEmitter> findBySubId(Long subId) {
+        Map<String, SseEmitter> bucket = emittersBySubId.get(subId);
+        if (bucket == null || bucket.isEmpty()) {
+            return List.of();
+        }
+
+        return bucket.entrySet().stream()
+                .map(entry -> new RegisteredEmitter(entry.getKey(), entry.getValue()))
+                .toList();
+    }
+
+    // 현재 등록된 전체 SSE 연결을 조회한다.
+    public List<RegisteredEmitter> findAll() {
+        return emittersByEmitterId.entrySet().stream()
+                .map(entry -> new RegisteredEmitter(entry.getKey(), entry.getValue()))
+                .toList();
+    }
+
+    // 이벤트를 전송하고 실패하면 해당 연결을 제거, 종료한다.
+    public void sendAndCleanupOnFailure(
+            RegisteredEmitter registeredEmitter,
+            SseEmitter.SseEventBuilder eventBuilder
+    ) {
+        try {
+            registeredEmitter.emitter().send(eventBuilder);
+        } catch (IOException | IllegalStateException ex) {
+            remove(registeredEmitter.emitterId());
+            registeredEmitter.emitter().complete();
+        }
+    }
+
+    // subId 버킷에서 emitter를 지우고 비면 버킷 자체도 삭제한다.
+    private void removeFromBucket(
+            ConcurrentMap<Long, ConcurrentMap<String, SseEmitter>> index,
+            Long key,
+            String emitterId
+    ) {
+        index.computeIfPresent(key, (unused, emitters) -> {
+            emitters.remove(emitterId);
+            return emitters.isEmpty() ? null : emitters;
+        });
+    }
+
+    public record RegisteredEmitter(String emitterId, SseEmitter emitter) {
+    }
+}

--- a/src/main/java/hotspot/user/dispatch/service/SsePushService.java
+++ b/src/main/java/hotspot/user/dispatch/service/SsePushService.java
@@ -36,7 +36,7 @@ public class SsePushService {
                     .notificationType(notification.getNotificationType())
                     .title(notification.getTitle())
                     .content(notification.getContent())
-                    .createdAt(notification.getCreatedTime())
+                    .createdTime(notification.getCreatedTime())
                     .unreadCount(unreadCount)
                     .build();
 

--- a/src/main/java/hotspot/user/dispatch/service/SsePushService.java
+++ b/src/main/java/hotspot/user/dispatch/service/SsePushService.java
@@ -1,0 +1,53 @@
+package hotspot.user.dispatch.service;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import hotspot.user.dispatch.domain.SsePayload;
+import hotspot.user.dispatch.registry.SseEmitterRegistry;
+import hotspot.user.kafka.dto.UserAlertNotificationsPersistedEvent;
+import hotspot.user.notification.domain.Notification;
+import hotspot.user.notification.service.port.NotificationRepository;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class SsePushService {
+
+    private final SseEmitterRegistry sseEmitterRegistry;
+    private final NotificationRepository notificationRepository;
+
+    @EventListener
+    // 알림이 DB에 저장 완료되면 해당 회선의 모든 SSE 구독자에게 실시간 알림 이벤트를 전송한다.
+    public void onNotificationsPersisted(UserAlertNotificationsPersistedEvent event) {
+        Map<Long, Long> unreadCountsBySubId = new HashMap<>();
+        for (Notification notification : event.persistedNotifications()) {
+            Long unreadCount = unreadCountsBySubId.computeIfAbsent(
+                    notification.getSubId(),
+                    notificationRepository::countUnreadBySubId
+            );
+
+            SsePayload payload = SsePayload.builder()
+                    .notificationId(notification.getId())
+                    .notificationType(notification.getNotificationType())
+                    .title(notification.getTitle())
+                    .content(notification.getContent())
+                    .createdAt(notification.getCreatedTime())
+                    .unreadCount(unreadCount)
+                    .build();
+
+            sseEmitterRegistry.findBySubId(notification.getSubId())
+                    .forEach(registeredEmitter -> sseEmitterRegistry.sendAndCleanupOnFailure(
+                            registeredEmitter,
+                            SseEmitter.event()
+                                    .name("notification")
+                                    .id(String.valueOf(notification.getId()))
+                                    .data(payload)
+                    ));
+        }
+    }
+}

--- a/src/main/java/hotspot/user/dispatch/service/SubscribeSseServiceImpl.java
+++ b/src/main/java/hotspot/user/dispatch/service/SubscribeSseServiceImpl.java
@@ -45,7 +45,7 @@ public class SubscribeSseServiceImpl implements SubscribeSseService {
                         .data(SseConnectedPayload.builder()
                                 .subId(subId)
                                 .lastEventId(lastEventId)
-                                .connectedAt(LocalDateTime.now())
+                                .connectedTime(LocalDateTime.now())
                                 .build())
         );
 

--- a/src/main/java/hotspot/user/dispatch/service/SubscribeSseServiceImpl.java
+++ b/src/main/java/hotspot/user/dispatch/service/SubscribeSseServiceImpl.java
@@ -1,0 +1,79 @@
+package hotspot.user.dispatch.service;
+
+import java.time.LocalDateTime;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import hotspot.user.common.exception.ApplicationException;
+import hotspot.user.common.exception.code.NotificationErrorCode;
+import hotspot.user.common.exception.code.SubscriptionErrorCode;
+import hotspot.user.dispatch.controller.port.SubscribeSseService;
+import hotspot.user.dispatch.domain.SseConnectedPayload;
+import hotspot.user.dispatch.registry.SseEmitterRegistry;
+import hotspot.user.subscription.domain.Subscription;
+import hotspot.user.subscription.service.SubscriptionService;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class SubscribeSseServiceImpl implements SubscribeSseService {
+
+    private static final long SSE_TIMEOUT_MILLIS = 30L * 60L * 1000L;
+
+    private final SseEmitterRegistry sseEmitterRegistry;
+    private final SubscriptionService subscriptionService;
+
+    @Override
+    // SSE 연결을 생성, 등록하고 콜백을 걸고 즉시 connected 이벤트를 보내고 emitter를 반환한다.
+    public SseEmitter subscribe(Long memberId, String lastEventId) {
+        Long subId = resolveSubIdByMemberId(memberId);
+
+        SseEmitter emitter = new SseEmitter(SSE_TIMEOUT_MILLIS);
+        String emitterId = sseEmitterRegistry.register(subId, emitter);
+
+        emitter.onCompletion(() -> sseEmitterRegistry.remove(emitterId));
+        emitter.onTimeout(() -> sseEmitterRegistry.remove(emitterId));
+        emitter.onError(ex -> sseEmitterRegistry.remove(emitterId));
+
+        sseEmitterRegistry.sendAndCleanupOnFailure(
+                new SseEmitterRegistry.RegisteredEmitter(emitterId, emitter),
+                SseEmitter.event()
+                        .name("connected")
+                        .id(emitterId)
+                        .data(SseConnectedPayload.builder()
+                                .subId(subId)
+                                .lastEventId(lastEventId)
+                                .connectedAt(LocalDateTime.now())
+                                .build())
+        );
+
+        return emitter;
+    }
+
+    @Scheduled(fixedDelayString = "${app.notification.sse.heartbeat-interval-ms:25000}")
+    // 현재 등록된 모든 SSE 연결에 주기적으로 heartbeat 이벤트를 보내며 끊긴 연결은 즉시 정리한다.
+    public void sendHeartbeat() {
+        sseEmitterRegistry.findAll()
+                .forEach(registeredEmitter -> sseEmitterRegistry.sendAndCleanupOnFailure(
+                        registeredEmitter,
+                        SseEmitter.event()
+                                .name("heartbeat")
+                                .data(LocalDateTime.now())
+                ));
+    }
+
+    // 구독을 조회하고 없으면 알림 관련 예외로 변환해 처리한다.
+    private Long resolveSubIdByMemberId(Long memberId) {
+        try {
+            Subscription subscription = subscriptionService.findByMemberId(memberId);
+            return subscription.getId();
+        } catch (ApplicationException e) {
+            if (e.getCode() == SubscriptionErrorCode.SUBSCRIPTION_NOT_FOUND) {
+                throw new ApplicationException(NotificationErrorCode.NOTIFICATION_NOT_FOUND);
+            }
+            throw e;
+        }
+    }
+}

--- a/src/main/java/hotspot/user/kafka/consumer/UserAlertEventsConsumer.java
+++ b/src/main/java/hotspot/user/kafka/consumer/UserAlertEventsConsumer.java
@@ -14,7 +14,7 @@ import hotspot.user.common.exception.ApplicationException;
 import hotspot.user.common.exception.code.KafkaErrorCode;
 import hotspot.user.family.service.port.FamilySubscriptionRepository;
 import hotspot.user.kafka.dto.UserAlertEvent;
-import hotspot.user.kafka.event.UserAlertNotificationsPersistedEvent;
+import hotspot.user.kafka.dto.UserAlertNotificationsPersistedEvent;
 import hotspot.user.kafka.mapper.UserAlertEventNotificationMapper;
 import hotspot.user.notification.domain.Notification;
 import hotspot.user.notification.service.port.NotificationRepository;
@@ -41,8 +41,9 @@ public class UserAlertEventsConsumer {
         List<Notification> persistedNotifications = new ArrayList<>();
         for (Long targetSubId : targetSubIds) {
             Notification notification = mapper.toNotification(event, targetSubId);
-            if (notificationRepository.insertIfAbsent(notification)) {
-                persistedNotifications.add(notification);
+            Notification persistedNotification = notificationRepository.insertIfAbsent(notification);
+            if (persistedNotification != null) {
+                persistedNotifications.add(persistedNotification);
             }
         }
 

--- a/src/main/java/hotspot/user/kafka/dto/UserAlertNotificationsPersistedEvent.java
+++ b/src/main/java/hotspot/user/kafka/dto/UserAlertNotificationsPersistedEvent.java
@@ -1,8 +1,7 @@
-package hotspot.user.kafka.event;
+package hotspot.user.kafka.dto;
 
 import java.util.List;
 
-import hotspot.user.kafka.dto.UserAlertEvent;
 import hotspot.user.notification.domain.Notification;
 
 public record UserAlertNotificationsPersistedEvent(

--- a/src/main/java/hotspot/user/kafka/mapper/UserAlertEventNotificationMapper.java
+++ b/src/main/java/hotspot/user/kafka/mapper/UserAlertEventNotificationMapper.java
@@ -46,6 +46,7 @@ public class UserAlertEventNotificationMapper {
                 .subId(requireSubId(targetSubId))
                 .eventId(resolveEventId(event))
                 .notificationType(mapping.notificationType().name())
+                .title(mapping.content().title())
                 .content(mapping.content().body())
                 .isRead(false)
                 .createdTime(resolveCreatedTime(event))

--- a/src/main/java/hotspot/user/notification/controller/response/NotificationResponse.java
+++ b/src/main/java/hotspot/user/notification/controller/response/NotificationResponse.java
@@ -12,6 +12,7 @@ public class NotificationResponse {
     private Long id;
     private String eventId;
     private String notificationType;
+    private String title;
     private String content;
     private boolean isRead;
     private LocalDateTime createdTime;

--- a/src/main/java/hotspot/user/notification/domain/Notification.java
+++ b/src/main/java/hotspot/user/notification/domain/Notification.java
@@ -14,6 +14,7 @@ public class Notification {
     private Long subId;
     private String eventId;
     private String notificationType;
+    private String title;
     private String content;
     private Boolean isRead;
     private LocalDateTime createdTime;

--- a/src/main/java/hotspot/user/notification/domain/mapper/NotificationMapper.java
+++ b/src/main/java/hotspot/user/notification/domain/mapper/NotificationMapper.java
@@ -17,6 +17,7 @@ public final class NotificationMapper {
                 .id(notification.getId())
                 .eventId(notification.getEventId())
                 .notificationType(notification.getNotificationType())
+                .title(notification.getTitle())
                 .content(notification.getContent())
                 .isRead(notification.getIsRead())
                 .createdTime(notification.getCreatedTime())

--- a/src/main/java/hotspot/user/notification/infrastructure/NotificationJpaRepository.java
+++ b/src/main/java/hotspot/user/notification/infrastructure/NotificationJpaRepository.java
@@ -1,6 +1,7 @@
 package hotspot.user.notification.infrastructure;
 
 import java.time.LocalDateTime;
+import java.util.Optional;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -21,6 +22,7 @@ public interface NotificationJpaRepository extends JpaRepository<NotificationEnt
                         sub_id,
                         event_id,
                         notification_type,
+                        notification_title,
                         notification_content,
                         is_read,
                         created_time
@@ -28,6 +30,7 @@ public interface NotificationJpaRepository extends JpaRepository<NotificationEnt
                         :subId,
                         :eventId,
                         :notificationType,
+                        :title,
                         :content,
                         false,
                         :createdTime
@@ -41,9 +44,12 @@ public interface NotificationJpaRepository extends JpaRepository<NotificationEnt
             @Param("subId") Long subId,
             @Param("eventId") String eventId,
             @Param("notificationType") String notificationType,
+            @Param("title") String title,
             @Param("content") String content,
             @Param("createdTime") LocalDateTime createdTime
     );
+
+    Optional<NotificationEntity> findByEventIdAndSubscriptionSubId(String eventId, Long subId);
 
     // created_time이 기준 시각 이상인 알림을 최신순으로 조회한다.
     Page<NotificationEntity> findBySubscriptionSubIdAndCreatedTimeGreaterThanEqualOrderByCreatedTimeDesc(

--- a/src/main/java/hotspot/user/notification/infrastructure/NotificationRepositoryImpl.java
+++ b/src/main/java/hotspot/user/notification/infrastructure/NotificationRepositoryImpl.java
@@ -21,15 +21,23 @@ public class NotificationRepositoryImpl implements NotificationRepository {
 
     // 충돌 시 무시하는 native insert 결과를 boolean으로 변환한다.
     @Override
-    public boolean insertIfAbsent(Notification notification) {
+    public Notification insertIfAbsent(Notification notification) {
         int affectedRows = notificationJpaRepository.insertIgnoreConflict(
                 notification.getSubId(),
                 notification.getEventId(),
                 notification.getNotificationType(),
+                notification.getTitle(),
                 notification.getContent(),
                 notification.getCreatedTime()
         );
-        return affectedRows > 0;
+        if (affectedRows == 0) {
+            return null;
+        }
+
+        return notificationJpaRepository
+                .findByEventIdAndSubscriptionSubId(notification.getEventId(), notification.getSubId())
+                .map(NotificationEntity::entityToDomain)
+                .orElse(null);
     }
 
     // JPA 페이지 결과를 도메인 페이지로 변환한다.

--- a/src/main/java/hotspot/user/notification/infrastructure/entity/NotificationEntity.java
+++ b/src/main/java/hotspot/user/notification/infrastructure/entity/NotificationEntity.java
@@ -56,6 +56,9 @@ public class NotificationEntity {
     @Column(name = "notification_type", length = 50, nullable = false)
     private String notificationType;
 
+    @Column(name = "notification_title", length = 120)
+    private String title;
+
     @Column(name = "notification_content", length = 255, nullable = false)
     private String content;
 
@@ -78,6 +81,7 @@ public class NotificationEntity {
                 .subscription(subscriptionProxy)
                 .eventId(notification.getEventId())
                 .notificationType(notification.getNotificationType())
+                .title(notification.getTitle())
                 .content(notification.getContent())
                 .isRead(notification.getIsRead())
                 .createdTime(notification.getCreatedTime())
@@ -91,6 +95,7 @@ public class NotificationEntity {
                 .subId(this.subscription != null ? this.subscription.getSubId() : null)
                 .eventId(this.eventId)
                 .notificationType(this.notificationType)
+                .title(this.title)
                 .content(this.content)
                 .isRead(this.isRead)
                 .createdTime(this.createdTime)

--- a/src/main/java/hotspot/user/notification/service/port/NotificationRepository.java
+++ b/src/main/java/hotspot/user/notification/service/port/NotificationRepository.java
@@ -8,7 +8,7 @@ import hotspot.user.notification.domain.Notification;
 public interface NotificationRepository {
 
     // (eventId, subId)가 없을 때만 저장하고, 중복이면 저장하지 않는다.
-    boolean insertIfAbsent(Notification notification);
+    Notification insertIfAbsent(Notification notification);
 
     // 특정 회선의 최근 알림을 페이지 단위로 조회한다.
     Page<Notification> findRecentBySubId(Long subId, Pageable pageable);

--- a/src/test/java/hotspot/user/dispatch/SubscribeSseServiceImplTest.java
+++ b/src/test/java/hotspot/user/dispatch/SubscribeSseServiceImplTest.java
@@ -1,0 +1,82 @@
+package hotspot.user.dispatch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import hotspot.user.common.exception.ApplicationException;
+import hotspot.user.common.exception.code.NotificationErrorCode;
+import hotspot.user.common.exception.code.SubscriptionErrorCode;
+import hotspot.user.dispatch.registry.SseEmitterRegistry;
+import hotspot.user.dispatch.service.SubscribeSseServiceImpl;
+import hotspot.user.subscription.domain.Subscription;
+import hotspot.user.subscription.service.SubscriptionService;
+
+@ExtendWith(MockitoExtension.class)
+class SubscribeSseServiceImplTest {
+
+    @Mock
+    private SseEmitterRegistry sseEmitterRegistry;
+
+    @Mock
+    private SubscriptionService subscriptionService;
+
+    @InjectMocks
+    private SubscribeSseServiceImpl subscribeSseService;
+
+    @Test
+    @DisplayName("subscribe registers emitter and sends connected event")
+    void subscribeSuccess() {
+        Subscription subscription = Subscription.builder().id(11L).build();
+        given(subscriptionService.findByMemberId(1L)).willReturn(subscription);
+        given(sseEmitterRegistry.register(org.mockito.ArgumentMatchers.eq(11L), any(SseEmitter.class)))
+                .willReturn("e-1");
+
+        SseEmitter result = subscribeSseService.subscribe(1L, "100");
+
+        assertThat(result).isNotNull();
+        then(subscriptionService).should().findByMemberId(1L);
+        then(sseEmitterRegistry).should().register(org.mockito.ArgumentMatchers.eq(11L), any(SseEmitter.class));
+        then(sseEmitterRegistry).should().sendAndCleanupOnFailure(any(), any());
+    }
+
+    @Test
+    @DisplayName("sendHeartbeat sends heartbeat to all registered emitters")
+    void sendHeartbeatSuccess() {
+        List<SseEmitterRegistry.RegisteredEmitter> emitters = List.of(
+                new SseEmitterRegistry.RegisteredEmitter("e-1", new SseEmitter()),
+                new SseEmitterRegistry.RegisteredEmitter("e-2", new SseEmitter())
+        );
+        given(sseEmitterRegistry.findAll()).willReturn(emitters);
+
+        subscribeSseService.sendHeartbeat();
+
+        then(sseEmitterRegistry).should().findAll();
+        then(sseEmitterRegistry).should(times(2)).sendAndCleanupOnFailure(any(), any());
+    }
+
+    @Test
+    @DisplayName("subscribe throws NOTIFICATION_NOT_FOUND when subscription is missing")
+    void subscribeFailWhenSubscriptionNotFound() {
+        given(subscriptionService.findByMemberId(1L))
+                .willThrow(new ApplicationException(SubscriptionErrorCode.SUBSCRIPTION_NOT_FOUND));
+
+        assertThatThrownBy(() -> subscribeSseService.subscribe(1L, null))
+                .isInstanceOf(ApplicationException.class)
+                .extracting(ex -> ((ApplicationException) ex).getCode())
+                .isEqualTo(NotificationErrorCode.NOTIFICATION_NOT_FOUND);
+    }
+}

--- a/src/test/java/hotspot/user/dispatch/controller/SseControllerTest.java
+++ b/src/test/java/hotspot/user/dispatch/controller/SseControllerTest.java
@@ -1,0 +1,47 @@
+package hotspot.user.dispatch.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import hotspot.user.common.security.PrincipalDetails;
+import hotspot.user.dispatch.controller.port.SubscribeSseService;
+import hotspot.user.member.domain.FamilyRole;
+import hotspot.user.member.domain.Status;
+
+@ExtendWith(MockitoExtension.class)
+class SseControllerTest {
+
+    @Mock
+    private SubscribeSseService subscribeSseService;
+
+    @InjectMocks
+    private SseController dispatchSseController;
+
+    @Test
+    @DisplayName("subscribe delegates to sse stream service")
+    void subscribeDelegatesToService() {
+        PrincipalDetails details = PrincipalDetails.builder()
+                .id(1L)
+                .email("test@example.com")
+                .familyId(10L)
+                .role(FamilyRole.OWNER)
+                .status(Status.APPROVED)
+                .build();
+        SseEmitter emitter = new SseEmitter();
+        given(subscribeSseService.subscribe(1L, "10")).willReturn(emitter);
+
+        SseEmitter response = dispatchSseController.subscribe(details, "10");
+
+        assertThat(response).isSameAs(emitter);
+        then(subscribeSseService).should().subscribe(1L, "10");
+    }
+}

--- a/src/test/java/hotspot/user/dispatch/registry/SseEmitterRegistryTest.java
+++ b/src/test/java/hotspot/user/dispatch/registry/SseEmitterRegistryTest.java
@@ -1,0 +1,28 @@
+package hotspot.user.dispatch.registry;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+class SseEmitterRegistryTest {
+
+    private final SseEmitterRegistry sseEmitterRegistry = new SseEmitterRegistry();
+
+    @Test
+    @DisplayName("register indexes emitter by subId and remove cleans registry")
+    void registerAndRemoveEmitter() {
+        SseEmitter emitter = new SseEmitter();
+
+        String emitterId = sseEmitterRegistry.register(11L, emitter);
+
+        assertThat(sseEmitterRegistry.findBySubId(11L)).hasSize(1);
+        assertThat(sseEmitterRegistry.findAll()).hasSize(1);
+
+        sseEmitterRegistry.remove(emitterId);
+
+        assertThat(sseEmitterRegistry.findBySubId(11L)).isEmpty();
+        assertThat(sseEmitterRegistry.findAll()).isEmpty();
+    }
+}

--- a/src/test/java/hotspot/user/dispatch/service/SsePushServiceTest.java
+++ b/src/test/java/hotspot/user/dispatch/service/SsePushServiceTest.java
@@ -1,0 +1,97 @@
+package hotspot.user.dispatch.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import hotspot.user.dispatch.registry.SseEmitterRegistry;
+import hotspot.user.kafka.dto.UserAlertEvent;
+import hotspot.user.kafka.dto.UserAlertNotificationsPersistedEvent;
+import hotspot.user.notification.domain.Notification;
+import hotspot.user.notification.service.port.NotificationRepository;
+
+@ExtendWith(MockitoExtension.class)
+class SsePushServiceTest {
+
+    @Mock
+    private SseEmitterRegistry sseEmitterRegistry;
+
+    @Mock
+    private NotificationRepository notificationRepository;
+
+    @InjectMocks
+    private SsePushService notificationSsePushService;
+
+    @Test
+    @DisplayName("pushes persisted notifications to all emitters in subId and includes unread count lookup")
+    void pushPersistedNotifications() {
+        Notification first = notification(101L, 1L, "TYPE_1");
+        Notification second = notification(102L, 1L, "TYPE_2");
+        UserAlertNotificationsPersistedEvent event = new UserAlertNotificationsPersistedEvent(
+                sourceEvent(),
+                List.of(first, second)
+        );
+
+        List<SseEmitterRegistry.RegisteredEmitter> emitters = List.of(
+                new SseEmitterRegistry.RegisteredEmitter("e-1", new SseEmitter()),
+                new SseEmitterRegistry.RegisteredEmitter("e-2", new SseEmitter())
+        );
+        given(sseEmitterRegistry.findBySubId(1L)).willReturn(emitters);
+        given(notificationRepository.countUnreadBySubId(1L)).willReturn(7L);
+
+        notificationSsePushService.onNotificationsPersisted(event);
+
+        then(notificationRepository).should().countUnreadBySubId(1L);
+        then(sseEmitterRegistry).should(times(2)).findBySubId(1L);
+        then(sseEmitterRegistry).should(times(4)).sendAndCleanupOnFailure(any(), any());
+        then(sseEmitterRegistry).should(times(2)).sendAndCleanupOnFailure(eq(emitters.get(0)), any());
+        then(sseEmitterRegistry).should(times(2)).sendAndCleanupOnFailure(eq(emitters.get(1)), any());
+    }
+
+    private UserAlertEvent sourceEvent() {
+        return new UserAlertEvent(
+                "alert-1",
+                "USAGE_THRESHOLD",
+                "PLAN_REMAINING",
+                "30",
+                null,
+                null,
+                null,
+                null,
+                Instant.parse("2026-02-23T10:15:30Z"),
+                1L,
+                null,
+                null,
+                0L,
+                30,
+                "evt-source"
+        );
+    }
+
+    private Notification notification(Long id, Long subId, String type) {
+        return Notification.builder()
+                .id(id)
+                .subId(subId)
+                .eventId("evt-" + id)
+                .notificationType(type)
+                .title("title-" + id)
+                .content("test-" + id)
+                .isRead(false)
+                .createdTime(LocalDateTime.of(2026, 2, 23, 10, 15, 30))
+                .build();
+    }
+}

--- a/src/test/java/hotspot/user/kafka/consumer/UserAlertEventsConsumerTest.java
+++ b/src/test/java/hotspot/user/kafka/consumer/UserAlertEventsConsumerTest.java
@@ -25,7 +25,7 @@ import hotspot.user.family.domain.Family;
 import hotspot.user.family.domain.FamilySubscription;
 import hotspot.user.family.service.port.FamilySubscriptionRepository;
 import hotspot.user.kafka.dto.UserAlertEvent;
-import hotspot.user.kafka.event.UserAlertNotificationsPersistedEvent;
+import hotspot.user.kafka.dto.UserAlertNotificationsPersistedEvent;
 import hotspot.user.kafka.mapper.UserAlertEventNotificationMapper;
 import hotspot.user.notification.domain.Notification;
 import hotspot.user.notification.service.port.NotificationRepository;
@@ -58,8 +58,9 @@ class UserAlertEventsConsumerTest {
     void consumeWithSubIdTarget() {
         UserAlertEvent event = event(101L, null, "evt-sub");
         Notification notification = notification(101L, "evt-sub");
+        Notification persisted = persistedNotification(1L, notification);
         given(mapper.toNotification(event, 101L)).willReturn(notification);
-        given(notificationRepository.insertIfAbsent(notification)).willReturn(true);
+        given(notificationRepository.insertIfAbsent(notification)).willReturn(persisted);
 
         consumer.consume(event, acknowledgment);
 
@@ -70,7 +71,7 @@ class UserAlertEventsConsumerTest {
                 ArgumentCaptor.forClass(UserAlertNotificationsPersistedEvent.class);
         then(applicationEventPublisher).should().publishEvent(eventCaptor.capture());
         assertThat(eventCaptor.getValue().sourceEvent()).isEqualTo(event);
-        assertThat(eventCaptor.getValue().persistedNotifications()).containsExactly(notification);
+        assertThat(eventCaptor.getValue().persistedNotifications()).containsExactly(persisted);
 
         then(acknowledgment).should().acknowledge();
     }
@@ -88,10 +89,11 @@ class UserAlertEventsConsumerTest {
 
         Notification first = notification(11L, "evt-family");
         Notification second = notification(22L, "evt-family");
+        Notification persistedFirst = persistedNotification(10L, first);
         given(mapper.toNotification(event, 11L)).willReturn(first);
         given(mapper.toNotification(event, 22L)).willReturn(second);
-        given(notificationRepository.insertIfAbsent(first)).willReturn(true);
-        given(notificationRepository.insertIfAbsent(second)).willReturn(false);
+        given(notificationRepository.insertIfAbsent(first)).willReturn(persistedFirst);
+        given(notificationRepository.insertIfAbsent(second)).willReturn(null);
 
         consumer.consume(event, acknowledgment);
 
@@ -104,7 +106,7 @@ class UserAlertEventsConsumerTest {
         ArgumentCaptor<UserAlertNotificationsPersistedEvent> eventCaptor =
                 ArgumentCaptor.forClass(UserAlertNotificationsPersistedEvent.class);
         then(applicationEventPublisher).should().publishEvent(eventCaptor.capture());
-        assertThat(eventCaptor.getValue().persistedNotifications()).containsExactly(first);
+        assertThat(eventCaptor.getValue().persistedNotifications()).containsExactly(persistedFirst);
 
         then(acknowledgment).should().acknowledge();
     }
@@ -116,7 +118,7 @@ class UserAlertEventsConsumerTest {
         UserAlertEvent event = event(303L, null, "evt-dup");
         Notification notification = notification(303L, "evt-dup");
         given(mapper.toNotification(event, 303L)).willReturn(notification);
-        given(notificationRepository.insertIfAbsent(notification)).willReturn(false);
+        given(notificationRepository.insertIfAbsent(notification)).willReturn(null);
 
         consumer.consume(event, acknowledgment);
 
@@ -167,9 +169,23 @@ class UserAlertEventsConsumerTest {
                 .subId(subId)
                 .eventId(eventId)
                 .notificationType("SINGLE_USAGE_THRESHOLD_30")
+                .title("Data alert")
                 .content("test")
                 .isRead(false)
                 .createdTime(LocalDateTime.of(2026, 2, 23, 10, 15, 30))
+                .build();
+    }
+
+    private Notification persistedNotification(Long id, Notification notification) {
+        return Notification.builder()
+                .id(id)
+                .subId(notification.getSubId())
+                .eventId(notification.getEventId())
+                .notificationType(notification.getNotificationType())
+                .title(notification.getTitle())
+                .content(notification.getContent())
+                .isRead(notification.getIsRead())
+                .createdTime(notification.getCreatedTime())
                 .build();
     }
 

--- a/src/test/java/hotspot/user/kafka/mapper/UserAlertEventNotificationMapperTest.java
+++ b/src/test/java/hotspot/user/kafka/mapper/UserAlertEventNotificationMapperTest.java
@@ -126,6 +126,7 @@ class UserAlertEventNotificationMapperTest {
         assertThat(notification.getSubId()).isEqualTo(101L);
         assertThat(notification.getEventId()).isEqualTo("evt-100");
         assertThat(notification.getNotificationType()).isEqualTo("SINGLE_USAGE_THRESHOLD_30");
+        assertThat(notification.getTitle()).isNotBlank();
         assertThat(notification.getContent()).contains("30%");
         assertThat(notification.getIsRead()).isFalse();
         assertThat(notification.getCreatedTime()).isEqualTo(LocalDateTime.of(2026, 2, 23, 10, 15, 30));

--- a/src/test/java/hotspot/user/notification/controller/NotificationControllerTest.java
+++ b/src/test/java/hotspot/user/notification/controller/NotificationControllerTest.java
@@ -67,6 +67,7 @@ class NotificationControllerTest {
                         .id(10L)
                         .eventId("evt-1")
                         .notificationType("ALERT")
+                        .title("Data alert")
                         .content("80% used")
                         .isRead(false)
                         .createdTime(LocalDateTime.of(2026, 2, 23, 12, 0))
@@ -87,6 +88,7 @@ class NotificationControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.notifications[0].id").value(10L))
                 .andExpect(jsonPath("$.data.notifications[0].eventId").value("evt-1"))
+                .andExpect(jsonPath("$.data.notifications[0].title").value("Data alert"))
                 .andExpect(jsonPath("$.data.totalElements").value(1));
 
         then(findNotificationService).should().findNotifications(eq(1L), isA(Pageable.class));

--- a/src/test/java/hotspot/user/notification/infrastructure/NotificationRepositoryImplTest.java
+++ b/src/test/java/hotspot/user/notification/infrastructure/NotificationRepositoryImplTest.java
@@ -6,7 +6,9 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -31,41 +33,57 @@ class NotificationRepositoryImplTest {
     private NotificationRepositoryImpl notificationRepository;
 
     @Test
-    @DisplayName("insertIfAbsent returns true when inserted")
+    @DisplayName("insertIfAbsent returns persisted notification when inserted")
     void insertIfAbsentInserted() {
         Notification notification = Notification.builder()
                 .subId(1L)
                 .eventId("evt-1")
                 .notificationType("ALERT")
+                .title("title")
                 .content("alert")
+                .createdTime(LocalDateTime.of(2026, 2, 23, 12, 0))
+                .build();
+        NotificationEntity persisted = NotificationEntity.builder()
+                .notificationId(10L)
+                .subscription(SubscriptionEntity.builder().subId(1L).build())
+                .eventId("evt-1")
+                .notificationType("ALERT")
+                .title("title")
+                .content("alert")
+                .isRead(false)
+                .createdTime(LocalDateTime.of(2026, 2, 23, 12, 0))
                 .build();
 
         given(notificationJpaRepository.insertIgnoreConflict(
-                eq(1L), eq("evt-1"), eq("ALERT"), eq("alert"), any()))
+                eq(1L), eq("evt-1"), eq("ALERT"), eq("title"), eq("alert"), any()))
                 .willReturn(1);
+        given(notificationJpaRepository.findByEventIdAndSubscriptionSubId("evt-1", 1L))
+                .willReturn(Optional.of(persisted));
 
-        boolean inserted = notificationRepository.insertIfAbsent(notification);
+        Notification inserted = notificationRepository.insertIfAbsent(notification);
 
-        assertThat(inserted).isTrue();
+        assertThat(inserted).isNotNull();
+        assertThat(inserted.getId()).isEqualTo(10L);
     }
 
     @Test
-    @DisplayName("insertIfAbsent returns false when duplicated")
+    @DisplayName("insertIfAbsent returns null when duplicated")
     void insertIfAbsentDuplicated() {
         Notification notification = Notification.builder()
                 .subId(1L)
                 .eventId("evt-1")
                 .notificationType("ALERT")
+                .title("title")
                 .content("alert")
                 .build();
 
         given(notificationJpaRepository.insertIgnoreConflict(
-                eq(1L), eq("evt-1"), eq("ALERT"), eq("alert"), any()))
+                eq(1L), eq("evt-1"), eq("ALERT"), eq("title"), eq("alert"), any()))
                 .willReturn(0);
 
-        boolean inserted = notificationRepository.insertIfAbsent(notification);
+        Notification inserted = notificationRepository.insertIfAbsent(notification);
 
-        assertThat(inserted).isFalse();
+        assertThat(inserted).isNull();
     }
 
     @Test
@@ -76,6 +94,7 @@ class NotificationRepositoryImplTest {
                 .subscription(SubscriptionEntity.builder().subId(1L).build())
                 .eventId("evt-1")
                 .notificationType("ALERT")
+                .title("title")
                 .content("alert")
                 .isRead(false)
                 .build();


### PR DESCRIPTION
## 🎫 지라 티켓

<!-- 지라 티켓을 작성해주세요 ex) HOTSPOT-123 -->
HOTSPOT-153

---

## 🔗 GitHub 이슈
<!-- 자동 close를 원하면 아래 형식으로 작성
예) Closes #12
-->
Closes #55 

---


## ✅ 작업 사항

<!-- 작업한 부분을 설명해주세요. -->
- SSE 구독 엔드포인트 추가 
  - GET /api/v1/sse/subscribe
- SSE 구독 서비스 구현 
  - 구독 등록, 초기 connected 이벤트 전송
- Emitter 정리 콜백 적용

- SseEmitterRegistry 구현
- Heartbeat 스케줄 전송 구현 및 @EnableScheduling 활성화
- 알림 저장 성공 후 후속 이벤트 발행/수신 연동 
- SsePushService에서 persisted 알림 기준 실시간 SSE 발송

- 알림 도메인/엔티티/조회 응답에 title 필드 추가
- 알림 저장 쿼리에 notification_title 반영
- Kafka 알림 매핑 시 title/body를 알림 모델로 반영

- Swagger 문서(dispatch/controller/swagger/SseApi) 추가
- 단위 테스트 추가/수정 (dispatch, kafka, notification)

---

## 📋 체크리스트

<!-- PR 제출 전 확인해주세요. 해당 항목에 [x]로 체크해주세요. -->

- [x] 코드가 정상적으로 빌드됩니다.
- [x] 관련 테스트 코드를 작성했습니다.
- [x] 기존 테스트가 모두 통과합니다.
- [x] 코드 스타일(Spotless, Checkstyle)을 준수합니다.
- [x] Jira 티켓 상태를 In Review / Done으로 변경했습니다.

---

## ⌨ 기타
