### PR TITLE
[HOTSPOT-166] 사용자 알림 OutBox 패턴 구현

### DIFF
--- a/src/main/java/hotspot/user/dispatch/service/SubscribeSseServiceImpl.java
+++ b/src/main/java/hotspot/user/dispatch/service/SubscribeSseServiceImpl.java
@@ -2,6 +2,8 @@ package hotspot.user.dispatch.service;
 
 import java.time.LocalDateTime;
 
+import jakarta.transaction.Transactional;
+
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
@@ -18,6 +20,7 @@ import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class SubscribeSseServiceImpl implements SubscribeSseService {
 
     private static final long SSE_TIMEOUT_MILLIS = 30L * 60L * 1000L;

--- a/src/main/java/hotspot/user/kafka/outbox/NotificationUserAlertOutboxPublisher.java
+++ b/src/main/java/hotspot/user/kafka/outbox/NotificationUserAlertOutboxPublisher.java
@@ -1,0 +1,191 @@
+package hotspot.user.kafka.outbox;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import org.springframework.stereotype.Component;
+
+import hotspot.user.kafka.domain.KafkaEventType;
+import hotspot.user.kafka.dto.UserAlertEvent;
+import hotspot.user.outbox.service.NotificationOutboxEventAppender;
+import hotspot.user.policy.domain.PolicyType;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class NotificationUserAlertOutboxPublisher {
+
+    private static final String ALERT_APPLIED = "APPLIED";
+    private static final String ALERT_RELEASED = "RELEASED";
+    private static final String ALERT_GIFTED = "GIFTED";
+    private static final String aggregateType = "user-alert";
+
+    private final NotificationOutboxEventAppender outboxEventAppender;
+
+    // 정책 적용 알림 이벤트를 outbox에 적재한다.
+    public void publishPolicyApplied(Long subId, Long familyId, String policyName, PolicyType policyType) {
+        publishPolicyAlert(subId, familyId, policyName, policyType, ALERT_APPLIED, "POLICY_APPLIED");
+    }
+
+    // 정책 해제 알림 이벤트를 outbox에 적재한다.
+    public void publishPolicyReleased(Long subId, Long familyId, String policyName, PolicyType policyType) {
+        publishPolicyAlert(subId, familyId, policyName, policyType, ALERT_RELEASED, "POLICY_RELEASED");
+    }
+
+    // 서비스 접근 차단 알림 이벤트를 outbox에 적재한다.
+    public void publishServiceAccessApplied(Long subId, Long familyId, String serviceName) {
+        publishServiceAlert(subId, familyId, serviceName, ALERT_APPLIED, "SERVICE_ACCESS_APPLIED");
+    }
+
+    // 서비스 접근 해제 알림 이벤트를 outbox에 적재한다.
+    public void publishServiceAccessReleased(Long subId, Long familyId, String serviceName) {
+        publishServiceAlert(subId, familyId, serviceName, ALERT_RELEASED, "SERVICE_ACCESS_RELEASED");
+    }
+
+    // 데이터 선물 알림 이벤트를 outbox에 적재한다.
+    public void publishPresentDataGifted(
+            Long targetSubId,
+            Long familyId,
+            String senderName,
+            String presentAmount,
+            String giftId
+    ) {
+        UserAlertEvent event = baseEvent(targetSubId, familyId, KafkaEventType.PRESENT_DATA.name(), ALERT_GIFTED)
+                .withPresent(senderName, presentAmount, giftId)
+                .build();
+        append("PRESENT_DATA_GIFTED", event);
+    }
+
+    // 정책 타입에 따라 이벤트 타입을 결정해 정책 알림 이벤트를 구성한다.
+    private void publishPolicyAlert(
+            Long subId,
+            Long familyId,
+            String policyName,
+            PolicyType policyType,
+            String alertType,
+            String outboxType
+    ) {
+        String eventType = policyType == PolicyType.SCHEDULED
+                ? KafkaEventType.TIME_WINDOW_POLICY.name()
+                : KafkaEventType.IMMEDIATE_BLOCK.name();
+
+        UserAlertEvent event = baseEvent(subId, familyId, eventType, alertType)
+                .withPolicyName(policyName)
+                .build();
+
+        append(outboxType, event);
+    }
+
+    // 서비스 알림 이벤트를 공통 포맷으로 구성한다.
+    private void publishServiceAlert(
+            Long subId,
+            Long familyId,
+            String serviceName,
+            String alertType,
+            String outboxType
+    ) {
+        UserAlertEvent event = baseEvent(subId, familyId, KafkaEventType.SERVICE_ACCESS.name(), alertType)
+                .withServiceName(serviceName)
+                .build();
+        append(outboxType, event);
+    }
+
+    // 집계 메타데이터와 함께 이벤트를 outbox_event 테이블에 저장한다.
+    private void append(String type, UserAlertEvent event) {
+        String aggregateId = event.subId() != null
+                ? String.valueOf(event.subId())
+                : event.familyId() != null ? String.valueOf(event.familyId()) : event.alertId();
+
+        outboxEventAppender.append(
+                aggregateType,
+                aggregateId,
+                type,
+                event
+        );
+    }
+
+    // 모든 알림 이벤트에서 공통으로 쓰는 기본 필드를 만든다.
+    private UserAlertEventBuilder baseEvent(Long subId, Long familyId, String eventType, String alertType) {
+        String eventId = UUID.randomUUID().toString();
+        return new UserAlertEventBuilder(
+                eventId,
+                eventType,
+                alertType,
+                Instant.now(),
+                subId,
+                familyId
+        );
+    }
+
+    private static class UserAlertEventBuilder {
+
+        private final String alertId;
+        private final String eventType;
+        private final String alertType;
+        private final Instant occurredAt;
+        private final Long subId;
+        private final Long familyId;
+        private String policyName;
+        private String serviceName;
+        private String presentSenderName;
+        private String presentAmount;
+        private String giftId;
+
+        UserAlertEventBuilder(
+                String alertId,
+                String eventType,
+                String alertType,
+                Instant occurredAt,
+                Long subId,
+                Long familyId
+        ) {
+            this.alertId = alertId;
+            this.eventType = eventType;
+            this.alertType = alertType;
+            this.occurredAt = occurredAt;
+            this.subId = subId;
+            this.familyId = familyId;
+        }
+
+        // 정책명을 설정한다.
+        UserAlertEventBuilder withPolicyName(String policyName) {
+            this.policyName = policyName;
+            return this;
+        }
+
+        // 서비스명을 설정한다.
+        UserAlertEventBuilder withServiceName(String serviceName) {
+            this.serviceName = serviceName;
+            return this;
+        }
+
+        // 선물 발신자명, 선물 용량, 선물 ID를 설정한다.
+        UserAlertEventBuilder withPresent(String senderName, String amount, String giftId) {
+            this.presentSenderName = senderName;
+            this.presentAmount = amount;
+            this.giftId = giftId;
+            return this;
+        }
+
+        // 누적된 필드로 UserAlertEvent를 생성한다.
+        UserAlertEvent build() {
+            return new UserAlertEvent(
+                    alertId,
+                    eventType,
+                    alertType,
+                    null,
+                    policyName,
+                    serviceName,
+                    presentSenderName,
+                    presentAmount,
+                    occurredAt,
+                    subId,
+                    familyId,
+                    giftId,
+                    0L,
+                    0,
+                    alertId
+            );
+        }
+    }
+}

--- a/src/main/java/hotspot/user/outbox/infrastructure/NotificationOutboxEventJpaRepository.java
+++ b/src/main/java/hotspot/user/outbox/infrastructure/NotificationOutboxEventJpaRepository.java
@@ -1,0 +1,10 @@
+package hotspot.user.outbox.infrastructure;
+
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import hotspot.user.outbox.infrastructure.entity.NotificationOutboxEventEntity;
+
+public interface NotificationOutboxEventJpaRepository extends JpaRepository<NotificationOutboxEventEntity, UUID> {
+}

--- a/src/main/java/hotspot/user/outbox/infrastructure/entity/NotificationOutboxEventEntity.java
+++ b/src/main/java/hotspot/user/outbox/infrastructure/entity/NotificationOutboxEventEntity.java
@@ -1,0 +1,40 @@
+package hotspot.user.outbox.infrastructure.entity;
+
+import java.util.UUID;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Table(name = "notification_outbox_event")
+public class NotificationOutboxEventEntity {
+
+    @Id
+    @Column(name = "id", nullable = false, updatable = false)
+    private UUID id;
+
+    @Column(name = "aggregatetype", nullable = false, length = 100)
+    private String aggregateType;
+
+    @Column(name = "aggregateid", nullable = false, length = 100)
+    private String aggregateId;
+
+    @Column(name = "type", nullable = false, length = 100)
+    private String type;
+
+    @Column(name = "payload", nullable = false, columnDefinition = "TEXT")
+    private String payload;
+
+}

--- a/src/main/java/hotspot/user/outbox/service/NotificationOutboxEventAppender.java
+++ b/src/main/java/hotspot/user/outbox/service/NotificationOutboxEventAppender.java
@@ -1,0 +1,47 @@
+package hotspot.user.outbox.service;
+
+import java.util.UUID;
+
+import jakarta.transaction.Transactional;
+
+import org.springframework.stereotype.Service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import hotspot.user.common.exception.ApplicationException;
+import hotspot.user.common.exception.code.GlobalErrorCode;
+import hotspot.user.outbox.infrastructure.NotificationOutboxEventJpaRepository;
+import hotspot.user.outbox.infrastructure.entity.NotificationOutboxEventEntity;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class NotificationOutboxEventAppender {
+
+    private final NotificationOutboxEventJpaRepository outboxEventJpaRepository;
+    private final ObjectMapper objectMapper;
+
+    // 단일 outbox 이벤트 레코드를 outbox_event 테이블에 저장한다.
+    public void append(String aggregateType, String aggregateId, String type, Object payload) {
+        outboxEventJpaRepository.save(
+                NotificationOutboxEventEntity.builder()
+                        .id(UUID.randomUUID())
+                        .aggregateType(aggregateType)
+                        .aggregateId(aggregateId)
+                        .type(type)
+                        .payload(toJson(payload))
+                        .build()
+        );
+    }
+
+    // payload 객체를 JSON 문자열로 직렬화한다.
+    private String toJson(Object payload) {
+        try {
+            return objectMapper.writeValueAsString(payload);
+        } catch (JsonProcessingException ex) {
+            throw new ApplicationException(GlobalErrorCode.INTERNAL_SERVER_ERROR);
+        }
+    }
+}

--- a/src/main/java/hotspot/user/policy/service/UpdateAppBlockedServiceServiceImpl.java
+++ b/src/main/java/hotspot/user/policy/service/UpdateAppBlockedServiceServiceImpl.java
@@ -1,7 +1,10 @@
 package hotspot.user.policy.service;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.springframework.stereotype.Service;
@@ -12,17 +15,19 @@ import hotspot.user.common.exception.code.AuthErrorCode;
 import hotspot.user.common.exception.code.FamilyErrorCode;
 import hotspot.user.family.domain.FamilySubscription;
 import hotspot.user.family.service.port.FamilySubscriptionRepository;
+import hotspot.user.kafka.outbox.NotificationUserAlertOutboxPublisher;
 import hotspot.user.member.domain.FamilyRole;
 import hotspot.user.policy.controller.port.UpdateAppBlockedServiceService;
 import hotspot.user.policy.controller.request.UpdateAppBlockedServiceRequest;
 import hotspot.user.policy.controller.response.UpdateAppBlockedServiceResponse;
+import hotspot.user.policy.domain.AppBlockedService;
 import hotspot.user.policy.domain.mapper.AppBlockedServiceMapper;
 import hotspot.user.policy.service.port.AppBlockedServiceRepository;
 import hotspot.user.policy.service.port.BlockedServiceSubRepository;
 import lombok.RequiredArgsConstructor;
 
 /**
- * 구성원별 차단 앱 서비스 업데이트 서비스 코드 구현체
+ * 회선의 앱 차단 서비스 목록을 갱신한다.
  */
 @Service
 @RequiredArgsConstructor
@@ -32,6 +37,7 @@ public class UpdateAppBlockedServiceServiceImpl implements UpdateAppBlockedServi
     private final BlockedServiceSubRepository blockedServiceSubRepository;
     private final FamilySubscriptionRepository familySubscriptionRepository;
     private final AppBlockedServiceRepository appBlockedServiceRepository;
+    private final NotificationUserAlertOutboxPublisher userAlertOutboxPublisher;
 
     @Override
     public UpdateAppBlockedServiceResponse updateAppBlockedService(
@@ -39,14 +45,14 @@ public class UpdateAppBlockedServiceServiceImpl implements UpdateAppBlockedServi
             Long requesterFamilyId,
             FamilyRole requesterRole) {
 
-        // 1. OWNER 권한 체크
+        // 차단 서비스 변경은 OWNER만 가능하다.
         if (requesterRole != FamilyRole.OWNER) {
             throw new ApplicationException(AuthErrorCode.ACCESS_DENIED);
         }
 
         Long subId = request.subId();
 
-        // 2. 수정 대상 회선이 존재하는지 & 요청자와 같은 가족인지 확인
+        // 대상 회선과 가족 소속을 검증한다.
         FamilySubscription familySub = familySubscriptionRepository.findBySubId(subId)
                 .orElseThrow(() -> new ApplicationException(FamilyErrorCode.FAMILY_SUBSCRIPTION_NOT_FOUND));
 
@@ -54,7 +60,7 @@ public class UpdateAppBlockedServiceServiceImpl implements UpdateAppBlockedServi
             throw new ApplicationException(FamilyErrorCode.NOT_FAMILY_MEMBER);
         }
 
-        // 3. 요청된 앱 ID들이 모두 유효한지 확인 (마스터 데이터 존재 여부)
+        // 요청된 서비스 ID가 모두 유효한지 검증한다.
         Set<Long> targetIds = new HashSet<>(request.blockedServiceIdList());
         if (!targetIds.isEmpty()) {
             long validCount = appBlockedServiceRepository.countByIdIn(targetIds);
@@ -63,32 +69,66 @@ public class UpdateAppBlockedServiceServiceImpl implements UpdateAppBlockedServi
             }
         }
 
-        // 4. 기존 DB 상태 조회 (현재 차단된 ID들만 직접 조회하여 NPE 방지)
+        // 현재 활성 차단 서비스 ID 목록을 조회한다.
         Set<Long> existingIds = new HashSet<>(blockedServiceSubRepository.findActiveServiceIdsBySubId(subId));
 
-        // 5. 차집합 계산
-        // (1) 새로 추가해야 할 ID들 (목표 리스트 - 기존 리스트)
+        // 변경분 계산: 추가/해제 대상 서비스 ID.
         Set<Long> toAddIds = new HashSet<>(targetIds);
         toAddIds.removeAll(existingIds);
 
-        // (2) 차단 해제해야 할 ID들 (기존 리스트 - 목표 리스트)
         Set<Long> toRemoveIds = new HashSet<>(existingIds);
         toRemoveIds.removeAll(targetIds);
 
-        // 6. 벌크 연산 수행 (쿼리 최소화)
         if (!toAddIds.isEmpty()) {
             blockedServiceSubRepository.saveAll(subId, toAddIds);
         }
         if (!toRemoveIds.isEmpty()) {
             blockedServiceSubRepository.deleteAll(subId, toRemoveIds);
         }
+        publishServiceAccessAlerts(subId, familySub.getFamily().getId(), toAddIds, toRemoveIds);
 
-        // 7. 최종 동기화 결과 재조회 및 반환 (ID 리스트만 직접 조회)
         List<Long> finalBlockedIdList = blockedServiceSubRepository.findActiveServiceIdsBySubId(subId);
 
         return AppBlockedServiceMapper.toUpdateAppBlockedServiceResponse(
                 familySub.getFamily().getId(),
                 subId,
                 finalBlockedIdList);
+    }
+
+    // 변경된 서비스 ID 기준으로 차단/해제 알림 outbox 이벤트를 발행한다.
+    private void publishServiceAccessAlerts(
+            Long subId,
+            Long familyId,
+            Set<Long> addedServiceIds,
+            Set<Long> removedServiceIds
+    ) {
+        Set<Long> changedServiceIds = new HashSet<>(addedServiceIds);
+        changedServiceIds.addAll(removedServiceIds);
+        if (changedServiceIds.isEmpty()) {
+            return;
+        }
+
+        Map<Long, String> serviceNameById = new HashMap<>();
+        List<AppBlockedService> services = appBlockedServiceRepository.findAllByAppBlockedServiceIds(
+                new ArrayList<>(changedServiceIds)
+        );
+        for (AppBlockedService service : services) {
+            serviceNameById.put(service.getId(), service.getName());
+        }
+
+        for (Long serviceId : addedServiceIds) {
+            userAlertOutboxPublisher.publishServiceAccessApplied(
+                    subId,
+                    familyId,
+                    serviceNameById.getOrDefault(serviceId, "service")
+            );
+        }
+        for (Long serviceId : removedServiceIds) {
+            userAlertOutboxPublisher.publishServiceAccessReleased(
+                    subId,
+                    familyId,
+                    serviceNameById.getOrDefault(serviceId, "service")
+            );
+        }
     }
 }

--- a/src/main/java/hotspot/user/policy/service/UpdateBlockPolicyServiceImpl.java
+++ b/src/main/java/hotspot/user/policy/service/UpdateBlockPolicyServiceImpl.java
@@ -14,6 +14,7 @@ import hotspot.user.common.exception.code.FamilyErrorCode;
 import hotspot.user.common.exception.code.PolicyErrorCode;
 import hotspot.user.family.domain.FamilySubscription;
 import hotspot.user.family.service.port.FamilySubscriptionRepository;
+import hotspot.user.kafka.outbox.NotificationUserAlertOutboxPublisher;
 import hotspot.user.member.domain.FamilyRole;
 import hotspot.user.policy.controller.port.UpdateBlockPolicyService;
 import hotspot.user.policy.controller.request.UpdateBlockPolicyRequest;
@@ -21,13 +22,14 @@ import hotspot.user.policy.controller.response.UpdateBlockPolicyResponse;
 import hotspot.user.policy.domain.BlockPolicy;
 import hotspot.user.policy.domain.DateSnapshot;
 import hotspot.user.policy.domain.PolicySub;
+import hotspot.user.policy.domain.PolicyType;
 import hotspot.user.policy.domain.mapper.BlockPolicyMapper;
 import hotspot.user.policy.service.port.BlockPolicyRepository;
 import hotspot.user.policy.service.port.PolicySubRepository;
 import lombok.RequiredArgsConstructor;
 
 /**
- * 구성원별 정책 업데이트 서비스 코드 구현체
+ * 회선에 적용된 차단 정책을 갱신한다.
  */
 @Service
 @RequiredArgsConstructor
@@ -37,6 +39,7 @@ public class UpdateBlockPolicyServiceImpl implements UpdateBlockPolicyService {
     private final PolicySubRepository policySubRepository;
     private final FamilySubscriptionRepository familySubscriptionRepository;
     private final BlockPolicyRepository blockPolicyRepository;
+    private final NotificationUserAlertOutboxPublisher userAlertOutboxPublisher;
 
     @Override
     public UpdateBlockPolicyResponse updateBlockPolicy(
@@ -44,58 +47,54 @@ public class UpdateBlockPolicyServiceImpl implements UpdateBlockPolicyService {
             Long requesterFamilyId,
             FamilyRole requesterRole) {
 
-        // 1. 권한 및 가족 매핑 검증
+        // 요청자의 권한과 가족 소속을 검증한다.
         validateAuthorityAndFamily(request.subId(), requesterFamilyId, requesterRole);
 
         List<Long> targetIdsList = request.blockPolicyIdList();
 
-        // 2. 요청된 원본 정책 전체 조회 & 예외 처리 로직
+        // 요청된 정책을 조회하고 누락된 ID가 없는지 확인한다.
         List<BlockPolicy> targetPolicies = blockPolicyRepository.findAllById(targetIdsList);
         if (!targetIdsList.isEmpty() && targetPolicies.size() != targetIdsList.size()) {
             throw new ApplicationException(PolicyErrorCode.POLICY_NOT_FOUND);
         }
 
-        // 3. 기존 DB 상태 조회 (현재 '활성화된(isDeleted=false)' 데이터만 조회)
+        // 현재 활성 정책 매핑을 policyId 기준으로 정리한다.
         List<PolicySub> activeSubs = policySubRepository.findBySubId(request.subId());
         Map<Long, PolicySub> activeMap = activeSubs.stream()
                 .collect(Collectors.toMap(PolicySub::getPolicyId, sub -> sub));
 
-        // 영속화(Save/Update) 대상 도메인 객체들을 담을 리스트
         List<PolicySub> domainsToSave = new ArrayList<>();
 
-        // 4. 요청된 타겟 정책들 처리 (기존 비활성화 + 신규 Insert)
+        // 요청 정책은 기존 매핑을 soft-delete하고 스냅샷 기반 새 매핑을 추가한다.
         for (BlockPolicy policy : targetPolicies) {
             DateSnapshot newSnapshot = createSnapshotFrom(policy);
 
-            // 해당 정책이 이미 활성화 상태라면, 기존 레코드를 비활성화(Delete) 처리
             if (activeMap.containsKey(policy.getId())) {
                 PolicySub oldSub = activeMap.get(policy.getId());
-                oldSub.delete(); // isDeleted = true 로 상태 변경
+                oldSub.delete();
                 domainsToSave.add(oldSub);
-
-                activeMap.remove(policy.getId()); // 처리 완료된 항목은 Map에서 제거
+                activeMap.remove(policy.getId());
             }
 
-            // 무조건 신규 도메인 객체 생성 (새로운 스냅샷으로 Insert)
             PolicySub newSub = PolicySub.builder()
                     .subId(request.subId())
                     .policyId(policy.getId())
                     .dateSnapshot(newSnapshot)
-                    .isDeleted(false) // 활성화 상태로 생성
+                    .isDeleted(false)
                     .build();
             domainsToSave.add(newSub);
         }
 
-        // 5. 요청 목록에 없는 나머지 기존 활성 정책들 처리 (순수 비활성화)
+        // 요청에서 제외된 기존 활성 매핑은 soft-delete 처리한다.
         for (PolicySub remainingSub : activeMap.values()) {
             remainingSub.delete();
             domainsToSave.add(remainingSub);
         }
 
-        // 6. 도메인 객체 리스트를 Port(어댑터)로 전달하여 일괄 영속화
         policySubRepository.saveAll(domainsToSave);
+        publishPolicyAppliedAlerts(targetPolicies, request.subId(), requesterFamilyId);
+        publishPolicyReleasedAlerts(activeMap.values(), request.subId(), requesterFamilyId);
 
-        // 7. 최종 결과 반환
         return BlockPolicyMapper.toUpdateBlockPolicyResponse(
                 requesterFamilyId,
                 request.subId(),
@@ -103,7 +102,7 @@ public class UpdateBlockPolicyServiceImpl implements UpdateBlockPolicyService {
         );
     }
 
-    // 권한 및 같은 가족인지 검증
+    // 요청자 권한과 가족 소유 관계를 검증한다.
     private void validateAuthorityAndFamily(Long subId, Long requesterFamilyId, FamilyRole requesterRole) {
         if (requesterRole != FamilyRole.OWNER) {
             throw new ApplicationException(AuthErrorCode.ACCESS_DENIED);
@@ -117,12 +116,39 @@ public class UpdateBlockPolicyServiceImpl implements UpdateBlockPolicyService {
         }
     }
 
-    // PolicySub에 저장할 DateSnapshot 조립하는 메서드
+    // 정책-회선 매핑에 저장할 스냅샷을 생성한다.
     private DateSnapshot createSnapshotFrom(BlockPolicy policy) {
         return DateSnapshot.builder()
                 .policyName(policy.getName())
                 .policyType(policy.getPolicyType())
                 .data(policy.getPolicySnapshot())
                 .build();
+    }
+
+    // 적용된 정책에 대한 알림 outbox 이벤트를 발행한다.
+    private void publishPolicyAppliedAlerts(List<BlockPolicy> policies, Long subId, Long familyId) {
+        for (BlockPolicy policy : policies) {
+            userAlertOutboxPublisher.publishPolicyApplied(
+                    subId,
+                    familyId,
+                    policy.getName(),
+                    policy.getPolicyType()
+            );
+        }
+    }
+
+    // 해제된 정책에 대한 알림 outbox 이벤트를 발행한다.
+    private void publishPolicyReleasedAlerts(Iterable<PolicySub> removedPolicies, Long subId, Long familyId) {
+        for (PolicySub removedPolicy : removedPolicies) {
+            DateSnapshot snapshot = removedPolicy.getDateSnapshot();
+            String policyName = snapshot != null ? snapshot.getPolicyName() : "policy";
+            PolicyType policyType = snapshot != null ? snapshot.getPolicyType() : null;
+            userAlertOutboxPublisher.publishPolicyReleased(
+                    subId,
+                    familyId,
+                    policyName,
+                    policyType
+            );
+        }
     }
 }

--- a/src/test/java/hotspot/user/kafka/outbox/NotificationUserAlertOutboxPublisherTest.java
+++ b/src/test/java/hotspot/user/kafka/outbox/NotificationUserAlertOutboxPublisherTest.java
@@ -1,0 +1,116 @@
+package hotspot.user.kafka.outbox;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.then;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import hotspot.user.kafka.dto.UserAlertEvent;
+import hotspot.user.outbox.service.NotificationOutboxEventAppender;
+import hotspot.user.policy.domain.PolicyType;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationUserAlertOutboxPublisherTest {
+
+    @Mock
+    private NotificationOutboxEventAppender outboxEventAppender;
+
+    @InjectMocks
+    private NotificationUserAlertOutboxPublisher publisher;
+
+    @Test
+    @DisplayName("publishPolicyApplied: SCHEDULED 정책은 TIME_WINDOW_POLICY 이벤트로 저장한다")
+    void publishPolicyAppliedWithScheduledType() {
+        publisher.publishPolicyApplied(101L, 11L, "study-time", PolicyType.SCHEDULED);
+
+        assertOutbox("101", "POLICY_APPLIED", "TIME_WINDOW_POLICY", "APPLIED", "study-time", null, null, null, null);
+    }
+
+    @Test
+    @DisplayName("publishPolicyReleased: ONCE 정책은 IMMEDIATE_BLOCK 이벤트로 저장한다")
+    void publishPolicyReleasedWithImmediateType() {
+        publisher.publishPolicyReleased(202L, 22L, "night-block", PolicyType.ONCE);
+
+        assertOutbox("202", "POLICY_RELEASED", "IMMEDIATE_BLOCK", "RELEASED", "night-block", null, null, null, null);
+    }
+
+    @Test
+    @DisplayName("publishServiceAccessApplied: 서비스 차단 적용 이벤트를 저장한다")
+    void publishServiceAccessApplied() {
+        publisher.publishServiceAccessApplied(303L, 33L, "YouTube");
+
+        assertOutbox("303", "SERVICE_ACCESS_APPLIED", "SERVICE_ACCESS", "APPLIED", null, "YouTube", null, null, null);
+    }
+
+    @Test
+    @DisplayName("publishServiceAccessReleased: subId가 없으면 familyId를 aggregateId로 사용한다")
+    void publishServiceAccessReleasedUsesFamilyIdAsAggregateIdWhenSubIdMissing() {
+        publisher.publishServiceAccessReleased(null, 44L, "Instagram");
+
+        assertOutbox(
+                "44",
+                "SERVICE_ACCESS_RELEASED",
+                "SERVICE_ACCESS",
+                "RELEASED",
+                null,
+                "Instagram",
+                null,
+                null,
+                null
+        );
+    }
+
+    @Test
+    @DisplayName("publishPresentDataGifted: 선물 데이터 이벤트를 저장한다")
+    void publishPresentDataGifted() {
+        publisher.publishPresentDataGifted(505L, 55L, "Alice", "1GB", "gift-1");
+
+        assertOutbox("505", "PRESENT_DATA_GIFTED", "PRESENT_DATA", "GIFTED", null, null, "Alice", "1GB", "gift-1");
+    }
+
+    private void assertOutbox(
+            String expectedAggregateId,
+            String expectedType,
+            String expectedEventType,
+            String expectedAlertType,
+            String expectedPolicyName,
+            String expectedServiceName,
+            String expectedSenderName,
+            String expectedAmount,
+            String expectedGiftId
+    ) {
+        ArgumentCaptor<String> aggregateTypeCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> aggregateIdCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> typeCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<Object> payloadCaptor = ArgumentCaptor.forClass(Object.class);
+
+        then(outboxEventAppender).should().append(
+                aggregateTypeCaptor.capture(),
+                aggregateIdCaptor.capture(),
+                typeCaptor.capture(),
+                payloadCaptor.capture()
+        );
+
+        assertThat(aggregateTypeCaptor.getValue()).isEqualTo("user-alert");
+        assertThat(aggregateIdCaptor.getValue()).isEqualTo(expectedAggregateId);
+        assertThat(typeCaptor.getValue()).isEqualTo(expectedType);
+
+        UserAlertEvent event = (UserAlertEvent) payloadCaptor.getValue();
+        assertThat(event.alertId()).isNotBlank();
+        assertThat(event.sourceEventId()).isEqualTo(event.alertId());
+        assertThat(event.occurredAt()).isNotNull();
+        assertThat(event.eventType()).isEqualTo(expectedEventType);
+        assertThat(event.alertType()).isEqualTo(expectedAlertType);
+        assertThat(event.policyName()).isEqualTo(expectedPolicyName);
+        assertThat(event.serviceName()).isEqualTo(expectedServiceName);
+        assertThat(event.presentSenderName()).isEqualTo(expectedSenderName);
+        assertThat(event.presentAmount()).isEqualTo(expectedAmount);
+        assertThat(event.giftId()).isEqualTo(expectedGiftId);
+    }
+}

--- a/src/test/java/hotspot/user/outbox/service/NotificationOutboxEventAppenderTest.java
+++ b/src/test/java/hotspot/user/outbox/service/NotificationOutboxEventAppenderTest.java
@@ -1,0 +1,72 @@
+package hotspot.user.outbox.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import hotspot.user.common.exception.ApplicationException;
+import hotspot.user.common.exception.code.GlobalErrorCode;
+import hotspot.user.outbox.infrastructure.NotificationOutboxEventJpaRepository;
+import hotspot.user.outbox.infrastructure.entity.NotificationOutboxEventEntity;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationOutboxEventAppenderTest {
+
+    @Mock
+    private NotificationOutboxEventJpaRepository outboxEventJpaRepository;
+
+    @Mock
+    private ObjectMapper objectMapper;
+
+    @InjectMocks
+    private NotificationOutboxEventAppender appender;
+
+    @Test
+    @DisplayName("append: payload를 JSON으로 저장한다")
+    void appendSavesSerializedPayload() throws Exception {
+        Map<String, Object> payload = Map.of("key", "value");
+        given(objectMapper.writeValueAsString(payload)).willReturn("{\"key\":\"value\"}");
+
+        appender.append("user-alert", "101", "POLICY_APPLIED", payload);
+
+        ArgumentCaptor<NotificationOutboxEventEntity> captor =
+                ArgumentCaptor.forClass(NotificationOutboxEventEntity.class);
+        then(outboxEventJpaRepository).should().save(captor.capture());
+
+        NotificationOutboxEventEntity entity = captor.getValue();
+        assertThat(entity.getId()).isNotNull();
+        assertThat(entity.getAggregateType()).isEqualTo("user-alert");
+        assertThat(entity.getAggregateId()).isEqualTo("101");
+        assertThat(entity.getType()).isEqualTo("POLICY_APPLIED");
+        assertThat(entity.getPayload()).isEqualTo("{\"key\":\"value\"}");
+    }
+
+    @Test
+    @DisplayName("append: 직렬화 실패 시 INTERNAL_SERVER_ERROR를 던진다")
+    void appendThrowsWhenSerializationFails() throws Exception {
+        Object payload = new Object();
+        given(objectMapper.writeValueAsString(payload)).willThrow(new JsonProcessingException("boom") {
+        });
+
+        assertThatThrownBy(() -> appender.append("user-alert", "101", "POLICY_APPLIED", payload))
+                .isInstanceOf(ApplicationException.class)
+                .satisfies(ex -> assertThat(((ApplicationException) ex).getCode())
+                        .isEqualTo(GlobalErrorCode.INTERNAL_SERVER_ERROR));
+
+        then(outboxEventJpaRepository).shouldHaveNoInteractions();
+    }
+}

--- a/src/test/java/hotspot/user/policy/service/UpdateAppBlockedServiceServiceImplTest.java
+++ b/src/test/java/hotspot/user/policy/service/UpdateAppBlockedServiceServiceImplTest.java
@@ -2,6 +2,7 @@ package hotspot.user.policy.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.BDDMockito.given;
@@ -24,9 +25,11 @@ import hotspot.user.common.exception.code.FamilyErrorCode;
 import hotspot.user.family.domain.Family;
 import hotspot.user.family.domain.FamilySubscription;
 import hotspot.user.family.service.port.FamilySubscriptionRepository;
+import hotspot.user.kafka.outbox.NotificationUserAlertOutboxPublisher;
 import hotspot.user.member.domain.FamilyRole;
 import hotspot.user.policy.controller.request.UpdateAppBlockedServiceRequest;
 import hotspot.user.policy.controller.response.UpdateAppBlockedServiceResponse;
+import hotspot.user.policy.domain.AppBlockedService;
 import hotspot.user.policy.service.port.AppBlockedServiceRepository;
 import hotspot.user.policy.service.port.BlockedServiceSubRepository;
 
@@ -41,6 +44,9 @@ class UpdateAppBlockedServiceServiceImplTest {
 
     @Mock
     private AppBlockedServiceRepository appBlockedServiceRepository;
+
+    @Mock
+    private NotificationUserAlertOutboxPublisher userAlertOutboxPublisher;
 
     @InjectMocks
     private UpdateAppBlockedServiceServiceImpl service;
@@ -61,6 +67,12 @@ class UpdateAppBlockedServiceServiceImplTest {
         given(familySubscriptionRepository.findBySubId(subId)).willReturn(Optional.of(familySub));
         given(appBlockedServiceRepository.countByIdIn(anySet())).willReturn(2L); // 2개 요청 -> 2개 유효
         given(blockedServiceSubRepository.findActiveServiceIdsBySubId(subId)).willReturn(List.of(1L, 2L));
+        given(appBlockedServiceRepository.findAllByAppBlockedServiceIds(anyList()))
+                .willReturn(List.of(
+                        AppBlockedService.builder().id(1L).name("YouTube").build(),
+                        AppBlockedService.builder().id(2L).name("TikTok").build(),
+                        AppBlockedService.builder().id(3L).name("Instagram").build()
+                ));
 
         // when
         UpdateAppBlockedServiceResponse response =

--- a/src/test/java/hotspot/user/policy/service/UpdateBlockPolicyServiceImplTest.java
+++ b/src/test/java/hotspot/user/policy/service/UpdateBlockPolicyServiceImplTest.java
@@ -24,6 +24,7 @@ import hotspot.user.common.exception.code.PolicyErrorCode;
 import hotspot.user.family.domain.Family;
 import hotspot.user.family.domain.FamilySubscription;
 import hotspot.user.family.service.port.FamilySubscriptionRepository;
+import hotspot.user.kafka.outbox.NotificationUserAlertOutboxPublisher;
 import hotspot.user.member.domain.FamilyRole;
 import hotspot.user.policy.controller.request.UpdateBlockPolicyRequest;
 import hotspot.user.policy.controller.response.UpdateBlockPolicyResponse;
@@ -46,6 +47,9 @@ class UpdateBlockPolicyServiceImplTest {
 
     @Mock
     private BlockPolicyRepository blockPolicyRepository;
+
+    @Mock
+    private NotificationUserAlertOutboxPublisher userAlertOutboxPublisher;
 
     @Test
     @DisplayName("성공: 유효한 요청일 경우 구성원에게 적용된 정책이 업데이트된다")
@@ -137,7 +141,7 @@ class UpdateBlockPolicyServiceImplTest {
     }
 
     @Test
-    @DisplayName("실패: 요청한 정책 중 일부가 존재하지 않으면 예외가 발생한다")
+    @DisplayName("?ㅽ뙣: ?붿껌???뺤콉 以??쇰?媛 議댁옱?섏? ?딆쑝硫??덉쇅媛 諛쒖깮?쒕떎")
     void updateBlockPolicyFailByPolicyNotFound() {
         // given
         UpdateBlockPolicyRequest request = new UpdateBlockPolicyRequest(100L, 1L, List.of(1L, 2L));


### PR DESCRIPTION
## 🎫 지라 티켓

<!-- 지라 티켓을 작성해주세요 ex) HOTSPOT-123 -->
HOTSPOT-166

---

## 🔗 GitHub 이슈
<!-- 자동 close를 원하면 아래 형식으로 작성
예) Closes #12
-->
Closes #74 

---


## ✅ 작업 사항

<!-- 작업한 부분을 설명해주세요. -->
- 사용자 알림 Outbox 발행 구조 추가
- notification_outbox_event 저장을 위한 엔티티/리포지토리/앱렌더 서비스 추가
- 정책 변경 로직에서 알림 이벤트를 Outbox로 발행하도록 연동
- 앱 차단 서비스 변경 시 적용/해제 이벤트 발행 로직 추가
- 차단 정책 변경 시 적용/해제 이벤트 발행 로직 추가
- NotificationUserAlertOutboxPublisher 단위 테스트 추가
- NotificationOutboxEventAppender 단위 테스트 추가

---

## 📋 체크리스트

<!-- PR 제출 전 확인해주세요. 해당 항목에 [x]로 체크해주세요. -->

- [x] 코드가 정상적으로 빌드됩니다.
- [x] 관련 테스트 코드를 작성했습니다.
- [x] 기존 테스트가 모두 통과합니다.
- [x] 코드 스타일(Spotless, Checkstyle)을 준수합니다.
- [x] Jira 티켓 상태를 In Review / Done으로 변경했습니다.

---

## ⌨ 기타
