### PR TITLE
[HOTSPOT-159] 회원 탈퇴 API 구현

### DIFF
--- a/src/main/java/hotspot/user/auth/controller/AuthController.java
+++ b/src/main/java/hotspot/user/auth/controller/AuthController.java
@@ -19,6 +19,7 @@ import hotspot.user.auth.controller.port.WithdrawService;
 import hotspot.user.auth.controller.request.OnboardingRequest;
 import hotspot.user.auth.controller.request.TokenRequest;
 import hotspot.user.auth.controller.response.TokenResponse;
+import hotspot.user.auth.controller.swagger.AuthApi;
 import hotspot.user.common.ApiResponse;
 import hotspot.user.common.exception.ApplicationException;
 import hotspot.user.common.exception.code.AuthErrorCode;
@@ -30,13 +31,14 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/auth")
-public class AuthController {
+public class AuthController implements AuthApi {
     private final ReissueTokenService reissueTokenService;
     private final LogoutService logoutService;
     private final OnboardingService onboardingService;
     private final WithdrawService withdrawService;
     private final JwtProperties jwtProperties;
 
+    @Override
     @PostMapping("/reissue")
     public ResponseEntity<ApiResponse<TokenResponse>> reissue(
             @CookieValue(value = "refreshToken", required = false) String refreshToken) {
@@ -57,6 +59,7 @@ public class AuthController {
                 .body(ApiResponse.success(response));
     }
 
+    @Override
     @PostMapping("/onboarding")
     public ResponseEntity<ApiResponse<TokenResponse>> onboarding(@RequestBody @Valid OnboardingRequest request) {
         TokenResponse response = onboardingService.onboarding(request);
@@ -71,6 +74,7 @@ public class AuthController {
                 .body(ApiResponse.success(response));
     }
 
+    @Override
     @PostMapping("/logout")
     public ResponseEntity<ApiResponse<Void>> logout(
             @AuthenticationPrincipal PrincipalDetails principal,
@@ -89,6 +93,7 @@ public class AuthController {
                 .body(ApiResponse.success());
     }
 
+    @Override
     @PostMapping("/withdraw")
     public ResponseEntity<ApiResponse<Void>> withdraw(
             @AuthenticationPrincipal PrincipalDetails principal,

--- a/src/main/java/hotspot/user/auth/controller/AuthController.java
+++ b/src/main/java/hotspot/user/auth/controller/AuthController.java
@@ -85,7 +85,7 @@ public class AuthController implements AuthApi {
         }
 
         TokenRequest request = new TokenRequest(refreshToken);
-        logoutService.logout(principal.getId(), request); // 💡 memberId 전달
+        logoutService.logout(principal.getId(), request); //  memberId 전달
         ResponseCookie cookie = CookieUtil.deleteCookie("refreshToken");
 
         return ResponseEntity.ok()
@@ -104,7 +104,7 @@ public class AuthController implements AuthApi {
         }
 
         TokenRequest request = new TokenRequest(refreshToken);
-        withdrawService.withdraw(principal.getId(), request); // 💡 memberId 전달
+        withdrawService.withdraw(principal.getId(), request); //  memberId 전달
         ResponseCookie cookie = CookieUtil.deleteCookie("refreshToken");
 
         return ResponseEntity.ok()

--- a/src/main/java/hotspot/user/auth/controller/AuthController.java
+++ b/src/main/java/hotspot/user/auth/controller/AuthController.java
@@ -34,7 +34,7 @@ public class AuthController {
     private final ReissueTokenService reissueTokenService;
     private final LogoutService logoutService;
     private final OnboardingService onboardingService;
-    private final WithdrawService withdrawService; // 회원 탈퇴
+    private final WithdrawService withdrawService;
     private final JwtProperties jwtProperties;
 
     @PostMapping("/reissue")
@@ -73,6 +73,7 @@ public class AuthController {
 
     @PostMapping("/logout")
     public ResponseEntity<ApiResponse<Void>> logout(
+            @AuthenticationPrincipal PrincipalDetails principal,
             @CookieValue(value = "refreshToken", required = false) String refreshToken) {
 
         if (refreshToken == null) {
@@ -80,7 +81,7 @@ public class AuthController {
         }
 
         TokenRequest request = new TokenRequest(refreshToken);
-        logoutService.logout(request);
+        logoutService.logout(principal.getId(), request); // 💡 memberId 전달
         ResponseCookie cookie = CookieUtil.deleteCookie("refreshToken");
 
         return ResponseEntity.ok()
@@ -88,7 +89,6 @@ public class AuthController {
                 .body(ApiResponse.success());
     }
 
-    // 회원 탈퇴
     @PostMapping("/withdraw")
     public ResponseEntity<ApiResponse<Void>> withdraw(
             @AuthenticationPrincipal PrincipalDetails principal,
@@ -98,7 +98,8 @@ public class AuthController {
             throw new ApplicationException(AuthErrorCode.REFRESH_TOKEN_NOT_FOUND);
         }
 
-        withdrawService.withdraw(principal.getId());
+        TokenRequest request = new TokenRequest(refreshToken);
+        withdrawService.withdraw(principal.getId(), request); // 💡 memberId 전달
         ResponseCookie cookie = CookieUtil.deleteCookie("refreshToken");
 
         return ResponseEntity.ok()

--- a/src/main/java/hotspot/user/auth/controller/AuthController.java
+++ b/src/main/java/hotspot/user/auth/controller/AuthController.java
@@ -61,8 +61,10 @@ public class AuthController implements AuthApi {
 
     @Override
     @PostMapping("/onboarding")
-    public ResponseEntity<ApiResponse<TokenResponse>> onboarding(@RequestBody @Valid OnboardingRequest request) {
-        TokenResponse response = onboardingService.onboarding(request);
+    public ResponseEntity<ApiResponse<TokenResponse>> onboarding(
+            @AuthenticationPrincipal PrincipalDetails principal,
+            @RequestBody @Valid OnboardingRequest request) {
+        TokenResponse response = onboardingService.onboarding(principal.getId(), principal.getEmail(), request);
 
         // Refresh Token 쿠키 설정
         ResponseCookie cookie = CookieUtil.createCookie("refreshToken",

--- a/src/main/java/hotspot/user/auth/controller/AuthController.java
+++ b/src/main/java/hotspot/user/auth/controller/AuthController.java
@@ -5,6 +5,7 @@ import jakarta.validation.Valid;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -14,12 +15,14 @@ import org.springframework.web.bind.annotation.RestController;
 import hotspot.user.auth.controller.port.LogoutService;
 import hotspot.user.auth.controller.port.OnboardingService;
 import hotspot.user.auth.controller.port.ReissueTokenService;
+import hotspot.user.auth.controller.port.WithdrawService;
 import hotspot.user.auth.controller.request.OnboardingRequest;
 import hotspot.user.auth.controller.request.TokenRequest;
 import hotspot.user.auth.controller.response.TokenResponse;
 import hotspot.user.common.ApiResponse;
 import hotspot.user.common.exception.ApplicationException;
 import hotspot.user.common.exception.code.AuthErrorCode;
+import hotspot.user.common.security.PrincipalDetails;
 import hotspot.user.common.security.jwt.JwtProperties;
 import hotspot.user.common.util.CookieUtil;
 import lombok.RequiredArgsConstructor;
@@ -31,6 +34,7 @@ public class AuthController {
     private final ReissueTokenService reissueTokenService;
     private final LogoutService logoutService;
     private final OnboardingService onboardingService;
+    private final WithdrawService withdrawService; // 회원 탈퇴
     private final JwtProperties jwtProperties;
 
     @PostMapping("/reissue")
@@ -77,6 +81,24 @@ public class AuthController {
 
         TokenRequest request = new TokenRequest(refreshToken);
         logoutService.logout(request);
+        ResponseCookie cookie = CookieUtil.deleteCookie("refreshToken");
+
+        return ResponseEntity.ok()
+                .header(HttpHeaders.SET_COOKIE, cookie.toString())
+                .body(ApiResponse.success());
+    }
+
+    // 회원 탈퇴
+    @PostMapping("/withdraw")
+    public ResponseEntity<ApiResponse<Void>> withdraw(
+            @AuthenticationPrincipal PrincipalDetails principal,
+            @CookieValue(value = "refreshToken", required = false) String refreshToken) {
+
+        if (refreshToken == null) {
+            throw new ApplicationException(AuthErrorCode.REFRESH_TOKEN_NOT_FOUND);
+        }
+
+        withdrawService.withdraw(principal.getId());
         ResponseCookie cookie = CookieUtil.deleteCookie("refreshToken");
 
         return ResponseEntity.ok()

--- a/src/main/java/hotspot/user/auth/controller/port/LogoutService.java
+++ b/src/main/java/hotspot/user/auth/controller/port/LogoutService.java
@@ -3,8 +3,13 @@ package hotspot.user.auth.controller.port;
 import hotspot.user.auth.controller.request.TokenRequest;
 
 /**
- * 로그아웃
+ * 로그아웃 서비스 포트
  */
 public interface LogoutService {
-    void logout(TokenRequest request);
+    /**
+     * 로그아웃을 처리합니다. (토큰 삭제)
+     * @param memberId 현재 로그인한 유저의 ID
+     * @param request Refresh Token 정보를 담은 객체
+     */
+    void logout(Long memberId, TokenRequest request);
 }

--- a/src/main/java/hotspot/user/auth/controller/port/OnboardingService.java
+++ b/src/main/java/hotspot/user/auth/controller/port/OnboardingService.java
@@ -7,5 +7,5 @@ import hotspot.user.auth.controller.response.TokenResponse;
  * 온보딩 서비스
  */
 public interface OnboardingService {
-    TokenResponse onboarding(OnboardingRequest request);
+    TokenResponse onboarding(Long memberId, String email, OnboardingRequest request);
 }

--- a/src/main/java/hotspot/user/auth/controller/port/WithdrawService.java
+++ b/src/main/java/hotspot/user/auth/controller/port/WithdrawService.java
@@ -1,7 +1,5 @@
 package hotspot.user.auth.controller.port;
 
-import hotspot.user.auth.controller.request.TokenRequest;
-
 /**
  * 회원 탈퇴 서비스 포트
  */

--- a/src/main/java/hotspot/user/auth/controller/port/WithdrawService.java
+++ b/src/main/java/hotspot/user/auth/controller/port/WithdrawService.java
@@ -1,0 +1,14 @@
+package hotspot.user.auth.controller.port;
+
+import hotspot.user.auth.controller.request.TokenRequest;
+
+/**
+ * 회원 탈퇴 서비스 포트
+ */
+public interface WithdrawService {
+    /**
+     * 회원 탈퇴를 처리합니다. (토큰 삭제, 회선 연결 해제, 소셜 계정 삭제, 회원 삭제)
+     * @param memberId 탈퇴할 회원의 ID
+     */
+    void withdraw(Long memberId);
+}

--- a/src/main/java/hotspot/user/auth/controller/port/WithdrawService.java
+++ b/src/main/java/hotspot/user/auth/controller/port/WithdrawService.java
@@ -1,12 +1,16 @@
 package hotspot.user.auth.controller.port;
 
+import hotspot.user.auth.controller.request.TokenRequest;
+
 /**
  * 회원 탈퇴 서비스 포트
  */
 public interface WithdrawService {
+
     /**
-     * 회원 탈퇴를 처리합니다. (토큰 삭제, 회선 연결 해제, 소셜 계정 삭제, 회원 삭제)
-     * @param memberId 탈퇴할 회원의 ID
+     * 회원 탈퇴를 처리
+     * @param memberId
+     * @param request
      */
-    void withdraw(Long memberId);
+    void withdraw(Long memberId, TokenRequest request);
 }

--- a/src/main/java/hotspot/user/auth/controller/request/OnboardingRequest.java
+++ b/src/main/java/hotspot/user/auth/controller/request/OnboardingRequest.java
@@ -1,13 +1,18 @@
 package hotspot.user.auth.controller.request;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
 /**
- * 온보딩 request Dto
+ * 온보딩 request Dto되었습니다.
  */
 public record OnboardingRequest(
-        Long memberId,
-        String email,
+        @NotBlank(message = "전화번호는 필수입니다.")
+        @Pattern(regexp = "^01(?:0|1|[6-9])(?:\\d{3}|\\d{4})\\d{4}$", message = "올바른 전화번호 형식이 아닙니다.")
         String phoneNumber,
+
+        @NotBlank(message = "생년월일은 필수입니다.")
+        @Pattern(regexp = "^\\d{6}$", message = "생년월일은 6자리 숫자여야 합니다. (YYMMDD)")
         String birthDate
 ) {
-
 }

--- a/src/main/java/hotspot/user/auth/controller/request/OnboardingRequest.java
+++ b/src/main/java/hotspot/user/auth/controller/request/OnboardingRequest.java
@@ -4,7 +4,7 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 
 /**
- * 온보딩 request Dto되었습니다.
+ * 온보딩 request Dto
  */
 public record OnboardingRequest(
         @NotBlank(message = "전화번호는 필수입니다.")

--- a/src/main/java/hotspot/user/auth/controller/swagger/AuthApi.java
+++ b/src/main/java/hotspot/user/auth/controller/swagger/AuthApi.java
@@ -1,0 +1,69 @@
+package hotspot.user.auth.controller.swagger;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import hotspot.user.auth.controller.request.OnboardingRequest;
+import hotspot.user.auth.controller.response.TokenResponse;
+import hotspot.user.common.exception.ErrorResponse;
+import hotspot.user.common.security.PrincipalDetails;
+
+@Tag(name = "Auth", description = "인증/인가 관련 API")
+public interface AuthApi {
+
+    @Operation(summary = "토큰 재발급", description = "Refresh Token을 이용하여 새로운 Access Token과 Refresh Token을 발급합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "재발급 성공"),
+        @ApiResponse(responseCode = "401", description = "유효하지 않거나 만료된 Refresh Token",
+                content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "404", description = "Refresh Token 쿠키를 찾을 수 없음",
+                content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    ResponseEntity<hotspot.user.common.ApiResponse<TokenResponse>> reissue(
+            @Parameter(description = "Refresh Token (Cookie)", in = ParameterIn.COOKIE) String refreshToken);
+
+    @Operation(summary = "온보딩 (최초 가입 승인)", description = "소셜 가입 후 전화번호 인증 등을 거쳐 최종 회원 승인을 완료합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "온보딩 성공"),
+        @ApiResponse(responseCode = "400", description = "잘못된 요청 파라미터",
+                content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "404", description = "회선 정보를 찾을 수 없음",
+                content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    ResponseEntity<hotspot.user.common.ApiResponse<TokenResponse>> onboarding(
+            @Valid @RequestBody OnboardingRequest request);
+
+    @Operation(summary = "로그아웃", description = "Refresh Token을 무효화하고 로그아웃 처리합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "로그아웃 성공"),
+        @ApiResponse(responseCode = "401", description = "토큰 소유권 검증 실패",
+                content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "404", description = "Refresh Token 쿠키를 찾을 수 없음",
+                content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    ResponseEntity<hotspot.user.common.ApiResponse<Void>> logout(
+            @Parameter(hidden = true) @AuthenticationPrincipal PrincipalDetails principal,
+            @Parameter(description = "Refresh Token (Cookie)", in = ParameterIn.COOKIE) String refreshToken);
+
+    @Operation(summary = "회원 탈퇴", description = "사용자의 모든 정보를 삭제(논리 삭제)하고 서비스를 탈퇴합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "회원 탈퇴 성공"),
+        @ApiResponse(responseCode = "401", description = "토큰 소유권 검증 실패",
+                content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "404", description = "회원 정보를 찾을 수 없음",
+                content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    ResponseEntity<hotspot.user.common.ApiResponse<Void>> withdraw(
+            @Parameter(hidden = true) @AuthenticationPrincipal PrincipalDetails principal,
+            @Parameter(description = "Refresh Token (Cookie)", in = ParameterIn.COOKIE) String refreshToken);
+}

--- a/src/main/java/hotspot/user/auth/controller/swagger/AuthApi.java
+++ b/src/main/java/hotspot/user/auth/controller/swagger/AuthApi.java
@@ -42,6 +42,7 @@ public interface AuthApi {
                 content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     ResponseEntity<hotspot.user.common.ApiResponse<TokenResponse>> onboarding(
+            @Parameter(hidden = true) @AuthenticationPrincipal PrincipalDetails principal,
             @Valid @RequestBody OnboardingRequest request);
 
     @Operation(summary = "로그아웃", description = "Refresh Token을 무효화하고 로그아웃 처리합니다.")

--- a/src/main/java/hotspot/user/auth/controller/swagger/AuthApi.java
+++ b/src/main/java/hotspot/user/auth/controller/swagger/AuthApi.java
@@ -1,14 +1,7 @@
 package hotspot.user.auth.controller.swagger;
 
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.enums.ParameterIn;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -17,6 +10,14 @@ import hotspot.user.auth.controller.request.OnboardingRequest;
 import hotspot.user.auth.controller.response.TokenResponse;
 import hotspot.user.common.exception.ErrorResponse;
 import hotspot.user.common.security.PrincipalDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 
 @Tag(name = "Auth", description = "인증/인가 관련 API")
 public interface AuthApi {

--- a/src/main/java/hotspot/user/auth/service/LogoutServiceImpl.java
+++ b/src/main/java/hotspot/user/auth/service/LogoutServiceImpl.java
@@ -6,6 +6,8 @@ import org.springframework.transaction.annotation.Transactional;
 import hotspot.user.auth.controller.port.LogoutService;
 import hotspot.user.auth.controller.request.TokenRequest;
 import hotspot.user.auth.service.port.TokenRepository;
+import hotspot.user.common.exception.ApplicationException;
+import hotspot.user.common.exception.code.AuthErrorCode;
 import hotspot.user.common.security.PrincipalDetails;
 import hotspot.user.common.security.jwt.JwtProvider;
 import lombok.RequiredArgsConstructor;
@@ -15,18 +17,27 @@ import lombok.RequiredArgsConstructor;
 @Transactional
 public class LogoutServiceImpl implements LogoutService {
 
-    private final JwtProvider jwtProvider;
     private final TokenRepository tokenRepository;
+    private final JwtProvider jwtProvider;
 
     @Override
-    public void logout(TokenRequest request) {
+    public void logout(Long memberId, TokenRequest request) {
         String refreshToken = request.refreshToken();
 
-        if (jwtProvider.validateToken(refreshToken)) {
-            // Refresh Token용 메서드를 사용하여 안전하게 사용자 정보 추출
-            PrincipalDetails principal = (PrincipalDetails) jwtProvider.getAuthenticationFromRefreshToken(refreshToken)
-                    .getPrincipal();
-            tokenRepository.deleteByMemberId(principal.getId());
+        // 1. 토큰 유효성 검증
+        if (!jwtProvider.validateToken(refreshToken)) {
+            throw new ApplicationException(AuthErrorCode.INVALID_TOKEN);
         }
+
+        // 2. 토큰에서 사용자 정보 추출 및 소유권 검증
+        PrincipalDetails principal = (PrincipalDetails) jwtProvider.getAuthenticationFromRefreshToken(refreshToken)
+                .getPrincipal();
+
+        if (!memberId.equals(principal.getId())) {
+            throw new ApplicationException(AuthErrorCode.INVALID_TOKEN);
+        }
+
+        // 3. 토큰 삭제 (무효화)
+        tokenRepository.deleteByMemberId(memberId);
     }
 }

--- a/src/main/java/hotspot/user/auth/service/OnboardingServiceImpl.java
+++ b/src/main/java/hotspot/user/auth/service/OnboardingServiceImpl.java
@@ -36,10 +36,10 @@ public class OnboardingServiceImpl implements OnboardingService {
     private final PhoneHashIndexer phoneHashIndexer;
 
     @Override
-    public TokenResponse onboarding(OnboardingRequest request) {
+    public TokenResponse onboarding(Long memberId, String email, OnboardingRequest request) {
         // 1. 데이터 조회 및 회선 검증
         Subscription subscription = validateAndGetSubscription(request.phoneNumber());
-        Member pendingMember = findPendingMember(request.memberId());
+        Member pendingMember = findPendingMember(memberId);
         SocialAccount socialAccount = findSocialAccount(pendingMember.getId());
 
         // 2. 신규 승인 또는 기존 회원 통합 처리
@@ -49,7 +49,7 @@ public class OnboardingServiceImpl implements OnboardingService {
         FamilySubscription familySub = getFamilySubscription(subscription.getId());
 
         // 4. 토큰 발급 (가족 ID 포함)
-        return issueTokenService.issue(finalMember, socialAccount.getEmail(),
+        return issueTokenService.issue(finalMember, email,
                 familySub.getFamilyRole(), familySub.getFamily().getId());
     }
 

--- a/src/main/java/hotspot/user/auth/service/WithdrawServiceImpl.java
+++ b/src/main/java/hotspot/user/auth/service/WithdrawServiceImpl.java
@@ -1,0 +1,56 @@
+package hotspot.user.auth.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import hotspot.user.auth.controller.port.WithdrawService;
+
+import hotspot.user.auth.service.port.TokenRepository;
+
+import hotspot.user.member.service.port.MemberRepository;
+import hotspot.user.member.service.port.SocialAccountRepository;
+import hotspot.user.subscription.domain.Subscription;
+import hotspot.user.subscription.service.port.SubscriptionRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class WithdrawServiceImpl implements WithdrawService {
+
+    private final MemberRepository memberRepository;
+    private final SocialAccountRepository socialAccountRepository;
+    private final SubscriptionRepository subscriptionRepository;
+    private final TokenRepository tokenRepository;
+
+    @Override
+    public void withdraw(Long memberId) {
+        log.info("회원 탈퇴 프로세스 시작: memberId={}", memberId);
+
+        // 1. 토큰 데이터 삭제 (Redis 또는 DB의 Refresh Token 무효화)
+        tokenRepository.deleteByMemberId(memberId);
+
+        // 2. 회선 정보에서 memberId 해제 (Subscription 업데이트)
+        subscriptionRepository.findByMemberId(memberId).ifPresent(subscription -> {
+            Subscription updatedSubscription = subscription.updateMember(null);
+            subscriptionRepository.save(updatedSubscription);
+            log.debug("회선 연결 해제 완료: subId={}", subscription.getId());
+        });
+
+        // 3. 소셜 계정 정보 삭제 (SocialAccount)
+        socialAccountRepository.findByMemberId(memberId).ifPresent(socialAccount -> {
+            socialAccountRepository.delete(socialAccount);
+            log.debug("소셜 계정 정보 삭제 완료: memberId={}", memberId);
+        });
+
+        // 4. 회원 정보 최종 삭제 (Member)
+        memberRepository.findById(memberId).ifPresent(member -> {
+            memberRepository.delete(member);
+            log.info("회원 데이터 최종 삭제 완료: memberId={}", memberId);
+        });
+
+        log.info("회원 탈퇴 프로세스 종료: memberId={}", memberId);
+    }
+}

--- a/src/main/java/hotspot/user/auth/service/WithdrawServiceImpl.java
+++ b/src/main/java/hotspot/user/auth/service/WithdrawServiceImpl.java
@@ -1,5 +1,6 @@
 package hotspot.user.auth.service;
 
+import hotspot.user.member.domain.Member;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -8,6 +9,7 @@ import hotspot.user.auth.controller.request.TokenRequest;
 import hotspot.user.auth.service.port.TokenRepository;
 import hotspot.user.common.exception.ApplicationException;
 import hotspot.user.common.exception.code.AuthErrorCode;
+import hotspot.user.common.exception.code.MemberErrorCode;
 import hotspot.user.common.security.PrincipalDetails;
 import hotspot.user.common.security.jwt.JwtProvider;
 import hotspot.user.member.service.port.MemberRepository;
@@ -32,14 +34,19 @@ public class WithdrawServiceImpl implements WithdrawService {
     @Override
     public void withdraw(Long memberId, TokenRequest request) {
         log.info("회원 탈퇴 프로세스 시작: memberId={}", memberId);
+
+        // 1. 회원 존재 여부 확인
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new ApplicationException(MemberErrorCode.MEMBER_NOT_FOUND));
+
         String refreshToken = request.refreshToken();
 
-        // 1. 토큰 유효성 검증
+        // 2. 토큰 유효성 검증
         if (!jwtProvider.validateToken(refreshToken)) {
             throw new ApplicationException(AuthErrorCode.INVALID_TOKEN);
         }
 
-        // 2. 토큰에서 사용자 정보 추출 및 소유권 검증
+        // 3. 토큰에서 사용자 정보 추출 및 소유권 검증
         PrincipalDetails principal = (PrincipalDetails) jwtProvider.getAuthenticationFromRefreshToken(refreshToken)
                 .getPrincipal();
 
@@ -48,20 +55,20 @@ public class WithdrawServiceImpl implements WithdrawService {
             throw new ApplicationException(AuthErrorCode.INVALID_TOKEN);
         }
 
-        // 3. 토큰 데이터 삭제
+        // 4. 토큰 데이터 삭제
         tokenRepository.deleteByMemberId(memberId);
 
-        // 4. 회선 정보에서 memberId 해제
+        // 5. 회선 정보에서 memberId 해제
         subscriptionRepository.findByMemberId(memberId).ifPresent(subscription -> {
             Subscription updatedSubscription = subscription.updateMember(null);
             subscriptionRepository.save(updatedSubscription);
         });
 
-        // 5. 소셜 계정 정보 삭제
+        // 6. 소셜 계정 정보 삭제
         socialAccountRepository.deleteByMemberId(memberId);
 
-        // 6. 회원 정보 최종 삭제
-        memberRepository.findById(memberId).ifPresent(memberRepository::delete);
+        // 7. 회원 정보 최종 삭제
+        memberRepository.delete(member);
 
         log.info("회원 탈퇴 프로세스 완료: memberId={}", memberId);
     }

--- a/src/main/java/hotspot/user/auth/service/WithdrawServiceImpl.java
+++ b/src/main/java/hotspot/user/auth/service/WithdrawServiceImpl.java
@@ -4,7 +4,12 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import hotspot.user.auth.controller.port.WithdrawService;
+import hotspot.user.auth.controller.request.TokenRequest;
 import hotspot.user.auth.service.port.TokenRepository;
+import hotspot.user.common.exception.ApplicationException;
+import hotspot.user.common.exception.code.AuthErrorCode;
+import hotspot.user.common.security.PrincipalDetails;
+import hotspot.user.common.security.jwt.JwtProvider;
 import hotspot.user.member.service.port.MemberRepository;
 import hotspot.user.member.service.port.SocialAccountRepository;
 import hotspot.user.subscription.domain.Subscription;
@@ -22,33 +27,42 @@ public class WithdrawServiceImpl implements WithdrawService {
     private final SocialAccountRepository socialAccountRepository;
     private final SubscriptionRepository subscriptionRepository;
     private final TokenRepository tokenRepository;
+    private final JwtProvider jwtProvider;
 
     @Override
-    public void withdraw(Long memberId) {
+    public void withdraw(Long memberId, TokenRequest request) {
         log.info("회원 탈퇴 프로세스 시작: memberId={}", memberId);
+        String refreshToken = request.refreshToken();
 
-        // 1. 토큰 데이터 삭제 (Redis 또는 DB의 Refresh Token 무효화)
+        // 1. 토큰 유효성 검증
+        if (!jwtProvider.validateToken(refreshToken)) {
+            throw new ApplicationException(AuthErrorCode.INVALID_TOKEN);
+        }
+
+        // 2. 토큰에서 사용자 정보 추출 및 소유권 검증
+        PrincipalDetails principal = (PrincipalDetails) jwtProvider.getAuthenticationFromRefreshToken(refreshToken)
+                .getPrincipal();
+
+        if (!memberId.equals(principal.getId())) {
+            log.warn("탈퇴 시도 보안 경고: 요청자 memberId={}와 토큰 소유자 memberId={} 불일치", memberId, principal.getId());
+            throw new ApplicationException(AuthErrorCode.INVALID_TOKEN);
+        }
+
+        // 3. 토큰 데이터 삭제
         tokenRepository.deleteByMemberId(memberId);
 
-        // 2. 회선 정보에서 memberId 해제 (Subscription 업데이트)
+        // 4. 회선 정보에서 memberId 해제
         subscriptionRepository.findByMemberId(memberId).ifPresent(subscription -> {
             Subscription updatedSubscription = subscription.updateMember(null);
             subscriptionRepository.save(updatedSubscription);
-            log.debug("회선 연결 해제 완료: subId={}", subscription.getId());
         });
 
-        // 3. 소셜 계정 정보 삭제 (SocialAccount)
-        socialAccountRepository.findByMemberId(memberId).ifPresent(socialAccount -> {
-            socialAccountRepository.deleteByMemberId(socialAccount.getMemberId());
-            log.debug("소셜 계정 정보 삭제 완료: memberId={}", memberId);
-        });
+        // 5. 소셜 계정 정보 삭제
+        socialAccountRepository.deleteByMemberId(memberId);
 
-        // 4. 회원 정보 최종 삭제 (Member)
-        memberRepository.findById(memberId).ifPresent(member -> {
-            memberRepository.deleteById(member.getId());
-            log.info("회원 데이터 최종 삭제 완료: memberId={}", memberId);
-        });
+        // 6. 회원 정보 최종 삭제
+        memberRepository.findById(memberId).ifPresent(memberRepository::delete);
 
-        log.info("회원 탈퇴 프로세스 종료: memberId={}", memberId);
+        log.info("회원 탈퇴 프로세스 완료: memberId={}", memberId);
     }
 }

--- a/src/main/java/hotspot/user/auth/service/WithdrawServiceImpl.java
+++ b/src/main/java/hotspot/user/auth/service/WithdrawServiceImpl.java
@@ -4,9 +4,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import hotspot.user.auth.controller.port.WithdrawService;
-
 import hotspot.user.auth.service.port.TokenRepository;
-
 import hotspot.user.member.service.port.MemberRepository;
 import hotspot.user.member.service.port.SocialAccountRepository;
 import hotspot.user.subscription.domain.Subscription;
@@ -41,13 +39,13 @@ public class WithdrawServiceImpl implements WithdrawService {
 
         // 3. 소셜 계정 정보 삭제 (SocialAccount)
         socialAccountRepository.findByMemberId(memberId).ifPresent(socialAccount -> {
-            socialAccountRepository.delete(socialAccount);
+            socialAccountRepository.deleteByMemberId(socialAccount.getMemberId());
             log.debug("소셜 계정 정보 삭제 완료: memberId={}", memberId);
         });
 
         // 4. 회원 정보 최종 삭제 (Member)
         memberRepository.findById(memberId).ifPresent(member -> {
-            memberRepository.delete(member);
+            memberRepository.deleteById(member.getId());
             log.info("회원 데이터 최종 삭제 완료: memberId={}", memberId);
         });
 

--- a/src/main/java/hotspot/user/auth/service/WithdrawServiceImpl.java
+++ b/src/main/java/hotspot/user/auth/service/WithdrawServiceImpl.java
@@ -1,6 +1,5 @@
 package hotspot.user.auth.service;
 
-import hotspot.user.member.domain.Member;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -12,6 +11,7 @@ import hotspot.user.common.exception.code.AuthErrorCode;
 import hotspot.user.common.exception.code.MemberErrorCode;
 import hotspot.user.common.security.PrincipalDetails;
 import hotspot.user.common.security.jwt.JwtProvider;
+import hotspot.user.member.domain.Member;
 import hotspot.user.member.service.port.MemberRepository;
 import hotspot.user.member.service.port.SocialAccountRepository;
 import hotspot.user.subscription.domain.Subscription;

--- a/src/main/java/hotspot/user/common/config/SecurityConfig.java
+++ b/src/main/java/hotspot/user/common/config/SecurityConfig.java
@@ -50,9 +50,9 @@ public class SecurityConfig {
         http.authorizeHttpRequests(auth -> auth
                 .requestMatchers(
                         "/", "/health", "/login/**", "/oauth2/**", "/oauth/**",
-                        "/swagger-ui/**", "/v3/api-docs/**", "/actuator/health",
-                        "/api/v1/auth/onboarding",
-                        "/api/v1/**" // 테스트 위해서 모든 API 열어둠 [To-Do] 삭제 필요
+                        "/swagger-ui/**", "/swagger-ui.html", "/v3/api-docs/**",
+                        "/actuator/health",
+                        "/api/v1/auth/onboarding", "/api/v1/auth/reissue"
                 ).permitAll()
                 .anyRequest().authenticated()
         );

--- a/src/main/java/hotspot/user/common/config/SecurityConfig.java
+++ b/src/main/java/hotspot/user/common/config/SecurityConfig.java
@@ -52,7 +52,7 @@ public class SecurityConfig {
                         "/", "/health", "/login/**", "/oauth2/**", "/oauth/**",
                         "/swagger-ui/**", "/swagger-ui.html", "/v3/api-docs/**",
                         "/actuator/health",
-                        "/api/v1/auth/onboarding", "/api/v1/auth/reissue"
+                        "/api/v1/auth/reissue"
                 ).permitAll()
                 .anyRequest().authenticated()
         );

--- a/src/main/java/hotspot/user/common/config/SecurityConfig.java
+++ b/src/main/java/hotspot/user/common/config/SecurityConfig.java
@@ -54,6 +54,10 @@ public class SecurityConfig {
                         "/actuator/health",
                         "/api/v1/auth/reissue"
                 ).permitAll()
+                // 온보딩 API는 PENDING 상태의 유저만 접근 가능하도록 보호 (임시 토큰 필요)
+                .requestMatchers("/api/v1/auth/onboarding").hasAuthority("PENDING")
+                // 나머지 비즈니스 API는 반드시 APPROVED 상태의 유저만 접근 가능
+                .requestMatchers("/api/v1/**").hasAuthority("APPROVED")
                 .anyRequest().authenticated()
         );
 

--- a/src/main/java/hotspot/user/common/security/jwt/JwtProperties.java
+++ b/src/main/java/hotspot/user/common/security/jwt/JwtProperties.java
@@ -13,4 +13,5 @@ public class JwtProperties {
     private final String secret;
     private final Long accessExpiration;
     private final Long refreshExpiration;
+    private final Long onboardingExpiration;
 }

--- a/src/main/java/hotspot/user/common/security/jwt/JwtProvider.java
+++ b/src/main/java/hotspot/user/common/security/jwt/JwtProvider.java
@@ -57,6 +57,12 @@ public class JwtProvider {
                 ACCESS_TOKEN_TYPE);
     }
 
+    public String createOnboardingToken(Authentication authentication) {
+        PrincipalDetails principal = (PrincipalDetails) authentication.getPrincipal();
+        return createToken(authentication, principal, jwtProperties.getOnboardingExpiration(),
+                ACCESS_TOKEN_TYPE);
+    }
+
     public String createRefreshToken(Authentication authentication) {
         PrincipalDetails principal = (PrincipalDetails) authentication.getPrincipal();
         return createToken(authentication, principal, jwtProperties.getRefreshExpiration(),

--- a/src/main/java/hotspot/user/common/security/oauth/OAuth2SuccessHandler.java
+++ b/src/main/java/hotspot/user/common/security/oauth/OAuth2SuccessHandler.java
@@ -54,10 +54,11 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         // 사용자 상태에 따라 처리 로직 분기
         String targetUrl;
 
-        // 온보딩으로 리다이렉트 (토큰 발급 X)
+        // 온보딩으로 리다이렉트 (임시 토큰 발급)
         if (principal.getStatus() == Status.PENDING) {
-            log.info("신규 사용자, 온보딩 페이지로 리다이렉트: memberId={}, email={}", principal.getId(), principal.getEmail());
-            targetUrl = determineOnboardingUrl(principal);
+            log.info("신규 사용자, 온보딩 페이지로 리다이렉트: memberId={}", principal.getId());
+            String accessToken = jwtProvider.createAccessToken(authentication);
+            targetUrl = determineOnboardingUrl(principal, accessToken);
         }
 
         // 바로 로그인 (토큰 발급 O)
@@ -80,11 +81,11 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         getRedirectStrategy().sendRedirect(request, response, targetUrl);
     }
 
-    private String determineOnboardingUrl(PrincipalDetails principal) {
+    private String determineOnboardingUrl(PrincipalDetails principal, String accessToken) {
         String baseUri = redirectUri + "/" + onboardingRedirectUri;
         return UriComponentsBuilder.fromUriString(baseUri)
                 .queryParam("memberId", principal.getId())
-                .queryParam("email", principal.getEmail())
+                .queryParam("accessToken", accessToken)
                 .build().toUriString();
     }
 

--- a/src/main/java/hotspot/user/common/security/oauth/OAuth2SuccessHandler.java
+++ b/src/main/java/hotspot/user/common/security/oauth/OAuth2SuccessHandler.java
@@ -57,7 +57,7 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         // 온보딩으로 리다이렉트 (임시 토큰 발급)
         if (principal.getStatus() == Status.PENDING) {
             log.info("신규 사용자, 온보딩 페이지로 리다이렉트: memberId={}", principal.getId());
-            String accessToken = jwtProvider.createAccessToken(authentication);
+            String accessToken = jwtProvider.createOnboardingToken(authentication);
             targetUrl = determineOnboardingUrl(principal, accessToken);
         }
 

--- a/src/main/java/hotspot/user/member/infrastructure/SocialAccountJpaRepository.java
+++ b/src/main/java/hotspot/user/member/infrastructure/SocialAccountJpaRepository.java
@@ -7,7 +7,6 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
-import org.springframework.transaction.annotation.Transactional;
 
 import hotspot.user.member.infrastructure.entity.SocialAccountEntity;
 

--- a/src/main/java/hotspot/user/member/infrastructure/SocialAccountJpaRepository.java
+++ b/src/main/java/hotspot/user/member/infrastructure/SocialAccountJpaRepository.java
@@ -22,7 +22,6 @@ public interface SocialAccountJpaRepository extends JpaRepository<SocialAccountE
 
     // Soft Delete
     @Modifying
-    @Transactional
     @Query("UPDATE SocialAccountEntity sa SET sa.isDeleted = true WHERE sa.member.id = :memberId")
     void deleteByMemberId(@Param("memberId") Long memberId);
 }

--- a/src/main/java/hotspot/user/member/infrastructure/SocialAccountJpaRepository.java
+++ b/src/main/java/hotspot/user/member/infrastructure/SocialAccountJpaRepository.java
@@ -3,9 +3,11 @@ package hotspot.user.member.infrastructure;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 import hotspot.user.member.infrastructure.entity.SocialAccountEntity;
 
@@ -18,5 +20,9 @@ public interface SocialAccountJpaRepository extends JpaRepository<SocialAccountE
 
     Optional<SocialAccountEntity> findByMemberId(Long memberId);
 
-    void deleteByMemberId(Long memberId);
+    // Soft Delete
+    @Modifying
+    @Transactional
+    @Query("UPDATE SocialAccountEntity sa SET sa.isDeleted = true WHERE sa.member.id = :memberId")
+    void deleteByMemberId(@Param("memberId") Long memberId);
 }

--- a/src/main/java/hotspot/user/member/infrastructure/SocialAccountJpaRepository.java
+++ b/src/main/java/hotspot/user/member/infrastructure/SocialAccountJpaRepository.java
@@ -17,4 +17,6 @@ public interface SocialAccountJpaRepository extends JpaRepository<SocialAccountE
     Optional<SocialAccountEntity> findByEmailWithMember(@Param("email") String email);
 
     Optional<SocialAccountEntity> findByMemberId(Long memberId);
+
+    void deleteByMemberId(Long memberId);
 }

--- a/src/main/java/hotspot/user/member/infrastructure/SocialAccountRepositoryImpl.java
+++ b/src/main/java/hotspot/user/member/infrastructure/SocialAccountRepositoryImpl.java
@@ -21,7 +21,6 @@ public class SocialAccountRepositoryImpl implements SocialAccountRepository {
 
     @Override
     public SocialAccount save(SocialAccount socialAccount) {
-        // SocialAccountEntity 생성을 위해 MemberEntity 조회가 필요함 (JPA 연관관계 때문)
         MemberEntity memberEntity = memberJpaRepository.findById(socialAccount.getMemberId())
                 .orElseThrow(() -> new ApplicationException(MemberErrorCode.MEMBER_NOT_FOUND));
 
@@ -39,5 +38,18 @@ public class SocialAccountRepositoryImpl implements SocialAccountRepository {
     public Optional<SocialAccount> findByEmail(String email) {
         return socialAccountJpaRepository.findByEmail(email)
                 .map(SocialAccountEntity::entityToDomain);
+    }
+
+    @Override
+    public void delete(SocialAccount socialAccount) {
+        MemberEntity memberEntity = memberJpaRepository.findById(socialAccount.getMemberId())
+                .orElseThrow(() -> new ApplicationException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+        socialAccountJpaRepository.delete(SocialAccountEntity.domainToEntity(socialAccount, memberEntity));
+    }
+
+    @Override
+    public void deleteByMemberId(Long memberId) {
+        socialAccountJpaRepository.deleteByMemberId(memberId);
     }
 }

--- a/src/main/java/hotspot/user/member/infrastructure/entity/MemberEntity.java
+++ b/src/main/java/hotspot/user/member/infrastructure/entity/MemberEntity.java
@@ -31,7 +31,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Table(name = "member")
-@SQLDelete(sql = "UPDATE member SET is_deleted = true WHERE id = ?")
+@SQLDelete(sql = "UPDATE member SET is_deleted = true WHERE member_id = ?")
 @Where(clause = "is_deleted = false")
 public class MemberEntity extends BaseEntity {
 

--- a/src/main/java/hotspot/user/member/infrastructure/entity/MemberEntity.java
+++ b/src/main/java/hotspot/user/member/infrastructure/entity/MemberEntity.java
@@ -31,11 +31,12 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Table(name = "member")
-@SQLDelete(sql = "UPDATE member SET is_deleted = true WHERE id = ?")
+@SQLDelete(sql = "UPDATE member SET is_deleted = true WHERE member_id = ?")
 @Where(clause = "is_deleted = false")
 public class MemberEntity extends BaseEntity {
 
     @Id
+    @Column(name = "member_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 

--- a/src/main/java/hotspot/user/member/infrastructure/entity/MemberEntity.java
+++ b/src/main/java/hotspot/user/member/infrastructure/entity/MemberEntity.java
@@ -36,6 +36,7 @@ import lombok.NoArgsConstructor;
 public class MemberEntity extends BaseEntity {
 
     @Id
+    @Column(name = "member_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 

--- a/src/main/java/hotspot/user/member/infrastructure/entity/SocialAccountEntity.java
+++ b/src/main/java/hotspot/user/member/infrastructure/entity/SocialAccountEntity.java
@@ -38,6 +38,7 @@ import lombok.NoArgsConstructor;
 public class SocialAccountEntity extends BaseEntity {
 
     @Id
+    @Column(name = "social_account_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 

--- a/src/main/java/hotspot/user/member/infrastructure/entity/SocialAccountEntity.java
+++ b/src/main/java/hotspot/user/member/infrastructure/entity/SocialAccountEntity.java
@@ -33,7 +33,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Table(name = "social_account")
-@SQLDelete(sql = "UPDATE social_account SET is_deleted = true WHERE id = ?")
+@SQLDelete(sql = "UPDATE social_account SET is_deleted = true WHERE social_account_id = ?")
 @Where(clause = "is_deleted = false")
 public class SocialAccountEntity extends BaseEntity {
 

--- a/src/main/java/hotspot/user/member/infrastructure/entity/SocialAccountEntity.java
+++ b/src/main/java/hotspot/user/member/infrastructure/entity/SocialAccountEntity.java
@@ -33,11 +33,12 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Table(name = "social_account")
-@SQLDelete(sql = "UPDATE social_account SET is_deleted = true WHERE id = ?")
+@SQLDelete(sql = "UPDATE social_account SET is_deleted = true WHERE social_account_id = ?")
 @Where(clause = "is_deleted = false")
 public class SocialAccountEntity extends BaseEntity {
 
     @Id
+    @Column(name = "social_account_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 

--- a/src/main/java/hotspot/user/member/service/port/SocialAccountRepository.java
+++ b/src/main/java/hotspot/user/member/service/port/SocialAccountRepository.java
@@ -8,4 +8,6 @@ public interface SocialAccountRepository {
     SocialAccount save(SocialAccount socialAccount);
     Optional<SocialAccount> findByMemberId(Long memberId);
     Optional<SocialAccount> findByEmail(String email);
+    void delete(SocialAccount socialAccount);
+    void deleteByMemberId(Long memberId);
 }

--- a/src/main/resources/jwt.yml
+++ b/src/main/resources/jwt.yml
@@ -2,3 +2,4 @@ jwt:
   secret: ${JWT_SECRET}
   access-expiration: ${JWT_ACCESS_EXPIRATION}
   refresh-expiration: ${JWT_REFRESH_EXPIRATION}
+  onboarding-expiration: ${JWT_ONBOARDING_EXPIRATION}

--- a/src/test/java/hotspot/user/auth/controller/AuthControllerTest.java
+++ b/src/test/java/hotspot/user/auth/controller/AuthControllerTest.java
@@ -2,6 +2,7 @@ package hotspot.user.auth.controller;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
@@ -123,10 +124,11 @@ class AuthControllerTest {
     @Test
     @DisplayName("온보딩(onboarding) 성공 시 AccessToken과 RefreshToken 쿠키를 반환한다")
     void onboardingSuccess() throws Exception {
-        OnboardingRequest request = new OnboardingRequest(MEMBER_ID, "test@email.com", "01012345678", "900101");
+        OnboardingRequest request = new OnboardingRequest("01012345678", "900101");
         TokenResponse mockResponse = new TokenResponse(ACCESS_TOKEN, REFRESH_TOKEN);
 
-        given(onboardingService.onboarding(any(OnboardingRequest.class))).willReturn(mockResponse);
+        given(onboardingService.onboarding(anyLong(), anyString(), any(OnboardingRequest.class)))
+                .willReturn(mockResponse);
 
         mockMvc.perform(post("/api/v1/auth/onboarding")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -143,7 +145,7 @@ class AuthControllerTest {
     @DisplayName("로그아웃(logout) 성공 시 RefreshToken 쿠키를 삭제(Max-Age=0)해야 한다")
     void logoutSuccess() throws Exception {
         Cookie requestCookie = new Cookie("refreshToken", REFRESH_TOKEN);
-        doNothing().when(logoutService).logout(anyLong(), any(TokenRequest.class)); //  시그니처 수정
+        doNothing().when(logoutService).logout(anyLong(), any(TokenRequest.class));
 
         mockMvc.perform(post("/api/v1/auth/logout")
                         .cookie(requestCookie))

--- a/src/test/java/hotspot/user/auth/controller/AuthControllerTest.java
+++ b/src/test/java/hotspot/user/auth/controller/AuthControllerTest.java
@@ -1,6 +1,7 @@
 package hotspot.user.auth.controller;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
@@ -23,6 +24,8 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.web.servlet.MockMvc;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -30,12 +33,16 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import hotspot.user.auth.controller.port.LogoutService;
 import hotspot.user.auth.controller.port.OnboardingService;
 import hotspot.user.auth.controller.port.ReissueTokenService;
+import hotspot.user.auth.controller.port.WithdrawService;
 import hotspot.user.auth.controller.request.OnboardingRequest;
 import hotspot.user.auth.controller.request.TokenRequest;
 import hotspot.user.auth.controller.response.TokenResponse;
+import hotspot.user.common.security.PrincipalDetails;
 import hotspot.user.common.security.jwt.JwtFilter;
 import hotspot.user.common.security.jwt.JwtProperties;
 import hotspot.user.common.security.jwt.JwtProvider;
+import hotspot.user.member.domain.FamilyRole;
+import hotspot.user.member.domain.Status;
 
 @WebMvcTest(AuthController.class)
 @AutoConfigureMockMvc(addFilters = false)
@@ -57,6 +64,9 @@ class AuthControllerTest {
     private OnboardingService onboardingService;
 
     @MockBean
+    private WithdrawService withdrawService; //  추가
+
+    @MockBean
     private JwtProperties jwtProperties;
 
     @MockBean
@@ -65,17 +75,30 @@ class AuthControllerTest {
     @MockBean
     private JwtProvider jwtProvider;
 
-    // JPA Auditing 에러 방지용 Mock Bean 추가
     @MockBean
     private JpaMetamodelMappingContext jpaMetamodelMappingContext;
 
     private static final String ACCESS_TOKEN = "access-token-example";
     private static final String REFRESH_TOKEN = "refresh-token-example";
     private static final long COOKIE_EXPIRATION = 604800000L;
+    private static final Long MEMBER_ID = 1L;
 
     @BeforeEach
     void setUp() {
         given(jwtProperties.getRefreshExpiration()).willReturn(COOKIE_EXPIRATION);
+
+        // PrincipalDetails Mocking 설정 (SecurityContext에 저장)
+        PrincipalDetails principal = new PrincipalDetails(
+                MEMBER_ID,
+                "test@email.com",
+                100L,
+                FamilyRole.PARENT, Status.APPROVED);
+
+        UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(
+                principal,
+                null,
+                principal.getAuthorities());
+        SecurityContextHolder.getContext().setAuthentication(auth);
     }
 
     @Test
@@ -100,7 +123,7 @@ class AuthControllerTest {
     @Test
     @DisplayName("온보딩(onboarding) 성공 시 AccessToken과 RefreshToken 쿠키를 반환한다")
     void onboardingSuccess() throws Exception {
-        OnboardingRequest request = createDummyOnboardingRequest();
+        OnboardingRequest request = new OnboardingRequest(MEMBER_ID, "test@email.com", "01012345678", "900101");
         TokenResponse mockResponse = new TokenResponse(ACCESS_TOKEN, REFRESH_TOKEN);
 
         given(onboardingService.onboarding(any(OnboardingRequest.class))).willReturn(mockResponse);
@@ -120,7 +143,7 @@ class AuthControllerTest {
     @DisplayName("로그아웃(logout) 성공 시 RefreshToken 쿠키를 삭제(Max-Age=0)해야 한다")
     void logoutSuccess() throws Exception {
         Cookie requestCookie = new Cookie("refreshToken", REFRESH_TOKEN);
-        doNothing().when(logoutService).logout(any(TokenRequest.class));
+        doNothing().when(logoutService).logout(anyLong(), any(TokenRequest.class)); //  시그니처 수정
 
         mockMvc.perform(post("/api/v1/auth/logout")
                         .cookie(requestCookie))
@@ -129,14 +152,22 @@ class AuthControllerTest {
                 .andExpect(header().exists(HttpHeaders.SET_COOKIE))
                 .andExpect(header().string(HttpHeaders.SET_COOKIE, Matchers.containsString("Max-Age=0")));
 
-        verify(logoutService).logout(any(TokenRequest.class));
+        verify(logoutService).logout(anyLong(), any(TokenRequest.class));
     }
 
-    private OnboardingRequest createDummyOnboardingRequest() {
-        try {
-            return new OnboardingRequest(1L, "test@email.com", "010-1234-5678", "900101-1");
-        } catch (Exception e) {
-            return null;
-        }
+    @Test
+    @DisplayName("회원탈퇴(withdraw) 성공 시 RefreshToken 쿠키를 삭제하고 상태를 반환한다")
+    void withdrawSuccess() throws Exception {
+        Cookie requestCookie = new Cookie("refreshToken", REFRESH_TOKEN);
+        doNothing().when(withdrawService).withdraw(anyLong(), any(TokenRequest.class));
+
+        mockMvc.perform(post("/api/v1/auth/withdraw")
+                        .cookie(requestCookie))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(header().exists(HttpHeaders.SET_COOKIE))
+                .andExpect(header().string(HttpHeaders.SET_COOKIE, Matchers.containsString("Max-Age=0")));
+
+        verify(withdrawService).withdraw(anyLong(), any(TokenRequest.class));
     }
 }

--- a/src/test/java/hotspot/user/auth/service/LogoutServiceImplTest.java
+++ b/src/test/java/hotspot/user/auth/service/LogoutServiceImplTest.java
@@ -1,5 +1,6 @@
 package hotspot.user.auth.service;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
@@ -14,6 +15,7 @@ import org.springframework.security.core.Authentication;
 
 import hotspot.user.auth.controller.request.TokenRequest;
 import hotspot.user.auth.service.port.TokenRepository;
+import hotspot.user.common.exception.ApplicationException;
 import hotspot.user.common.security.PrincipalDetails;
 import hotspot.user.common.security.jwt.JwtProvider;
 import hotspot.user.member.domain.FamilyRole;
@@ -33,41 +35,68 @@ class LogoutServiceImplTest {
     @InjectMocks
     private LogoutServiceImpl logoutService;
 
-            @Test
-            @DisplayName("로그아웃 성공: 유효한 토큰일 때 Redis에서 리프레시 토큰을 삭제한다")
-            void logoutSuccess() {
-                // given
-                String refreshToken = "valid-token";
-                TokenRequest request = new TokenRequest(refreshToken);
-                Long memberId = 1L;
+    @Test
+    @DisplayName("로그아웃 성공: 유효한 토큰 및 본인 소유일 때 토큰을 삭제한다")
+    void logoutSuccess() {
+        // given
+        String refreshToken = "valid-token";
+        TokenRequest request = new TokenRequest(refreshToken);
+        Long memberId = 1L;
 
-                        PrincipalDetails principal = new PrincipalDetails(memberId, "test@test.com", 100L,
+        PrincipalDetails principal = new PrincipalDetails(memberId, "test@test.com", 100L,
                 FamilyRole.CHILD, Status.APPROVED);
 
-                Authentication authentication = Mockito.mock(Authentication.class);
-                given(authentication.getPrincipal()).willReturn(principal);
+        Authentication authentication = Mockito.mock(Authentication.class);
+        given(authentication.getPrincipal()).willReturn(principal);
 
-                given(jwtProvider.validateToken(refreshToken)).willReturn(true);
-                given(jwtProvider.getAuthenticationFromRefreshToken(refreshToken)).willReturn(authentication);
+        given(jwtProvider.validateToken(refreshToken)).willReturn(true);
+        given(jwtProvider.getAuthenticationFromRefreshToken(refreshToken)).willReturn(authentication);
 
-                // when
-                logoutService.logout(request);
+        // when
+        logoutService.logout(memberId, request); // 💡 memberId 추가
 
-                // then
-                verify(tokenRepository).deleteByMemberId(memberId);
-            }
+        // then
+        verify(tokenRepository).deleteByMemberId(memberId);
+    }
 
-            @Test
-            @DisplayName("로그아웃 종료: 유효하지 않은 토큰일 때 아무런 동작을 하지 않는다")
-            void logoutWithInvalidToken() {
-                // given
-                String invalidToken = "invalid-token";
-                TokenRequest request = new TokenRequest(invalidToken);
-                given(jwtProvider.validateToken(invalidToken)).willReturn(false);
+    @Test
+    @DisplayName("로그아웃 실패: 유효하지 않은 토큰일 때 예외를 발생시킨다")
+    void logoutWithInvalidToken() {
+        // given
+        String invalidToken = "invalid-token";
+        TokenRequest request = new TokenRequest(invalidToken);
+        Long memberId = 1L;
+        given(jwtProvider.validateToken(invalidToken)).willReturn(false);
 
-                // when
-                logoutService.logout(request);
+        // when & then
+        assertThatThrownBy(() -> logoutService.logout(memberId, request))
+                .isInstanceOf(ApplicationException.class);
 
-                // then
-                verify(tokenRepository, Mockito.never()).deleteByMemberId(Mockito.anyLong());
-            }}
+        verify(tokenRepository, Mockito.never()).deleteByMemberId(Mockito.anyLong());
+    }
+
+    @Test
+    @DisplayName("로그아웃 실패: 토큰 소유자가 요청자와 다를 때 예외를 발생시킨다")
+    void logoutWithWrongOwner() {
+        // given
+        String refreshToken = "others-token";
+        TokenRequest request = new TokenRequest(refreshToken);
+        Long requesterId = 1L;
+        Long ownerId = 2L;
+
+        PrincipalDetails principal = new PrincipalDetails(ownerId, "other@test.com", 100L,
+                FamilyRole.CHILD, Status.APPROVED);
+
+        Authentication authentication = Mockito.mock(Authentication.class);
+        given(authentication.getPrincipal()).willReturn(principal);
+
+        given(jwtProvider.validateToken(refreshToken)).willReturn(true);
+        given(jwtProvider.getAuthenticationFromRefreshToken(refreshToken)).willReturn(authentication);
+
+        // when & then
+        assertThatThrownBy(() -> logoutService.logout(requesterId, request))
+                .isInstanceOf(ApplicationException.class);
+
+        verify(tokenRepository, Mockito.never()).deleteByMemberId(Mockito.anyLong());
+    }
+}

--- a/src/test/java/hotspot/user/auth/service/LogoutServiceImplTest.java
+++ b/src/test/java/hotspot/user/auth/service/LogoutServiceImplTest.java
@@ -53,7 +53,7 @@ class LogoutServiceImplTest {
         given(jwtProvider.getAuthenticationFromRefreshToken(refreshToken)).willReturn(authentication);
 
         // when
-        logoutService.logout(memberId, request); // 💡 memberId 추가
+        logoutService.logout(memberId, request);
 
         // then
         verify(tokenRepository).deleteByMemberId(memberId);

--- a/src/test/java/hotspot/user/auth/service/OnboardingServiceImplTest.java
+++ b/src/test/java/hotspot/user/auth/service/OnboardingServiceImplTest.java
@@ -64,12 +64,13 @@ class OnboardingServiceImplTest {
         // given
         Long memberId = 1L;
         Long familyId = 100L;
+        String email = "test@test.com";
         String phoneNumber = "01012345678";
         String phoneHash = phoneHashIndexer.toHash(phoneNumber);
-        OnboardingRequest request = new OnboardingRequest(memberId, "test@test.com", phoneNumber, "950101");
+        OnboardingRequest request = new OnboardingRequest(phoneNumber, "950101");
 
         Member pendingMember = Member.builder().id(memberId).name("test").status(Status.PENDING).build();
-        SocialAccount socialAccount = SocialAccount.builder().memberId(memberId).email("test@test.com").build();
+        SocialAccount socialAccount = SocialAccount.builder().memberId(memberId).email(email).build();
         Subscription subscription = Subscription.builder().id(100L).phoneHash(phoneHash).build();
         Family family = Family.builder().id(familyId).build();
         FamilySubscription familySubscription = FamilySubscription.builder()
@@ -84,11 +85,11 @@ class OnboardingServiceImplTest {
         given(subscriptionRepository.save(any(Subscription.class))).willAnswer(invocation -> invocation.getArgument(0));
 
         TokenResponse expectedResponse = new TokenResponse("at", "rt");
-        given(issueTokenService.issue(any(Member.class), eq("test@test.com"), eq(FamilyRole.CHILD), eq(familyId)))
+        given(issueTokenService.issue(any(Member.class), eq(email), eq(FamilyRole.CHILD), eq(familyId)))
                 .willReturn(expectedResponse);
 
         // when
-        TokenResponse response = onboardingService.onboarding(request);
+        TokenResponse response = onboardingService.onboarding(memberId, email, request);
 
         // then
         assertThat(response.accessToken()).isEqualTo("at");
@@ -104,13 +105,14 @@ class OnboardingServiceImplTest {
         Long pendingMemberId = 1L;
         Long existingMemberId = 2L;
         Long familyId = 100L;
+        String email = "test@test.com";
         String phoneNumber = "01012345678";
         String phoneHash = phoneHashIndexer.toHash(phoneNumber);
-        OnboardingRequest request = new OnboardingRequest(pendingMemberId, "test@test.com", phoneNumber, "950101");
+        OnboardingRequest request = new OnboardingRequest(phoneNumber, "950101");
 
         Member pendingMember = Member.builder().id(pendingMemberId).status(Status.PENDING).build();
         Member existingMember = Member.builder().id(existingMemberId).status(Status.APPROVED).build();
-        SocialAccount socialAccount = SocialAccount.builder().memberId(pendingMemberId).email("test@test.com").build();
+        SocialAccount socialAccount = SocialAccount.builder().memberId(pendingMemberId).email(email).build();
         Subscription subscription = Subscription.builder().id(100L).member(existingMember).phoneHash(phoneHash).build();
         Family family = Family.builder().id(familyId).build();
         FamilySubscription familySubscription = FamilySubscription.builder()
@@ -125,11 +127,11 @@ class OnboardingServiceImplTest {
                 .willAnswer(invocation -> invocation.getArgument(0));
 
         TokenResponse expectedResponse = new TokenResponse("at", "rt");
-        given(issueTokenService.issue(any(Member.class), eq("test@test.com"), eq(FamilyRole.PARENT), eq(familyId)))
+        given(issueTokenService.issue(any(Member.class), eq(email), eq(FamilyRole.PARENT), eq(familyId)))
                 .willReturn(expectedResponse);
 
         // when
-        TokenResponse response = onboardingService.onboarding(request);
+        TokenResponse response = onboardingService.onboarding(pendingMemberId, email, request);
 
         // then
         assertThat(response.accessToken()).isEqualTo("at");
@@ -144,12 +146,12 @@ class OnboardingServiceImplTest {
         // given
         String phoneNumber = "01000000000";
         String phoneHash = phoneHashIndexer.toHash(phoneNumber);
-        OnboardingRequest request = new OnboardingRequest(1L, "test@test.com", phoneNumber, "950101");
+        OnboardingRequest request = new OnboardingRequest(phoneNumber, "950101");
 
         given(subscriptionRepository.findByPhoneHash(phoneHash)).willReturn(Optional.empty());
 
         // when & then
-        assertThatThrownBy(() -> onboardingService.onboarding(request))
+        assertThatThrownBy(() -> onboardingService.onboarding(1L, "test@test.com", request))
                 .isInstanceOf(ApplicationException.class)
                 .hasMessage(MemberErrorCode.SUBSCRIPTION_NOT_FOUND.getMessage());
     }
@@ -159,9 +161,10 @@ class OnboardingServiceImplTest {
     void onboardingFailFamilySubscriptionNotFound() {
         // given
         Long memberId = 1L;
+        String email = "test@test.com";
         String phoneNumber = "01012345678";
         String phoneHash = phoneHashIndexer.toHash(phoneNumber);
-        OnboardingRequest request = new OnboardingRequest(memberId, "test@test.com", phoneNumber, "950101");
+        OnboardingRequest request = new OnboardingRequest(phoneNumber, "950101");
 
         Member pendingMember = Member.builder().id(memberId).status(Status.PENDING).build();
         Subscription subscription = Subscription.builder().id(100L).phoneHash(phoneHash).build();
@@ -173,7 +176,7 @@ class OnboardingServiceImplTest {
         given(familySubscriptionRepository.findBySubId(100L)).willReturn(Optional.empty());
 
         // when & then
-        assertThatThrownBy(() -> onboardingService.onboarding(request))
+        assertThatThrownBy(() -> onboardingService.onboarding(memberId, email, request))
                 .isInstanceOf(ApplicationException.class)
                 .hasMessage(MemberErrorCode.FAMILY_SUBSCRIPTION_NOT_FOUND.getMessage());
     }

--- a/src/test/java/hotspot/user/auth/service/WithdrawServiceImplTest.java
+++ b/src/test/java/hotspot/user/auth/service/WithdrawServiceImplTest.java
@@ -1,0 +1,105 @@
+package hotspot.user.auth.service;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.Authentication;
+
+import hotspot.user.auth.controller.request.TokenRequest;
+import hotspot.user.auth.service.port.TokenRepository;
+import hotspot.user.common.exception.ApplicationException;
+import hotspot.user.common.security.PrincipalDetails;
+import hotspot.user.common.security.jwt.JwtProvider;
+import hotspot.user.member.domain.FamilyRole;
+import hotspot.user.member.domain.Member;
+import hotspot.user.member.domain.Status;
+import hotspot.user.member.service.port.MemberRepository;
+import hotspot.user.member.service.port.SocialAccountRepository;
+import hotspot.user.subscription.domain.Subscription;
+import hotspot.user.subscription.service.port.SubscriptionRepository;
+
+@ExtendWith(MockitoExtension.class)
+class WithdrawServiceImplTest {
+
+    @Mock
+    private MemberRepository memberRepository;
+    @Mock
+    private SocialAccountRepository socialAccountRepository;
+    @Mock
+    private SubscriptionRepository subscriptionRepository;
+    @Mock
+    private TokenRepository tokenRepository;
+    @Mock
+    private JwtProvider jwtProvider;
+
+    @InjectMocks
+    private WithdrawServiceImpl withdrawService;
+
+    @Test
+    @DisplayName("회원 탈퇴 성공: 모든 연관 데이터가 정상적으로 처리된다")
+    void withdrawSuccess() {
+        // given
+        Long memberId = 1L;
+        String refreshToken = "valid-token";
+        TokenRequest request = new TokenRequest(refreshToken);
+
+        PrincipalDetails principal = new PrincipalDetails(
+                memberId, "test@test.com", 100L, FamilyRole.PARENT, Status.APPROVED);
+        Authentication authentication = Mockito.mock(Authentication.class);
+        given(authentication.getPrincipal()).willReturn(principal);
+
+        given(jwtProvider.validateToken(refreshToken)).willReturn(true);
+        given(jwtProvider.getAuthenticationFromRefreshToken(refreshToken)).willReturn(authentication);
+
+        Subscription subscription = Subscription.builder().id(10L).build();
+        given(subscriptionRepository.findByMemberId(memberId)).willReturn(Optional.of(subscription));
+
+        Member member = Member.builder().id(memberId).build();
+        given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
+
+        // when
+        withdrawService.withdraw(memberId, request);
+
+        // then
+        verify(tokenRepository).deleteByMemberId(memberId);
+        verify(subscriptionRepository).save(any(Subscription.class)); // memberId=null 업데이트 확인
+        verify(socialAccountRepository).deleteByMemberId(memberId);
+        verify(memberRepository).delete(member);
+    }
+
+    @Test
+    @DisplayName("회원 탈퇴 실패: 타인의 토큰으로 탈퇴 시도 시 예외 발생")
+    void withdrawFailWrongOwner() {
+        // given
+        Long requesterId = 1L;
+        Long ownerId = 2L;
+        String refreshToken = "others-token";
+        TokenRequest request = new TokenRequest(refreshToken);
+
+        PrincipalDetails principal = new PrincipalDetails(
+                ownerId, "other@test.com", 100L, FamilyRole.CHILD, Status.APPROVED);
+        Authentication authentication = Mockito.mock(Authentication.class);
+        given(authentication.getPrincipal()).willReturn(principal);
+
+        given(jwtProvider.validateToken(refreshToken)).willReturn(true);
+        given(jwtProvider.getAuthenticationFromRefreshToken(refreshToken)).willReturn(authentication);
+
+        // when & then
+        assertThatThrownBy(() -> withdrawService.withdraw(requesterId, request))
+                .isInstanceOf(ApplicationException.class);
+
+        verify(memberRepository, never()).delete(any());
+    }
+}

--- a/src/test/java/hotspot/user/auth/service/WithdrawServiceImplTest.java
+++ b/src/test/java/hotspot/user/auth/service/WithdrawServiceImplTest.java
@@ -55,6 +55,9 @@ class WithdrawServiceImplTest {
         String refreshToken = "valid-token";
         TokenRequest request = new TokenRequest(refreshToken);
 
+        Member member = Member.builder().id(memberId).build();
+        given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
+
         PrincipalDetails principal = new PrincipalDetails(
                 memberId, "test@test.com", 100L, FamilyRole.PARENT, Status.APPROVED);
         Authentication authentication = Mockito.mock(Authentication.class);
@@ -65,9 +68,6 @@ class WithdrawServiceImplTest {
 
         Subscription subscription = Subscription.builder().id(10L).build();
         given(subscriptionRepository.findByMemberId(memberId)).willReturn(Optional.of(subscription));
-
-        Member member = Member.builder().id(memberId).build();
-        given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
 
         // when
         withdrawService.withdraw(memberId, request);
@@ -87,6 +87,9 @@ class WithdrawServiceImplTest {
         Long ownerId = 2L;
         String refreshToken = "others-token";
         TokenRequest request = new TokenRequest(refreshToken);
+
+        Member requester = Member.builder().id(requesterId).build();
+        given(memberRepository.findById(requesterId)).willReturn(Optional.of(requester));
 
         PrincipalDetails principal = new PrincipalDetails(
                 ownerId, "other@test.com", 100L, FamilyRole.CHILD, Status.APPROVED);

--- a/src/test/java/hotspot/user/member/infrastructure/SocialAccountRepositoryImplTest.java
+++ b/src/test/java/hotspot/user/member/infrastructure/SocialAccountRepositoryImplTest.java
@@ -3,6 +3,7 @@ package hotspot.user.member.infrastructure;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
 
 import java.util.Optional;
 
@@ -18,14 +19,12 @@ import hotspot.user.member.domain.SocialAccount;
 import hotspot.user.member.infrastructure.entity.MemberEntity;
 import hotspot.user.member.infrastructure.entity.SocialAccountEntity;
 
-/**
- * 소셜 계정 Repository 단위 테스트
- */
 @ExtendWith(MockitoExtension.class)
 class SocialAccountRepositoryImplTest {
 
     @Mock
     private SocialAccountJpaRepository socialAccountJpaRepository;
+
     @Mock
     private MemberJpaRepository memberJpaRepository;
 
@@ -33,64 +32,44 @@ class SocialAccountRepositoryImplTest {
     private SocialAccountRepositoryImpl socialAccountRepository;
 
     @Test
-    @DisplayName("소셜 계정 저장 성공: 연관된 멤버 엔티티를 찾아 함께 저장한다")
-    void saveSocialAccountSuccess() {
+    @DisplayName("소셜 계정 저장 성공")
+    void saveSuccess() {
         // given
-        Long memberId = 1L;
         SocialAccount socialAccount = SocialAccount.builder()
-                .memberId(memberId)
+                .memberId(1L)
                 .email("test@test.com")
+                .socialId("12345")
                 .provider(Provider.KAKAO)
-                .socialId("abc")
                 .build();
 
-        MemberEntity memberEntity = MemberEntity.builder().id(memberId).build();
-        SocialAccountEntity entity = SocialAccountEntity.builder()
-                .id(10L)
-                .member(memberEntity)
-                .email("test@test.com")
-                .build();
+        MemberEntity memberEntity = MemberEntity.builder().id(1L).build();
+        SocialAccountEntity entity = SocialAccountEntity.domainToEntity(socialAccount, memberEntity);
 
-        given(memberJpaRepository.findById(memberId)).willReturn(Optional.of(memberEntity));
+        given(memberJpaRepository.findById(1L)).willReturn(Optional.of(memberEntity));
         given(socialAccountJpaRepository.save(any(SocialAccountEntity.class))).willReturn(entity);
 
         // when
         SocialAccount result = socialAccountRepository.save(socialAccount);
 
         // then
-        assertThat(result.getId()).isEqualTo(10L);
         assertThat(result.getEmail()).isEqualTo("test@test.com");
+        verify(socialAccountJpaRepository).save(any(SocialAccountEntity.class));
     }
 
     @Test
-    @DisplayName("이메일로 소셜 계정 조회 성공")
-    void findByEmailSuccess() {
-        // given
-        String email = "test@test.com";
-        SocialAccountEntity entity = SocialAccountEntity.builder()
-                .id(10L)
-                .email(email)
-                .member(MemberEntity.builder().id(1L).build())
-                .build();
-        given(socialAccountJpaRepository.findByEmail(email)).willReturn(Optional.of(entity));
-
-        // when
-        Optional<SocialAccount> result = socialAccountRepository.findByEmail(email);
-
-        // then
-        assertThat(result).isPresent();
-        assertThat(result.get().getEmail()).isEqualTo(email);
-    }
-
-    @Test
-    @DisplayName("멤버 ID로 소셜 계정 조회 성공")
+    @DisplayName("memberId로 소셜 계정 조회 성공")
     void findByMemberIdSuccess() {
         // given
         Long memberId = 1L;
+        MemberEntity memberEntity = MemberEntity.builder().id(memberId).build();
         SocialAccountEntity entity = SocialAccountEntity.builder()
                 .id(10L)
-                .member(MemberEntity.builder().id(memberId).build())
+                .member(memberEntity)
+                .email("test@test.com")
+                .socialId("social123")
+                .provider(Provider.GOOGLE)
                 .build();
+
         given(socialAccountJpaRepository.findByMemberId(memberId)).willReturn(Optional.of(entity));
 
         // when
@@ -98,6 +77,61 @@ class SocialAccountRepositoryImplTest {
 
         // then
         assertThat(result).isPresent();
-        assertThat(result.get().getMemberId()).isEqualTo(memberId);
+        assertThat(result.get().getEmail()).isEqualTo("test@test.com");
+    }
+
+    @Test
+    @DisplayName("이메일로 소셜 계정 조회 성공")
+    void findByEmailSuccess() {
+        // given
+        String email = "test@test.com";
+        MemberEntity memberEntity = MemberEntity.builder().id(1L).build();
+        SocialAccountEntity entity = SocialAccountEntity.builder()
+                .id(10L)
+                .member(memberEntity)
+                .email(email)
+                .socialId("social123")
+                .provider(Provider.GOOGLE)
+                .build();
+
+        given(socialAccountJpaRepository.findByEmail(email)).willReturn(Optional.of(entity));
+
+        // when
+        Optional<SocialAccount> result = socialAccountRepository.findByEmail(email);
+
+        // then
+        assertThat(result).isPresent();
+        assertThat(result.get().getSocialId()).isEqualTo("social123");
+    }
+
+    @Test
+    @DisplayName("소셜 계정 객체로 삭제 호출 확인")
+    void deleteSuccess() {
+        // given
+        SocialAccount socialAccount = SocialAccount.builder()
+                .memberId(1L)
+                .build();
+        MemberEntity memberEntity = MemberEntity.builder().id(1L).build();
+
+        given(memberJpaRepository.findById(1L)).willReturn(Optional.of(memberEntity));
+
+        // when
+        socialAccountRepository.delete(socialAccount);
+
+        // then
+        verify(socialAccountJpaRepository).delete(any(SocialAccountEntity.class));
+    }
+
+    @Test
+    @DisplayName("memberId로 소셜 계정 삭제(Soft Delete) 호출 확인")
+    void deleteByMemberIdSuccess() {
+        // given
+        Long memberId = 1L;
+
+        // when
+        socialAccountRepository.deleteByMemberId(memberId);
+
+        // then
+        verify(socialAccountJpaRepository).deleteByMemberId(memberId);
     }
 }


### PR DESCRIPTION
## 🎫 지라 티켓

<!-- 지라 티켓을 작성해주세요 ex) HOTSPOT-123 -->
HOTSPOT-159

---

## 🔗 GitHub 이슈
<!-- 자동 close를 원하면 아래 형식으로 작성
예) Closes #12
-->
Closes #59 

---


## ✅ 작업 사항

<!-- 작업한 부분을 설명해주세요. -->

회원 탈퇴 API 구현 및 로그아웃 리팩토링

---

1. 회원 탈퇴 및 데이터 처리 (Soft Delete)
   * `WithdrawService` 구현: 회원 탈퇴 시 연관된 소셜 계정, 토큰 정보를 삭제하고 회선(Subscription)과의 연결을 해제하는 로직을 구현   * 논리 삭제(Soft Delete) 보장: Member 및 SocialAccount 엔티티에 @SQLDelete 및 isDeleted 필드를 활용하여 물리 삭제 대신 논리 삭제가 수행되도록 설정
   * SQL 문법 오류 수정: @SQLDelete 내 실제 DB 컬럼명(member_id, social_account_id)을 명시하여 발생하던 SQLGrammarException을 해결

<br/>


2. 시스템 보안 강화 (Security & Authorization)
   * 토큰 소유권 검증: 로그아웃 및 회원 탈퇴 시, 전달된 Refresh Token의 주인이 현재 로그인한 사용자와 일치하는지 검증하는 로직을 추가
   * `SecurityConfig` 최적화: 테스트용으로 개방되었던 /api/v1/** 경로를 제거하고, onboarding, reissue, swagger, health 등 필수 공개 경로만 permitAll()로 설정


---

## 📋 체크리스트

<!-- PR 제출 전 확인해주세요. 해당 항목에 [x]로 체크해주세요. -->

- [x] 코드가 정상적으로 빌드됩니다.
- [x] 관련 테스트 코드를 작성했습니다.
- [x] 기존 테스트가 모두 통과합니다.
- [x] 코드 스타일(Spotless, Checkstyle)을 준수합니다.
- [x] Jira 티켓 상태를 In Review / Done으로 변경했습니다.

---

## ⌨ 기타
