### PR TITLE
[HOTSPOT-160] 알림 허용 여부 검증 로직 구현

### DIFF
--- a/src/main/java/hotspot/user/common/exception/code/KafkaErrorCode.java
+++ b/src/main/java/hotspot/user/common/exception/code/KafkaErrorCode.java
@@ -8,12 +8,12 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum KafkaErrorCode implements BaseErrorCode {
-    UNSUPPORTED_KAFKA_EVENT_TYPE(HttpStatus.BAD_REQUEST, "KAFKA_001", "吏?먰븯吏 ?딅뒗 Kafka eventType ?낅땲??"),
-    UNSUPPORTED_KAFKA_ALERT_TYPE(HttpStatus.BAD_REQUEST, "KAFKA_002", "吏?먰븯吏 ?딅뒗 Kafka alertType ?낅땲??"),
-    UNSUPPORTED_KAFKA_THRESHOLD(HttpStatus.BAD_REQUEST, "KAFKA_003", "吏?먰븯吏 ?딅뒗 Kafka threshold ?낅땲??"),
-    KAFKA_EVENT_ID_REQUIRED(HttpStatus.BAD_REQUEST, "KAFKA_004", "Kafka eventId(sourceEventId or alertId)媛 ?꾩슂?⑸땲??"),
-    KAFKA_SUB_ID_REQUIRED(HttpStatus.BAD_REQUEST, "KAFKA_005", "Kafka subId媛 ?꾩슂?⑸땲??"),
-    KAFKA_SUB_ID_INVALID(HttpStatus.BAD_REQUEST, "KAFKA_006", "Kafka subId媛 ?좏슚?섏? ?딆뒿?덈떎."),
+    UNSUPPORTED_KAFKA_EVENT_TYPE(HttpStatus.BAD_REQUEST, "KAFKA_001", "지원하지 않는 Kafka eventType 입니다."),
+    UNSUPPORTED_KAFKA_ALERT_TYPE(HttpStatus.BAD_REQUEST, "KAFKA_002", "지원하지 않는 Kafka alertType 입니다."),
+    UNSUPPORTED_KAFKA_THRESHOLD(HttpStatus.BAD_REQUEST, "KAFKA_003", "지원하지 않는 Kafka threshold 입니다."),
+    KAFKA_EVENT_ID_REQUIRED(HttpStatus.BAD_REQUEST, "KAFKA_004", "Kafka eventId가 필요합니다."),
+    KAFKA_SUB_ID_REQUIRED(HttpStatus.BAD_REQUEST, "KAFKA_005", "Kafka subId가 필요합니다."),
+    KAFKA_SUB_ID_INVALID(HttpStatus.BAD_REQUEST, "KAFKA_006", "Kafka subId가 유효하지 않습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/hotspot/user/common/exception/code/NotificationErrorCode.java
+++ b/src/main/java/hotspot/user/common/exception/code/NotificationErrorCode.java
@@ -9,6 +9,11 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum NotificationErrorCode implements BaseErrorCode {
     NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "NOTI_001", "알림 정보를 찾을 수 없습니다."),
+    NOTIFICATION_CATEGORY_MAPPING_NOT_FOUND(
+            HttpStatus.BAD_REQUEST,
+            "NOTI_002",
+            "알림 타입에 대한 카테고리 매핑 정보를 찾을 수 없습니다."
+    ),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/hotspot/user/kafka/consumer/UserAlertEventsConsumer.java
+++ b/src/main/java/hotspot/user/kafka/consumer/UserAlertEventsConsumer.java
@@ -12,11 +12,15 @@ import org.springframework.transaction.annotation.Transactional;
 
 import hotspot.user.common.exception.ApplicationException;
 import hotspot.user.common.exception.code.KafkaErrorCode;
+import hotspot.user.common.exception.code.NotificationErrorCode;
 import hotspot.user.family.service.port.FamilySubscriptionRepository;
+import hotspot.user.kafka.domain.NotificationType;
 import hotspot.user.kafka.dto.UserAlertEvent;
 import hotspot.user.kafka.dto.UserAlertNotificationsPersistedEvent;
 import hotspot.user.kafka.mapper.UserAlertEventNotificationMapper;
 import hotspot.user.notification.domain.Notification;
+import hotspot.user.notification.domain.NotificationCategory;
+import hotspot.user.notification.service.port.NotificationAllowRepository;
 import hotspot.user.notification.service.port.NotificationRepository;
 import lombok.RequiredArgsConstructor;
 
@@ -26,6 +30,7 @@ public class UserAlertEventsConsumer {
 
     private final UserAlertEventNotificationMapper mapper;
     private final NotificationRepository notificationRepository;
+    private final NotificationAllowRepository notificationAllowRepository;
     private final FamilySubscriptionRepository familySubscriptionRepository;
     private final ApplicationEventPublisher applicationEventPublisher;
 
@@ -41,6 +46,9 @@ public class UserAlertEventsConsumer {
         List<Notification> persistedNotifications = new ArrayList<>();
         for (Long targetSubId : targetSubIds) {
             Notification notification = mapper.toNotification(event, targetSubId);
+            if (!isNotificationAllowed(targetSubId, notification.getNotificationType())) {
+                continue;
+            }
             Notification persistedNotification = notificationRepository.insertIfAbsent(notification);
             if (persistedNotification != null) {
                 persistedNotifications.add(persistedNotification);
@@ -72,5 +80,21 @@ public class UserAlertEventsConsumer {
                 .filter(Objects::nonNull)
                 .distinct()
                 .toList();
+    }
+
+    // 알림 타입을 카테고리로 변환해 허용된 경우에만 저장/전송 대상으로 처리한다.
+    private boolean isNotificationAllowed(Long subId, String notificationTypeRaw) {
+        NotificationCategory category = resolveNotificationCategory(notificationTypeRaw);
+        return notificationAllowRepository.findBySubIdAndCategory(subId, category)
+                .map(notificationAllow -> Boolean.TRUE.equals(notificationAllow.getNotificationAllow()))
+                .orElse(false);
+    }
+
+    private NotificationCategory resolveNotificationCategory(String notificationTypeRaw) {
+        try {
+            return NotificationType.valueOf(notificationTypeRaw).category();
+        } catch (IllegalArgumentException ex) {
+            throw new ApplicationException(NotificationErrorCode.NOTIFICATION_CATEGORY_MAPPING_NOT_FOUND);
+        }
     }
 }

--- a/src/main/java/hotspot/user/kafka/consumer/UserAlertEventsConsumer.java
+++ b/src/main/java/hotspot/user/kafka/consumer/UserAlertEventsConsumer.java
@@ -23,8 +23,10 @@ import hotspot.user.notification.domain.NotificationCategory;
 import hotspot.user.notification.service.port.NotificationAllowRepository;
 import hotspot.user.notification.service.port.NotificationRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Component
+@Slf4j
 @RequiredArgsConstructor
 public class UserAlertEventsConsumer {
 
@@ -46,7 +48,27 @@ public class UserAlertEventsConsumer {
         List<Notification> persistedNotifications = new ArrayList<>();
         for (Long targetSubId : targetSubIds) {
             Notification notification = mapper.toNotification(event, targetSubId);
-            if (!isNotificationAllowed(targetSubId, notification.getNotificationType())) {
+            NotificationCategory category;
+            try {
+                category = resolveNotificationCategory(notification.getNotificationType());
+            } catch (ApplicationException ex) {
+                log.warn(
+                        "Skip invalid notification type. subId={}, eventId={}, notificationType={}",
+                        targetSubId,
+                        resolveEventId(event),
+                        notification.getNotificationType()
+                );
+                acknowledgment.acknowledge();
+                return;
+            }
+
+            if (!isNotificationAllowed(targetSubId, category)) {
+                log.info(
+                        "Skip disallowed notification. subId={}, category={}, eventId={}",
+                        targetSubId,
+                        category,
+                        notification.getEventId()
+                );
                 continue;
             }
             Notification persistedNotification = notificationRepository.insertIfAbsent(notification);
@@ -83,8 +105,7 @@ public class UserAlertEventsConsumer {
     }
 
     // 알림 타입을 카테고리로 변환해 허용된 경우에만 저장/전송 대상으로 처리한다.
-    private boolean isNotificationAllowed(Long subId, String notificationTypeRaw) {
-        NotificationCategory category = resolveNotificationCategory(notificationTypeRaw);
+    private boolean isNotificationAllowed(Long subId, NotificationCategory category) {
         return notificationAllowRepository.findBySubIdAndCategory(subId, category)
                 .map(notificationAllow -> Boolean.TRUE.equals(notificationAllow.getNotificationAllow()))
                 .orElse(false);
@@ -96,5 +117,12 @@ public class UserAlertEventsConsumer {
         } catch (IllegalArgumentException ex) {
             throw new ApplicationException(NotificationErrorCode.NOTIFICATION_CATEGORY_MAPPING_NOT_FOUND);
         }
+    }
+
+    private String resolveEventId(UserAlertEvent event) {
+        if (event.sourceEventId() != null && !event.sourceEventId().isBlank()) {
+            return event.sourceEventId();
+        }
+        return event.alertId();
     }
 }

--- a/src/main/java/hotspot/user/kafka/domain/NotificationType.java
+++ b/src/main/java/hotspot/user/kafka/domain/NotificationType.java
@@ -1,23 +1,35 @@
 package hotspot.user.kafka.domain;
 
+import hotspot.user.notification.domain.NotificationCategory;
+
 public enum NotificationType {
-    SINGLE_USAGE_THRESHOLD_50,
-    SINGLE_USAGE_THRESHOLD_30,
-    SINGLE_USAGE_THRESHOLD_10,
-    SINGLE_USAGE_EXHAUSTED,
-    FAMILY_USAGE_THRESHOLD_50,
-    FAMILY_USAGE_THRESHOLD_30,
-    FAMILY_USAGE_THRESHOLD_10,
-    FAMILY_USAGE_EXHAUSTED,
-    PRESENT_USAGE_THRESHOLD_50,
-    PRESENT_USAGE_THRESHOLD_30,
-    PRESENT_USAGE_THRESHOLD_10,
-    PRESENT_USAGE_EXHAUSTED,
-    TIME_WINDOW_POLICY_APPLIED,
-    TIME_WINDOW_POLICY_RELEASED,
-    IMMEDIATE_BLOCK_APPLIED,
-    IMMEDIATE_BLOCK_RELEASED,
-    SERVICE_ACCESS_BLOCKED,
-    SERVICE_ACCESS_RELEASED,
-    PRESENT_DATA
+    SINGLE_USAGE_THRESHOLD_50(NotificationCategory.DATA),
+    SINGLE_USAGE_THRESHOLD_30(NotificationCategory.DATA),
+    SINGLE_USAGE_THRESHOLD_10(NotificationCategory.DATA),
+    SINGLE_USAGE_EXHAUSTED(NotificationCategory.DATA),
+    FAMILY_USAGE_THRESHOLD_50(NotificationCategory.DATA),
+    FAMILY_USAGE_THRESHOLD_30(NotificationCategory.DATA),
+    FAMILY_USAGE_THRESHOLD_10(NotificationCategory.DATA),
+    FAMILY_USAGE_EXHAUSTED(NotificationCategory.DATA),
+    PRESENT_USAGE_THRESHOLD_50(NotificationCategory.PRESENT),
+    PRESENT_USAGE_THRESHOLD_30(NotificationCategory.PRESENT),
+    PRESENT_USAGE_THRESHOLD_10(NotificationCategory.PRESENT),
+    PRESENT_USAGE_EXHAUSTED(NotificationCategory.PRESENT),
+    TIME_WINDOW_POLICY_APPLIED(NotificationCategory.POLICY),
+    TIME_WINDOW_POLICY_RELEASED(NotificationCategory.POLICY),
+    IMMEDIATE_BLOCK_APPLIED(NotificationCategory.POLICY),
+    IMMEDIATE_BLOCK_RELEASED(NotificationCategory.POLICY),
+    SERVICE_ACCESS_BLOCKED(NotificationCategory.APP_SERVICE),
+    SERVICE_ACCESS_RELEASED(NotificationCategory.APP_SERVICE),
+    PRESENT_DATA(NotificationCategory.PRESENT);
+
+    private final NotificationCategory category;
+
+    NotificationType(NotificationCategory category) {
+        this.category = category;
+    }
+
+    public NotificationCategory category() {
+        return category;
+    }
 }

--- a/src/test/java/hotspot/user/kafka/consumer/UserAlertEventsConsumerTest.java
+++ b/src/test/java/hotspot/user/kafka/consumer/UserAlertEventsConsumerTest.java
@@ -2,13 +2,18 @@ package hotspot.user.kafka.consumer;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.lenient;
 
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -21,6 +26,7 @@ import org.springframework.kafka.support.Acknowledgment;
 
 import hotspot.user.common.exception.ApplicationException;
 import hotspot.user.common.exception.code.KafkaErrorCode;
+import hotspot.user.common.exception.code.NotificationErrorCode;
 import hotspot.user.family.domain.Family;
 import hotspot.user.family.domain.FamilySubscription;
 import hotspot.user.family.service.port.FamilySubscriptionRepository;
@@ -28,6 +34,9 @@ import hotspot.user.kafka.dto.UserAlertEvent;
 import hotspot.user.kafka.dto.UserAlertNotificationsPersistedEvent;
 import hotspot.user.kafka.mapper.UserAlertEventNotificationMapper;
 import hotspot.user.notification.domain.Notification;
+import hotspot.user.notification.domain.NotificationAllow;
+import hotspot.user.notification.domain.NotificationCategory;
+import hotspot.user.notification.service.port.NotificationAllowRepository;
 import hotspot.user.notification.service.port.NotificationRepository;
 import hotspot.user.subscription.domain.Subscription;
 
@@ -41,6 +50,9 @@ class UserAlertEventsConsumerTest {
     private NotificationRepository notificationRepository;
 
     @Mock
+    private NotificationAllowRepository notificationAllowRepository;
+
+    @Mock
     private FamilySubscriptionRepository familySubscriptionRepository;
 
     @Mock
@@ -51,6 +63,14 @@ class UserAlertEventsConsumerTest {
 
     @InjectMocks
     private UserAlertEventsConsumer consumer;
+
+    @BeforeEach
+    void setUp() {
+        lenient().when(notificationAllowRepository.findBySubIdAndCategory(anyLong(), any(NotificationCategory.class)))
+                .thenReturn(Optional.of(NotificationAllow.builder()
+                        .notificationAllow(true)
+                        .build()));
+    }
 
     @Test
     @DisplayName("subId target: persist and publish only inserted notifications, then ack")
@@ -73,6 +93,23 @@ class UserAlertEventsConsumerTest {
         assertThat(eventCaptor.getValue().sourceEvent()).isEqualTo(event);
         assertThat(eventCaptor.getValue().persistedNotifications()).containsExactly(persisted);
 
+        then(acknowledgment).should().acknowledge();
+    }
+
+    @Test
+    @DisplayName("does not persist or publish when category is not allowed")
+    // category 허용 설정이 없거나 false면 저장/발행 없이 ack만 수행하는지 검증한다.
+    void consumeSkipsWhenNotificationCategoryDisallowed() {
+        UserAlertEvent event = event(101L, null, "evt-disallowed");
+        Notification notification = notification(101L, "evt-disallowed");
+        given(mapper.toNotification(event, 101L)).willReturn(notification);
+        given(notificationAllowRepository.findBySubIdAndCategory(101L, NotificationCategory.DATA))
+                .willReturn(Optional.empty());
+
+        consumer.consume(event, acknowledgment);
+
+        then(notificationRepository).shouldHaveNoInteractions();
+        then(applicationEventPublisher).shouldHaveNoInteractions();
         then(acknowledgment).should().acknowledge();
     }
 
@@ -140,6 +177,30 @@ class UserAlertEventsConsumerTest {
         then(applicationEventPublisher).shouldHaveNoInteractions();
         then(notificationRepository).shouldHaveNoInteractions();
         then(mapper).shouldHaveNoInteractions();
+    }
+
+    @Test
+    @DisplayName("throws notification mapping error when notification type has no category mapping")
+    void consumeWithUnknownNotificationType() {
+        UserAlertEvent event = event(101L, null, "evt-unknown-type");
+        Notification unknownTypeNotification = Notification.builder()
+                .subId(101L)
+                .eventId("evt-unknown-type")
+                .notificationType("UNKNOWN_TYPE")
+                .title("unknown")
+                .content("unknown")
+                .isRead(false)
+                .createdTime(LocalDateTime.of(2026, 2, 23, 10, 15, 30))
+                .build();
+        given(mapper.toNotification(event, 101L)).willReturn(unknownTypeNotification);
+
+        assertThatThrownBy(() -> consumer.consume(event, acknowledgment))
+                .isInstanceOf(ApplicationException.class)
+                .hasMessage(NotificationErrorCode.NOTIFICATION_CATEGORY_MAPPING_NOT_FOUND.getMessage());
+
+        then(notificationRepository).shouldHaveNoInteractions();
+        then(applicationEventPublisher).shouldHaveNoInteractions();
+        then(acknowledgment).shouldHaveNoInteractions();
     }
 
     // 테스트용 이벤트 객체를 생성한다.

--- a/src/test/java/hotspot/user/kafka/consumer/UserAlertEventsConsumerTest.java
+++ b/src/test/java/hotspot/user/kafka/consumer/UserAlertEventsConsumerTest.java
@@ -26,7 +26,6 @@ import org.springframework.kafka.support.Acknowledgment;
 
 import hotspot.user.common.exception.ApplicationException;
 import hotspot.user.common.exception.code.KafkaErrorCode;
-import hotspot.user.common.exception.code.NotificationErrorCode;
 import hotspot.user.family.domain.Family;
 import hotspot.user.family.domain.FamilySubscription;
 import hotspot.user.family.service.port.FamilySubscriptionRepository;
@@ -180,7 +179,7 @@ class UserAlertEventsConsumerTest {
     }
 
     @Test
-    @DisplayName("throws notification mapping error when notification type has no category mapping")
+    @DisplayName("acks and skips when notification type has no category mapping")
     void consumeWithUnknownNotificationType() {
         UserAlertEvent event = event(101L, null, "evt-unknown-type");
         Notification unknownTypeNotification = Notification.builder()
@@ -194,13 +193,11 @@ class UserAlertEventsConsumerTest {
                 .build();
         given(mapper.toNotification(event, 101L)).willReturn(unknownTypeNotification);
 
-        assertThatThrownBy(() -> consumer.consume(event, acknowledgment))
-                .isInstanceOf(ApplicationException.class)
-                .hasMessage(NotificationErrorCode.NOTIFICATION_CATEGORY_MAPPING_NOT_FOUND.getMessage());
+        consumer.consume(event, acknowledgment);
 
         then(notificationRepository).shouldHaveNoInteractions();
         then(applicationEventPublisher).shouldHaveNoInteractions();
-        then(acknowledgment).shouldHaveNoInteractions();
+        then(acknowledgment).should().acknowledge();
     }
 
     // 테스트용 이벤트 객체를 생성한다.


### PR DESCRIPTION
## 🎫 지라 티켓

<!-- 지라 티켓을 작성해주세요 ex) HOTSPOT-123 -->
HOTSPOT-160

---

## 🔗 GitHub 이슈
<!-- 자동 close를 원하면 아래 형식으로 작성
예) Closes #12
-->
Closes #64 

---


## ✅ 작업 사항

<!-- 작업한 부분을 설명해주세요. -->
- 알림 생성 진입점(Consumer)에서 NotificationCategory 결정 경로 정리
- NotificationAllowRepository.findBySubIdAndCategory(subId, category) 기반 허용 검증 로직 추가
- 허용 검증 정책 반영
  - 설정 없음 / soft-delete(조회 제외) / false → 알림 DB 저장 및 후속 발행 스킵
  - true → 기존대로 저장 및 후속 발행 진행

- 저장 스킵 시에도 Kafka ack 정상 수행 유지
  - 파이프라인 정체 방지 목적

- 매핑 실패 상황 분리를 위한 공통 에러코드 추가
- 단위 테스트 보강
  - 비허용 설정 시 저장/발행 스킵 케이스 추가
  - 카테고리 매핑 실패 예외 케이스 추가

- KafkaErrorCode 메시지 인코딩 깨짐 복구

---

## 📋 체크리스트

<!-- PR 제출 전 확인해주세요. 해당 항목에 [x]로 체크해주세요. -->

- [x] 코드가 정상적으로 빌드됩니다.
- [x] 관련 테스트 코드를 작성했습니다.
- [x] 기존 테스트가 모두 통과합니다.
- [x] 코드 스타일(Spotless, Checkstyle)을 준수합니다.
- [x] Jira 티켓 상태를 In Review / Done으로 변경했습니다.

---

## ⌨ 기타
