### PR TITLE
[HOTSPOT-164] 알림 내역 조회 Paging -> Slicing 전환

### DIFF
--- a/src/main/java/hotspot/user/notification/controller/response/NotificationListResponse.java
+++ b/src/main/java/hotspot/user/notification/controller/response/NotificationListResponse.java
@@ -12,7 +12,5 @@ public class NotificationListResponse {
     private List<NotificationResponse> notifications;
     private int page;
     private int size;
-    private int totalPages;
-    private long totalElements;
     private boolean hasNext;
 }

--- a/src/main/java/hotspot/user/notification/controller/swagger/NotificationApi.java
+++ b/src/main/java/hotspot/user/notification/controller/swagger/NotificationApi.java
@@ -20,7 +20,11 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 @Tag(name = "Notification", description = "사용자 알림 조회 및 읽음 처리 API")
 public interface NotificationApi {
 
-    @Operation(summary = "알림 목록 조회", description = "로그인한 사용자의 최근 30일 알림을 페이지 단위로 조회합니다.")
+    @Operation(
+            summary = "알림 목록 조회",
+            description = "로그인한 사용자의 최근 30일 알림을 Slice 기반으로 조회합니다. "
+                    + "응답의 hasNext를 기준으로 무한 스크롤을 처리합니다."
+    )
     @ApiResponses(value = {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
@@ -36,10 +40,10 @@ public interface NotificationApi {
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class))
             ),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "404",
-                description = "조회 대상을 찾을 수 없음\n"
-                    + "- NOTI_001: 알림 정보를 찾을 수 없습니다.",
-                content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+                    responseCode = "404",
+                    description = "조회 대상을 찾을 수 없음\n"
+                            + "- NOTI_001: 알림 정보를 찾을 수 없습니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
             )
     })
     ResponseEntity<ApiResponse<NotificationListResponse>> getNotifications(
@@ -47,7 +51,7 @@ public interface NotificationApi {
             Pageable pageable
     );
 
-    @Operation(summary = "미읽은 알림 개수 조회", description = "로그인한 사용자의 미읽은 알림 개수를 조회합니다.")
+    @Operation(summary = "미읽음 알림 개수 조회", description = "로그인한 사용자의 미읽음 알림 개수를 조회합니다.")
     @ApiResponses(value = {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
@@ -57,17 +61,17 @@ public interface NotificationApi {
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class))
             ),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "404",
-                description = "조회 대상을 찾을 수 없음\n"
-                    + "- NOTI_001: 알림 정보를 찾을 수 없습니다.",
-                content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+                    responseCode = "404",
+                    description = "조회 대상을 찾을 수 없음\n"
+                            + "- NOTI_001: 알림 정보를 찾을 수 없습니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
             )
     })
     ResponseEntity<ApiResponse<UnreadNotificationCountResponse>> getUnreadCount(
             @Parameter(hidden = true) @AuthenticationPrincipal PrincipalDetails details
     );
 
-    @Operation(summary = "알림 전체 읽음 처리", description = "로그인한 사용자의 알림을 전체 읽음 상태로 변경합니다.")
+    @Operation(summary = "알림 전체 읽음 처리", description = "로그인한 사용자의 모든 알림을 읽음 상태로 변경합니다.")
     @ApiResponses(value = {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "처리 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
@@ -77,17 +81,17 @@ public interface NotificationApi {
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class))
             ),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "404",
-                description = "처리 대상을 찾을 수 없음\n"
-                    + "- NOTI_001: 알림 정보를 찾을 수 없습니다.",
-                content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+                    responseCode = "404",
+                    description = "처리 대상을 찾을 수 없음\n"
+                            + "- NOTI_001: 알림 정보를 찾을 수 없습니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
             )
     })
     ResponseEntity<ApiResponse<Void>> markAllRead(
             @Parameter(hidden = true) @AuthenticationPrincipal PrincipalDetails details
     );
 
-    @Operation(summary = "알림 단건 읽음 처리", description = "로그인한 사용자의 특정 알림 1건을 읽음 상태로 변경합니다.")
+    @Operation(summary = "알림 단건 읽음 처리", description = "로그인한 사용자의 알림 1건을 읽음 상태로 변경합니다.")
     @ApiResponses(value = {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "처리 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
@@ -103,10 +107,10 @@ public interface NotificationApi {
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class))
             ),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "404",
-                description = "처리 대상을 찾을 수 없음\n"
-                    + "- NOTI_001: 알림 정보를 찾을 수 없습니다.",
-                content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+                    responseCode = "404",
+                    description = "처리 대상을 찾을 수 없음\n"
+                            + "- NOTI_001: 알림 정보를 찾을 수 없습니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
             )
     })
     ResponseEntity<ApiResponse<Void>> markRead(

--- a/src/main/java/hotspot/user/notification/domain/mapper/NotificationMapper.java
+++ b/src/main/java/hotspot/user/notification/domain/mapper/NotificationMapper.java
@@ -24,12 +24,10 @@ public final class NotificationMapper {
                 .build();
     }
 
-    // Slice 조회 결과를 알림 리스트 + page/size + hasNext를 포함한 목록 응답으로 변환한다.
+    // Slice 조회 결과를 알림 리스트와 page/size/hasNext를 포함한 응답으로 변환한다.
     public static NotificationListResponse toListResponse(Slice<Notification> notifications) {
         return NotificationListResponse.builder()
-                .notifications(notifications.getContent().stream()
-                        .map(NotificationMapper::toResponse)
-                        .toList())
+                .notifications(notifications.map(NotificationMapper::toResponse).getContent())
                 .page(notifications.getNumber())
                 .size(notifications.getSize())
                 .hasNext(notifications.hasNext())

--- a/src/main/java/hotspot/user/notification/domain/mapper/NotificationMapper.java
+++ b/src/main/java/hotspot/user/notification/domain/mapper/NotificationMapper.java
@@ -1,6 +1,6 @@
 package hotspot.user.notification.domain.mapper;
 
-import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Slice;
 
 import hotspot.user.notification.controller.response.NotificationListResponse;
 import hotspot.user.notification.controller.response.NotificationResponse;
@@ -11,7 +11,7 @@ public final class NotificationMapper {
     private NotificationMapper() {
     }
 
-    // Converts notification domain to response DTO.
+    // Notification 도메인 객체 1건을 API 응답 DTO로 변환한다.
     public static NotificationResponse toResponse(Notification notification) {
         return NotificationResponse.builder()
                 .id(notification.getId())
@@ -24,16 +24,14 @@ public final class NotificationMapper {
                 .build();
     }
 
-    // Converts paged notifications to list response DTO.
-    public static NotificationListResponse toListResponse(Page<Notification> notifications) {
+    // Slice 조회 결과를 알림 리스트 + page/size + hasNext를 포함한 목록 응답으로 변환한다.
+    public static NotificationListResponse toListResponse(Slice<Notification> notifications) {
         return NotificationListResponse.builder()
                 .notifications(notifications.getContent().stream()
                         .map(NotificationMapper::toResponse)
                         .toList())
                 .page(notifications.getNumber())
                 .size(notifications.getSize())
-                .totalPages(notifications.getTotalPages())
-                .totalElements(notifications.getTotalElements())
                 .hasNext(notifications.hasNext())
                 .build();
     }

--- a/src/main/java/hotspot/user/notification/infrastructure/NotificationJpaRepository.java
+++ b/src/main/java/hotspot/user/notification/infrastructure/NotificationJpaRepository.java
@@ -3,8 +3,8 @@ package hotspot.user.notification.infrastructure;
 import java.time.LocalDateTime;
 import java.util.Optional;
 
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -52,7 +52,7 @@ public interface NotificationJpaRepository extends JpaRepository<NotificationEnt
     Optional<NotificationEntity> findByEventIdAndSubscriptionSubId(String eventId, Long subId);
 
     // created_time이 기준 시각 이상인 알림을 최신순으로 조회한다.
-    Page<NotificationEntity> findBySubscriptionSubIdAndCreatedTimeGreaterThanEqualOrderByCreatedTimeDesc(
+    Slice<NotificationEntity> findBySubscriptionSubIdAndCreatedTimeGreaterThanEqualOrderByCreatedTimeDesc(
             Long subId,
             LocalDateTime cutoffDateTime,
             Pageable pageable

--- a/src/main/java/hotspot/user/notification/infrastructure/NotificationJpaRepository.java
+++ b/src/main/java/hotspot/user/notification/infrastructure/NotificationJpaRepository.java
@@ -52,7 +52,7 @@ public interface NotificationJpaRepository extends JpaRepository<NotificationEnt
     Optional<NotificationEntity> findByEventIdAndSubscriptionSubId(String eventId, Long subId);
 
     // created_time이 기준 시각 이상인 알림을 최신순으로 조회한다.
-    Slice<NotificationEntity> findBySubscriptionSubIdAndCreatedTimeGreaterThanEqualOrderByCreatedTimeDesc(
+    Slice<NotificationEntity> findBySubscriptionSubIdAndCreatedTimeGreaterThanEqual(
             Long subId,
             LocalDateTime cutoffDateTime,
             Pageable pageable

--- a/src/main/java/hotspot/user/notification/infrastructure/NotificationRepositoryImpl.java
+++ b/src/main/java/hotspot/user/notification/infrastructure/NotificationRepositoryImpl.java
@@ -45,7 +45,7 @@ public class NotificationRepositoryImpl implements NotificationRepository {
     public Slice<Notification> findRecentBySubId(Long subId, Pageable pageable) {
         LocalDateTime cutoffDateTime = LocalDateTime.now().minusDays(RECENT_DAYS);
         return notificationJpaRepository
-                .findBySubscriptionSubIdAndCreatedTimeGreaterThanEqualOrderByCreatedTimeDesc(
+                .findBySubscriptionSubIdAndCreatedTimeGreaterThanEqual(
                         subId,
                         cutoffDateTime,
                         pageable

--- a/src/main/java/hotspot/user/notification/infrastructure/NotificationRepositoryImpl.java
+++ b/src/main/java/hotspot/user/notification/infrastructure/NotificationRepositoryImpl.java
@@ -2,8 +2,8 @@ package hotspot.user.notification.infrastructure;
 
 import java.time.LocalDateTime;
 
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Repository;
 
 import hotspot.user.notification.domain.Notification;
@@ -42,7 +42,7 @@ public class NotificationRepositoryImpl implements NotificationRepository {
 
     // JPA 페이지 결과를 도메인 페이지로 변환한다.
     @Override
-    public Page<Notification> findRecentBySubId(Long subId, Pageable pageable) {
+    public Slice<Notification> findRecentBySubId(Long subId, Pageable pageable) {
         LocalDateTime cutoffDateTime = LocalDateTime.now().minusDays(RECENT_DAYS);
         return notificationJpaRepository
                 .findBySubscriptionSubIdAndCreatedTimeGreaterThanEqualOrderByCreatedTimeDesc(

--- a/src/main/java/hotspot/user/notification/infrastructure/NotificationRepositoryImpl.java
+++ b/src/main/java/hotspot/user/notification/infrastructure/NotificationRepositoryImpl.java
@@ -40,7 +40,7 @@ public class NotificationRepositoryImpl implements NotificationRepository {
                 .orElse(null);
     }
 
-    // JPA 페이지 결과를 도메인 페이지로 변환한다.
+    // JPA 페이지 결과를 슬라이스로 변환한다.
     @Override
     public Slice<Notification> findRecentBySubId(Long subId, Pageable pageable) {
         LocalDateTime cutoffDateTime = LocalDateTime.now().minusDays(RECENT_DAYS);

--- a/src/main/java/hotspot/user/notification/service/FindNotificationServiceImpl.java
+++ b/src/main/java/hotspot/user/notification/service/FindNotificationServiceImpl.java
@@ -1,8 +1,8 @@
 package hotspot.user.notification.service;
 
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -27,15 +27,17 @@ public class FindNotificationServiceImpl implements FindNotificationService {
     private final NotificationRepository notificationRepository;
     private final SubscriptionService subscriptionService;
 
+    // Pageable을 기본값/정렬로 보정해서 최신 알림을 Slice로 조회하고 목록 응답으로 반환한다.
     @Override
     public NotificationListResponse findNotifications(Long memberId, Pageable pageable) {
         Subscription subscription = subscriptionService.findByMemberId(memberId);
         Long subId = subscription.getId();
         Pageable normalizedPageable = normalizePageable(pageable);
-        Page<Notification> notifications = notificationRepository.findRecentBySubId(subId, normalizedPageable);
+        Slice<Notification> notifications = notificationRepository.findRecentBySubId(subId, normalizedPageable);
         return NotificationMapper.toListResponse(notifications);
     }
 
+    // 읽지 않은 알림 개수를 조회해 응답으로 반환한다.
     @Override
     public UnreadNotificationCountResponse findUnreadCount(Long memberId) {
         Subscription subscription = subscriptionService.findByMemberId(memberId);
@@ -45,6 +47,7 @@ public class FindNotificationServiceImpl implements FindNotificationService {
                 .build();
     }
 
+    // pageable이 없거나 값이 부족하면 기본 페이지/사이즈를 적용하고 createdTime 내림차순 정렬이 붙도록 Pageable을 표준화한다.
     private Pageable normalizePageable(Pageable pageable) {
         int page = pageable == null ? 0 : pageable.getPageNumber();
         int size = pageable == null ? DEFAULT_PAGE_SIZE : pageable.getPageSize();

--- a/src/main/java/hotspot/user/notification/service/port/NotificationRepository.java
+++ b/src/main/java/hotspot/user/notification/service/port/NotificationRepository.java
@@ -1,7 +1,7 @@
 package hotspot.user.notification.service.port;
 
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 
 import hotspot.user.notification.domain.Notification;
 
@@ -11,7 +11,7 @@ public interface NotificationRepository {
     Notification insertIfAbsent(Notification notification);
 
     // 특정 회선의 최근 알림을 페이지 단위로 조회한다.
-    Page<Notification> findRecentBySubId(Long subId, Pageable pageable);
+    Slice<Notification> findRecentBySubId(Long subId, Pageable pageable);
 
     // 특정 회선의 안 읽은 알림 개수를 조회한다.
     long countUnreadBySubId(Long subId);

--- a/src/main/java/hotspot/user/notification/service/port/NotificationRepository.java
+++ b/src/main/java/hotspot/user/notification/service/port/NotificationRepository.java
@@ -10,7 +10,7 @@ public interface NotificationRepository {
     // (eventId, subId)가 없을 때만 저장하고, 중복이면 저장하지 않는다.
     Notification insertIfAbsent(Notification notification);
 
-    // 특정 회선의 최근 알림을 페이지 단위로 조회한다.
+    // 특정 회선의 최근 알림을 슬라이스 단위로 조회한다.
     Slice<Notification> findRecentBySubId(Long subId, Pageable pageable);
 
     // 특정 회선의 안 읽은 알림 개수를 조회한다.

--- a/src/test/java/hotspot/user/notification/controller/NotificationControllerTest.java
+++ b/src/test/java/hotspot/user/notification/controller/NotificationControllerTest.java
@@ -74,8 +74,6 @@ class NotificationControllerTest {
                         .build()))
                 .page(0)
                 .size(20)
-                .totalPages(1)
-                .totalElements(1)
                 .hasNext(false)
                 .build();
 
@@ -89,7 +87,7 @@ class NotificationControllerTest {
                 .andExpect(jsonPath("$.data.notifications[0].id").value(10L))
                 .andExpect(jsonPath("$.data.notifications[0].eventId").value("evt-1"))
                 .andExpect(jsonPath("$.data.notifications[0].title").value("Data alert"))
-                .andExpect(jsonPath("$.data.totalElements").value(1));
+                .andExpect(jsonPath("$.data.hasNext").value(false));
 
         then(findNotificationService).should().findNotifications(eq(1L), isA(Pageable.class));
     }

--- a/src/test/java/hotspot/user/notification/infrastructure/NotificationRepositoryImplTest.java
+++ b/src/test/java/hotspot/user/notification/infrastructure/NotificationRepositoryImplTest.java
@@ -100,7 +100,7 @@ class NotificationRepositoryImplTest {
                 .build();
 
         given(notificationJpaRepository
-                .findBySubscriptionSubIdAndCreatedTimeGreaterThanEqualOrderByCreatedTimeDesc(
+                .findBySubscriptionSubIdAndCreatedTimeGreaterThanEqual(
                         eq(1L), any(), any()))
                 .willReturn(new SliceImpl<>(List.of(entity), PageRequest.of(0, 20), false));
 

--- a/src/test/java/hotspot/user/notification/infrastructure/NotificationRepositoryImplTest.java
+++ b/src/test/java/hotspot/user/notification/infrastructure/NotificationRepositoryImplTest.java
@@ -16,8 +16,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.SliceImpl;
 
 import hotspot.user.notification.domain.Notification;
 import hotspot.user.notification.infrastructure.entity.NotificationEntity;
@@ -102,7 +102,7 @@ class NotificationRepositoryImplTest {
         given(notificationJpaRepository
                 .findBySubscriptionSubIdAndCreatedTimeGreaterThanEqualOrderByCreatedTimeDesc(
                         eq(1L), any(), any()))
-                .willReturn(new PageImpl<>(List.of(entity), PageRequest.of(0, 20), 1));
+                .willReturn(new SliceImpl<>(List.of(entity), PageRequest.of(0, 20), false));
 
         var result = notificationRepository.findRecentBySubId(1L, PageRequest.of(0, 20));
 

--- a/src/test/java/hotspot/user/notification/service/FindNotificationServiceImplTest.java
+++ b/src/test/java/hotspot/user/notification/service/FindNotificationServiceImplTest.java
@@ -17,9 +17,9 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.SliceImpl;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import hotspot.user.common.exception.ApplicationException;
@@ -70,7 +70,7 @@ class FindNotificationServiceImplTest {
                 .build();
 
         given(notificationRepository.findRecentBySubId(eq(mySubId), any(Pageable.class)))
-                .willReturn(new PageImpl<>(List.of(notification), PageRequest.of(0, 20), 1));
+                .willReturn(new SliceImpl<>(List.of(notification), PageRequest.of(0, 20), false));
 
         NotificationListResponse response = findNotificationService.findNotifications(memberId, PageRequest.of(0, 10));
         @SuppressWarnings("unchecked")


### PR DESCRIPTION
## 🎫 지라 티켓

<!-- 지라 티켓을 작성해주세요 ex) HOTSPOT-123 -->
HOTSPOT-164

---

## 🔗 GitHub 이슈
<!-- 자동 close를 원하면 아래 형식으로 작성
예) Closes #12
-->
Closes #68 

---


## ✅ 작업 사항

<!-- 작업한 부분을 설명해주세요. -->
- 알림 내역 조회 페이징 방식을 Page 기반에서 Slice 기반으로 전환
- 서비스/리포지토리/JPA 레이어의 조회 반환 타입을 Page → Slice로 일괄 변경
- NotificationListResponse에서 무한 스크롤에 불필요한 totalPages, totalElements 필드 제거
- NotificationMapper를 Slice 입력 기준으로 수정하고 hasNext 중심 응답 매핑으로 변경
- 정렬/페이지 크기 처리는 유지하여 기존 API 사용성 보존
- 알림 관련 단위/웹 테스트를 PageImpl → SliceImpl 및 hasNext 검증 기준으로 업데이트

---

## 📋 체크리스트

<!-- PR 제출 전 확인해주세요. 해당 항목에 [x]로 체크해주세요. -->

- [x] 코드가 정상적으로 빌드됩니다.
- [x] 관련 테스트 코드를 작성했습니다.
- [x] 기존 테스트가 모두 통과합니다.
- [x] 코드 스타일(Spotless, Checkstyle)을 준수합니다.
- [x] Jira 티켓 상태를 In Review / Done으로 변경했습니다.

---

## ⌨ 기타
