### PR TITLE
[HOTSPOT-166] 사용자 알림 OutBox 패턴 동기화 리팩토링

### DIFF
--- a/src/main/java/hotspot/user/common/exception/ApplicationException.java
+++ b/src/main/java/hotspot/user/common/exception/ApplicationException.java
@@ -7,4 +7,8 @@ public class ApplicationException extends BaseException {
   public ApplicationException(BaseErrorCode code) {
     super(code);
   }
+
+  public ApplicationException(BaseErrorCode code, Throwable cause) {
+    super(code, cause);
+  }
 }

--- a/src/main/java/hotspot/user/common/exception/BaseException.java
+++ b/src/main/java/hotspot/user/common/exception/BaseException.java
@@ -13,6 +13,11 @@ public abstract class BaseException extends RuntimeException {
     this.code = code;
   }
 
+  protected BaseException(BaseErrorCode code, Throwable cause) {
+    super(code.getMessage(), cause);
+    this.code = code;
+  }
+
   public static <T extends BaseException> T from(BaseErrorCode code, Class<T> exceptionClass) {
     try {
       return exceptionClass.getConstructor(BaseErrorCode.class).newInstance(code);

--- a/src/main/java/hotspot/user/common/exception/ExceptionAdvice.java
+++ b/src/main/java/hotspot/user/common/exception/ExceptionAdvice.java
@@ -20,7 +20,7 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
   @ExceptionHandler(BaseException.class)
   public ResponseEntity<Object> handleBaseException(BaseException e, HttpServletRequest request) {
     BaseErrorCode code = e.getCode();
-    log.error("[BaseException] {} - {}", code.name(), code.getMessage());
+    log.error("[BaseException] {} - {}", code.name(), code.getMessage(), e);
 
     ErrorResponse response =
         new ErrorResponse(code.getHttpStatus().value(), code.getCustomCode(), code.getMessage());

--- a/src/main/java/hotspot/user/common/exception/code/OutboxErrorCode.java
+++ b/src/main/java/hotspot/user/common/exception/code/OutboxErrorCode.java
@@ -13,6 +13,16 @@ public enum OutboxErrorCode implements BaseErrorCode {
             "OUTBOX_001",
             "Outbox payload serialization failed."
     ),
+    OUTBOX_EVENT_SAVE_FAILED(
+            HttpStatus.INTERNAL_SERVER_ERROR,
+            "OUTBOX_002",
+            "Outbox event save failed."
+    ),
+    OUTBOX_EVENT_PUBLISH_FAILED(
+            HttpStatus.INTERNAL_SERVER_ERROR,
+            "OUTBOX_003",
+            "Outbox event publish failed."
+    ),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/hotspot/user/common/exception/code/OutboxErrorCode.java
+++ b/src/main/java/hotspot/user/common/exception/code/OutboxErrorCode.java
@@ -1,0 +1,21 @@
+package hotspot.user.common.exception.code;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum OutboxErrorCode implements BaseErrorCode {
+    OUTBOX_PAYLOAD_SERIALIZATION_FAILED(
+            HttpStatus.INTERNAL_SERVER_ERROR,
+            "OUTBOX_001",
+            "Outbox payload serialization failed."
+    ),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String customCode;
+    private final String message;
+}

--- a/src/main/java/hotspot/user/common/exception/code/OutboxErrorCode.java
+++ b/src/main/java/hotspot/user/common/exception/code/OutboxErrorCode.java
@@ -11,17 +11,17 @@ public enum OutboxErrorCode implements BaseErrorCode {
     OUTBOX_PAYLOAD_SERIALIZATION_FAILED(
             HttpStatus.INTERNAL_SERVER_ERROR,
             "OUTBOX_001",
-            "Outbox payload serialization failed."
+            "Outbox payload의 직렬화를 실패하였습니다."
     ),
     OUTBOX_EVENT_SAVE_FAILED(
             HttpStatus.INTERNAL_SERVER_ERROR,
             "OUTBOX_002",
-            "Outbox event save failed."
+            "Outbox event 저장을 실패하였습니다."
     ),
     OUTBOX_EVENT_PUBLISH_FAILED(
             HttpStatus.INTERNAL_SERVER_ERROR,
             "OUTBOX_003",
-            "Outbox event publish failed."
+            "Outbox event 발행을 실패하였습니다."
     ),
     ;
 

--- a/src/main/java/hotspot/user/dispatch/service/SubscribeSseServiceImpl.java
+++ b/src/main/java/hotspot/user/dispatch/service/SubscribeSseServiceImpl.java
@@ -2,8 +2,6 @@ package hotspot.user.dispatch.service;
 
 import java.time.LocalDateTime;
 
-import jakarta.transaction.Transactional;
-
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
@@ -20,7 +18,6 @@ import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
-@Transactional
 public class SubscribeSseServiceImpl implements SubscribeSseService {
 
     private static final long SSE_TIMEOUT_MILLIS = 30L * 60L * 1000L;

--- a/src/main/java/hotspot/user/kafka/consumer/UserAlertEventsConsumer.java
+++ b/src/main/java/hotspot/user/kafka/consumer/UserAlertEventsConsumer.java
@@ -36,12 +36,12 @@ public class UserAlertEventsConsumer {
     private final FamilySubscriptionRepository familySubscriptionRepository;
     private final ApplicationEventPublisher applicationEventPublisher;
 
+    //Kafka에서 유저 알림 이벤트를 소비해 대상 구독자별 알림을 생성·허용여부를 확인·중복 없이 저장하고, 저장된 알림이 있으면 후속 이벤트를 발행한 뒤 ACK 처리한다.
     @Transactional
     @KafkaListener(
             topics = "${app.topics.user-alert-events}",
             containerFactory = "userAlertKafkaListenerContainerFactory"
     )
-    // 이벤트를 수신해 대상별 저장 후 성공 건만 후속 이벤트로 전달한다.
     public void consume(UserAlertEvent event, Acknowledgment acknowledgment) {
         List<Long> targetSubIds = resolveTargetSubIds(event);
 
@@ -55,7 +55,7 @@ public class UserAlertEventsConsumer {
                 log.warn(
                         "Skip invalid notification type. subId={}, eventId={}, notificationType={}",
                         targetSubId,
-                        resolveEventId(event),
+                        event.alertId(),
                         notification.getNotificationType()
                 );
                 acknowledgment.acknowledge();
@@ -86,7 +86,7 @@ public class UserAlertEventsConsumer {
         acknowledgment.acknowledge();
     }
 
-    // subId 우선, 없으면 familyId 기준으로 fan-out 대상 subId 목록을 만든다.
+    // 이벤트에 subId가 있으면 단건 대상으로, 없으면 familyId로 가족 구성원의 subId 목록을 조회해 알림 대상들을 결정한다.
     private List<Long> resolveTargetSubIds(UserAlertEvent event) {
         if (event.subId() != null) {
             return List.of(event.subId());
@@ -104,25 +104,19 @@ public class UserAlertEventsConsumer {
                 .toList();
     }
 
-    // 알림 타입을 카테고리로 변환해 허용된 경우에만 저장/전송 대상으로 처리한다.
+    // 해당 구독자가 해당 카테고리 알림을 허용했는지 설정 저장소에서 확인한다.
     private boolean isNotificationAllowed(Long subId, NotificationCategory category) {
         return notificationAllowRepository.findBySubIdAndCategory(subId, category)
                 .map(notificationAllow -> Boolean.TRUE.equals(notificationAllow.getNotificationAllow()))
                 .orElse(false);
     }
 
+    // 문자열로 들어온 알림 타입을 enum으로 매핑해 알림 카테고리를 결정하고, 매핑 불가 시 예외를 발생시킨다.
     private NotificationCategory resolveNotificationCategory(String notificationTypeRaw) {
         try {
             return NotificationType.valueOf(notificationTypeRaw).category();
         } catch (IllegalArgumentException ex) {
             throw new ApplicationException(NotificationErrorCode.NOTIFICATION_CATEGORY_MAPPING_NOT_FOUND);
         }
-    }
-
-    private String resolveEventId(UserAlertEvent event) {
-        if (event.sourceEventId() != null && !event.sourceEventId().isBlank()) {
-            return event.sourceEventId();
-        }
-        return event.alertId();
     }
 }

--- a/src/main/java/hotspot/user/kafka/dto/UserAlertEvent.java
+++ b/src/main/java/hotspot/user/kafka/dto/UserAlertEvent.java
@@ -1,6 +1,6 @@
 package hotspot.user.kafka.dto;
 
-import java.time.Instant;
+import java.time.LocalDateTime;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
@@ -9,17 +9,15 @@ public record UserAlertEvent(
         String alertId,
         String eventType,
         String alertType,
+        Long subId,
+        Long familyId,
         String threshold,
         String policyName,
         String serviceName,
         String presentSenderName,
         String presentAmount,
-        Instant occurredAt,
-        Long subId,
-        Long familyId,
         String giftId,
-        long remainingBytes,
-        int remainingPct,
-        String sourceEventId
+        String targetName,
+        LocalDateTime createdTime
 ) {
 }

--- a/src/main/java/hotspot/user/kafka/mapper/orchestrator/UserAlertEventNotificationMapper.java
+++ b/src/main/java/hotspot/user/kafka/mapper/orchestrator/UserAlertEventNotificationMapper.java
@@ -22,7 +22,6 @@ public class UserAlertEventNotificationMapper {
 
     private final Map<KafkaEventType, UserAlertEventMappingStrategy> strategiesByEventType;
 
-    // 등록된 매핑 전략을 이벤트 타입별 1:1 맵으로 초기화한다.
     public UserAlertEventNotificationMapper(List<UserAlertEventMappingStrategy> mappingStrategies) {
         this.strategiesByEventType = new EnumMap<>(KafkaEventType.class);
         for (KafkaEventType eventType : KafkaEventType.values()) {
@@ -31,24 +30,21 @@ public class UserAlertEventNotificationMapper {
         }
     }
 
-    // 이벤트 타입을 해석한 뒤 해당 전략으로 매핑 결과를 생성한다.
     public AlertNotificationMappingResult map(UserAlertEvent event) {
         KafkaEventType eventType = KafkaEventType.from(AlertEventMappingSupport.normalize(event.eventType()));
         UserAlertEventMappingStrategy strategy = strategiesByEventType.get(eventType);
         return strategy.map(event);
     }
 
-    // 이벤트의 subId를 대상으로 Notification 엔티티를 생성한다.
     public Notification toNotification(UserAlertEvent event) {
         return toNotification(event, event.subId());
     }
 
-    // 지정된 targetSubId를 대상으로 Notification 엔티티를 생성한다.
     public Notification toNotification(UserAlertEvent event, Long targetSubId) {
         AlertNotificationMappingResult mapping = map(event);
         return Notification.builder()
                 .subId(requireSubId(targetSubId))
-                .eventId(resolveEventId(event))
+                .eventId(requireEventId(event.alertId()))
                 .notificationType(mapping.notificationType().name())
                 .title(mapping.content().title())
                 .content(mapping.content().body())
@@ -57,24 +53,20 @@ public class UserAlertEventNotificationMapper {
                 .build();
     }
 
-    // sourceEventId를 우선 사용하고 비어 있으면 alertId로 대체한다.
-    private String resolveEventId(UserAlertEvent event) {
-        String eventId = AlertEventMappingSupport.defaultIfBlank(event.sourceEventId(), event.alertId());
-        if (eventId.isBlank()) {
+    private String requireEventId(String eventId) {
+        if (eventId == null || eventId.isBlank()) {
             throw new ApplicationException(KafkaErrorCode.KAFKA_EVENT_ID_REQUIRED);
         }
         return eventId;
     }
 
-    // occurredAt을 UTC 기준 LocalDateTime으로 변환한다. 값이 없으면 현재 UTC 시간을 사용한다.
     private LocalDateTime resolveCreatedTime(UserAlertEvent event) {
-        if (event.occurredAt() == null) {
+        if (event.createdTime() == null) {
             return LocalDateTime.now(ZoneOffset.UTC);
         }
-        return LocalDateTime.ofInstant(event.occurredAt(), ZoneOffset.UTC);
+        return event.createdTime();
     }
 
-    // subId의 null/양수 여부를 검증한다.
     private static Long requireSubId(Long subId) {
         if (subId == null) {
             throw new ApplicationException(KafkaErrorCode.KAFKA_SUB_ID_REQUIRED);
@@ -85,7 +77,6 @@ public class UserAlertEventNotificationMapper {
         return subId;
     }
 
-    // 이벤트 타입별 전략이 정확히 1개인지 검증하고 반환한다.
     private UserAlertEventMappingStrategy resolveSingleStrategy(
             KafkaEventType eventType,
             List<UserAlertEventMappingStrategy> mappingStrategies

--- a/src/main/java/hotspot/user/kafka/mapper/strategy/usage/UsageThresholdAlertEventMappingStrategy.java
+++ b/src/main/java/hotspot/user/kafka/mapper/strategy/usage/UsageThresholdAlertEventMappingStrategy.java
@@ -28,22 +28,22 @@ public class UsageThresholdAlertEventMappingStrategy implements UserAlertEventMa
             return switch (threshold) {
                 case 50 -> AlertEventMappingSupport.create(
                         NotificationType.SINGLE_USAGE_THRESHOLD_50,
-                        "데이터 임계치 알림",
+                        "개인 요금제 데이터 알림",
                         "데이터 잔여량이 50% 이하입니다."
                 );
                 case 30 -> AlertEventMappingSupport.create(
                         NotificationType.SINGLE_USAGE_THRESHOLD_30,
-                        "데이터 임계치 알림",
+                        "개인 요금제 데이터 알림",
                         "데이터 잔여량이 30% 이하입니다."
                 );
                 case 10 -> AlertEventMappingSupport.create(
                         NotificationType.SINGLE_USAGE_THRESHOLD_10,
-                        "데이터 임계치 알림",
+                        "개인 요금제 데이터 알림",
                         "데이터 잔여량이 10% 이하입니다."
                 );
                 case 0 -> AlertEventMappingSupport.create(
                         NotificationType.SINGLE_USAGE_EXHAUSTED,
-                        "데이터 임계치 알림",
+                        "개인 요금제 데이터 알림",
                         "데이터 잔여량이 모두 소진되었습니다."
                 );
                 default -> throw new ApplicationException(KafkaErrorCode.UNSUPPORTED_KAFKA_THRESHOLD);

--- a/src/main/java/hotspot/user/kafka/mapper/support/AlertEventMappingSupport.java
+++ b/src/main/java/hotspot/user/kafka/mapper/support/AlertEventMappingSupport.java
@@ -51,7 +51,7 @@ public final class AlertEventMappingSupport {
 
     // 이벤트의 임계치 문자열을 가져와 숫자만 추출해 임계치로 반환한다.
     public static int resolveThreshold(UserAlertEvent event) {
-        String thresholdRaw = defaultIfBlank(event.threshold(), String.valueOf(event.remainingPct()));
+        String thresholdRaw = defaultIfBlank(event.threshold(), "");
         Matcher matcher = NUMBER_PATTERN.matcher(thresholdRaw);
         if (!matcher.find()) {
             throw new ApplicationException(KafkaErrorCode.UNSUPPORTED_KAFKA_THRESHOLD);

--- a/src/main/java/hotspot/user/kafka/outbox/NotificationUserAlertOutboxPublisher.java
+++ b/src/main/java/hotspot/user/kafka/outbox/NotificationUserAlertOutboxPublisher.java
@@ -1,6 +1,7 @@
 package hotspot.user.kafka.outbox;
 
-import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.UUID;
 
 import org.springframework.stereotype.Component;
@@ -119,7 +120,7 @@ public class NotificationUserAlertOutboxPublisher {
                 eventId,
                 eventType,
                 alertType,
-                Instant.now(),
+                LocalDateTime.now(ZoneOffset.UTC),
                 subId,
                 familyId
         );
@@ -130,9 +131,10 @@ public class NotificationUserAlertOutboxPublisher {
         private final String alertId;
         private final String eventType;
         private final String alertType;
-        private final Instant occurredAt;
+        private final LocalDateTime createdTime;
         private final Long subId;
         private final Long familyId;
+        private String threshold;
         private String policyName;
         private String serviceName;
         private String presentSenderName;
@@ -143,14 +145,14 @@ public class NotificationUserAlertOutboxPublisher {
                 String alertId,
                 String eventType,
                 String alertType,
-                Instant occurredAt,
+                LocalDateTime createdTime,
                 Long subId,
                 Long familyId
         ) {
             this.alertId = alertId;
             this.eventType = eventType;
             this.alertType = alertType;
-            this.occurredAt = occurredAt;
+            this.createdTime = createdTime;
             this.subId = subId;
             this.familyId = familyId;
         }
@@ -181,18 +183,16 @@ public class NotificationUserAlertOutboxPublisher {
                     alertId,
                     eventType,
                     alertType,
-                    null,
+                    subId,
+                    familyId,
+                    threshold,
                     policyName,
                     serviceName,
                     presentSenderName,
                     presentAmount,
-                    occurredAt,
-                    subId,
-                    familyId,
                     giftId,
-                    0L,
-                    0,
-                    alertId
+                    null,
+                    createdTime
             );
         }
     }

--- a/src/main/java/hotspot/user/kafka/outbox/NotificationUserAlertOutboxPublisher.java
+++ b/src/main/java/hotspot/user/kafka/outbox/NotificationUserAlertOutboxPublisher.java
@@ -5,6 +5,8 @@ import java.util.UUID;
 
 import org.springframework.stereotype.Component;
 
+import hotspot.user.common.exception.ApplicationException;
+import hotspot.user.common.exception.code.OutboxErrorCode;
 import hotspot.user.kafka.domain.KafkaEventType;
 import hotspot.user.kafka.dto.UserAlertEvent;
 import hotspot.user.outbox.service.NotificationOutboxEventAppender;
@@ -92,16 +94,22 @@ public class NotificationUserAlertOutboxPublisher {
 
     // 집계 메타데이터와 함께 이벤트를 outbox_event 테이블에 저장한다.
     private void append(String type, UserAlertEvent event) {
-        String aggregateId = event.subId() != null
-                ? String.valueOf(event.subId())
-                : event.familyId() != null ? String.valueOf(event.familyId()) : event.alertId();
+        try {
+            String aggregateId = event.subId() != null
+                    ? String.valueOf(event.subId())
+                    : event.familyId() != null ? String.valueOf(event.familyId()) : event.alertId();
 
-        outboxEventAppender.append(
-                aggregateType,
-                aggregateId,
-                type,
-                event
-        );
+            outboxEventAppender.append(
+                    aggregateType,
+                    aggregateId,
+                    type,
+                    event
+            );
+        } catch (ApplicationException ex) {
+            throw ex;
+        } catch (Exception ex) {
+            throw new ApplicationException(OutboxErrorCode.OUTBOX_EVENT_PUBLISH_FAILED, ex);
+        }
     }
 
     // 모든 알림 이벤트에서 공통으로 쓰는 기본 필드를 만든다.

--- a/src/main/java/hotspot/user/outbox/service/NotificationOutboxEventAppender.java
+++ b/src/main/java/hotspot/user/outbox/service/NotificationOutboxEventAppender.java
@@ -10,7 +10,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import hotspot.user.common.exception.ApplicationException;
-import hotspot.user.common.exception.code.GlobalErrorCode;
+import hotspot.user.common.exception.code.OutboxErrorCode;
 import hotspot.user.outbox.infrastructure.NotificationOutboxEventJpaRepository;
 import hotspot.user.outbox.infrastructure.entity.NotificationOutboxEventEntity;
 import lombok.RequiredArgsConstructor;
@@ -41,7 +41,7 @@ public class NotificationOutboxEventAppender {
         try {
             return objectMapper.writeValueAsString(payload);
         } catch (JsonProcessingException ex) {
-            throw new ApplicationException(GlobalErrorCode.INTERNAL_SERVER_ERROR);
+            throw new ApplicationException(OutboxErrorCode.OUTBOX_PAYLOAD_SERIALIZATION_FAILED, ex);
         }
     }
 }

--- a/src/main/java/hotspot/user/outbox/service/NotificationOutboxEventAppender.java
+++ b/src/main/java/hotspot/user/outbox/service/NotificationOutboxEventAppender.java
@@ -4,6 +4,7 @@ import java.util.UUID;
 
 import jakarta.transaction.Transactional;
 
+import org.springframework.dao.DataAccessException;
 import org.springframework.stereotype.Service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -25,15 +26,19 @@ public class NotificationOutboxEventAppender {
 
     // 단일 outbox 이벤트 레코드를 outbox_event 테이블에 저장한다.
     public void append(String aggregateType, String aggregateId, String type, Object payload) {
-        outboxEventJpaRepository.save(
-                NotificationOutboxEventEntity.builder()
-                        .id(UUID.randomUUID())
-                        .aggregateType(aggregateType)
-                        .aggregateId(aggregateId)
-                        .type(type)
-                        .payload(toJson(payload))
-                        .build()
-        );
+        try {
+            outboxEventJpaRepository.save(
+                    NotificationOutboxEventEntity.builder()
+                            .id(UUID.randomUUID())
+                            .aggregateType(aggregateType)
+                            .aggregateId(aggregateId)
+                            .type(type)
+                            .payload(toJson(payload))
+                            .build()
+            );
+        } catch (DataAccessException ex) {
+            throw new ApplicationException(OutboxErrorCode.OUTBOX_EVENT_SAVE_FAILED, ex);
+        }
     }
 
     // payload 객체를 JSON 문자열로 직렬화한다.

--- a/src/test/java/hotspot/user/common/config/KafkaConsumerConfigTest.java
+++ b/src/test/java/hotspot/user/common/config/KafkaConsumerConfigTest.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
 import java.nio.charset.StandardCharsets;
-import java.time.Instant;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 
@@ -36,13 +36,11 @@ class KafkaConsumerConfigTest {
                   "eventType": "USAGE",
                   "alertType": "THRESHOLD_EXCEEDED",
                   "threshold": "80",
-                  "occurredAt": "2026-02-23T01:00:00Z",
+                  "createdTime": "2026-02-23T01:00:00",
                   "subId": 1001,
                   "familyId": 2002,
                   "giftId": "3003",
-                  "remainingBytes": 1048576,
-                  "remainingPct": 12,
-                  "sourceEventId": "worker-event-999"
+                  "targetName": "Kid A"
                 }
                 """;
 
@@ -58,13 +56,11 @@ class KafkaConsumerConfigTest {
         assertThat(event.eventType()).isEqualTo("USAGE");
         assertThat(event.alertType()).isEqualTo("THRESHOLD_EXCEEDED");
         assertThat(event.threshold()).isEqualTo("80");
-        assertThat(event.occurredAt()).isEqualTo(Instant.parse("2026-02-23T01:00:00Z"));
+        assertThat(event.createdTime()).isEqualTo(LocalDateTime.parse("2026-02-23T01:00:00"));
         assertThat(event.subId()).isEqualTo(1001L);
         assertThat(event.familyId()).isEqualTo(2002L);
         assertThat(event.giftId()).isEqualTo("3003");
-        assertThat(event.remainingBytes()).isEqualTo(1048576L);
-        assertThat(event.remainingPct()).isEqualTo(12);
-        assertThat(event.sourceEventId()).isEqualTo("worker-event-999");
+        assertThat(event.targetName()).isEqualTo("Kid A");
     }
 
     @Test

--- a/src/test/java/hotspot/user/dispatch/service/SsePushServiceTest.java
+++ b/src/test/java/hotspot/user/dispatch/service/SsePushServiceTest.java
@@ -6,7 +6,6 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.times;
 
-import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -67,18 +66,16 @@ class SsePushServiceTest {
                 "alert-1",
                 "USAGE_THRESHOLD",
                 "PLAN_REMAINING",
+                1L,
+                null,
                 "30",
                 null,
                 null,
                 null,
                 null,
-                Instant.parse("2026-02-23T10:15:30Z"),
-                1L,
                 null,
                 null,
-                0L,
-                30,
-                "evt-source"
+                LocalDateTime.of(2026, 2, 23, 10, 15, 30)
         );
     }
 

--- a/src/test/java/hotspot/user/kafka/consumer/UserAlertEventsConsumerTest.java
+++ b/src/test/java/hotspot/user/kafka/consumer/UserAlertEventsConsumerTest.java
@@ -8,7 +8,6 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.lenient;
 
-import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -201,23 +200,21 @@ class UserAlertEventsConsumerTest {
     }
 
     // 테스트용 이벤트 객체를 생성한다.
-    private UserAlertEvent event(Long subId, Long familyId, String sourceEventId) {
+    private UserAlertEvent event(Long subId, Long familyId, String alertId) {
         return new UserAlertEvent(
-                "alert-1",
+                alertId,
                 "USAGE_THRESHOLD",
                 "PLAN_REMAINING",
+                subId,
+                familyId,
                 "30",
                 null,
                 null,
                 null,
                 null,
-                Instant.parse("2026-02-23T10:15:30Z"),
-                subId,
-                familyId,
                 null,
-                0L,
-                30,
-                sourceEventId
+                null,
+                LocalDateTime.of(2026, 2, 23, 10, 15, 30)
         );
     }
 

--- a/src/test/java/hotspot/user/kafka/mapper/orchestrator/UserAlertEventNotificationMapperTest.java
+++ b/src/test/java/hotspot/user/kafka/mapper/orchestrator/UserAlertEventNotificationMapperTest.java
@@ -3,7 +3,6 @@ package hotspot.user.kafka.mapper.orchestrator;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -48,34 +47,32 @@ class UserAlertEventNotificationMapperTest {
     @Test
     @DisplayName("toNotification maps deterministic fields")
     void toNotificationSuccess() {
-        Instant occurredAt = Instant.parse("2026-02-23T10:15:30Z");
+        LocalDateTime createdTime = LocalDateTime.of(2026, 2, 23, 10, 15, 30);
         UserAlertEvent event = new UserAlertEvent(
                 "alert-1",
                 "USAGE_THRESHOLD",
                 "PLAN_REMAINING",
+                101L,
+                null,
                 "30",
                 null,
                 null,
                 null,
                 null,
-                occurredAt,
-                101L,
                 null,
                 null,
-                0L,
-                30,
-                "evt-100"
+                createdTime
         );
 
         Notification notification = mapper.toNotification(event);
 
         assertThat(notification.getSubId()).isEqualTo(101L);
-        assertThat(notification.getEventId()).isEqualTo("evt-100");
+        assertThat(notification.getEventId()).isEqualTo("alert-1");
         assertThat(notification.getNotificationType()).isEqualTo("SINGLE_USAGE_THRESHOLD_30");
         assertThat(notification.getTitle()).isNotBlank();
         assertThat(notification.getContent()).contains("30%");
         assertThat(notification.getIsRead()).isFalse();
-        assertThat(notification.getCreatedTime()).isEqualTo(LocalDateTime.of(2026, 2, 23, 10, 15, 30));
+        assertThat(notification.getCreatedTime()).isEqualTo(createdTime);
     }
 
     @Test
@@ -95,18 +92,16 @@ class UserAlertEventNotificationMapperTest {
                 "alert-1",
                 "USAGE_THRESHOLD",
                 "PLAN_REMAINING",
+                null,
+                null,
                 "30",
                 null,
                 null,
                 null,
                 null,
-                Instant.parse("2026-02-23T10:15:30Z"),
                 null,
                 null,
-                null,
-                0L,
-                30,
-                "evt-100"
+                LocalDateTime.of(2026, 2, 23, 10, 15, 30)
         );
 
         assertThatThrownBy(() -> mapper.toNotification(event))
@@ -121,18 +116,16 @@ class UserAlertEventNotificationMapperTest {
                 "alert-1",
                 "USAGE_THRESHOLD",
                 "PLAN_REMAINING",
+                0L,
+                null,
                 "30",
                 null,
                 null,
                 null,
                 null,
-                Instant.parse("2026-02-23T10:15:30Z"),
-                0L,
                 null,
                 null,
-                0L,
-                30,
-                "evt-100"
+                LocalDateTime.of(2026, 2, 23, 10, 15, 30)
         );
 
         assertThatThrownBy(() -> mapper.toNotification(event))
@@ -145,18 +138,16 @@ class UserAlertEventNotificationMapperTest {
                 "alert-1",
                 eventType,
                 alertType,
+                100L,
+                null,
                 threshold,
                 null,
                 null,
                 null,
                 null,
-                Instant.parse("2026-02-23T10:15:30Z"),
-                100L,
                 null,
                 null,
-                0L,
-                10,
-                "evt-1"
+                LocalDateTime.of(2026, 2, 23, 10, 15, 30)
         );
     }
 }

--- a/src/test/java/hotspot/user/kafka/mapper/strategy/appservice/AppServiceAlertEventMappingStrategyTest.java
+++ b/src/test/java/hotspot/user/kafka/mapper/strategy/appservice/AppServiceAlertEventMappingStrategyTest.java
@@ -3,7 +3,7 @@ package hotspot.user.kafka.mapper.strategy.appservice;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import java.time.Instant;
+import java.time.LocalDateTime;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -41,18 +41,16 @@ class AppServiceAlertEventMappingStrategyTest {
                 "alert-1",
                 "SERVICE_ACCESS",
                 alertType,
+                100L,
+                null,
                 null,
                 null,
                 serviceName,
                 null,
                 null,
-                Instant.parse("2026-02-23T10:15:30Z"),
-                100L,
                 null,
                 null,
-                0L,
-                10,
-                "evt-1"
+                LocalDateTime.of(2026, 2, 23, 10, 15, 30)
         );
     }
 }

--- a/src/test/java/hotspot/user/kafka/mapper/strategy/policy/PolicyAlertEventMappingStrategyTest.java
+++ b/src/test/java/hotspot/user/kafka/mapper/strategy/policy/PolicyAlertEventMappingStrategyTest.java
@@ -3,7 +3,7 @@ package hotspot.user.kafka.mapper.strategy.policy;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import java.time.Instant;
+import java.time.LocalDateTime;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -51,18 +51,16 @@ class PolicyAlertEventMappingStrategyTest {
                 "alert-1",
                 eventType,
                 alertType,
+                100L,
+                null,
                 null,
                 policyName,
                 null,
                 null,
                 null,
-                Instant.parse("2026-02-23T10:15:30Z"),
-                100L,
                 null,
                 null,
-                0L,
-                10,
-                "evt-1"
+                LocalDateTime.of(2026, 2, 23, 10, 15, 30)
         );
     }
 }

--- a/src/test/java/hotspot/user/kafka/mapper/strategy/present/PresentDataAlertEventMappingStrategyTest.java
+++ b/src/test/java/hotspot/user/kafka/mapper/strategy/present/PresentDataAlertEventMappingStrategyTest.java
@@ -2,7 +2,7 @@ package hotspot.user.kafka.mapper.strategy.present;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.time.Instant;
+import java.time.LocalDateTime;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -37,18 +37,16 @@ class PresentDataAlertEventMappingStrategyTest {
                 "alert-1",
                 "PRESENT_DATA",
                 null,
+                100L,
+                null,
                 null,
                 null,
                 null,
                 senderName,
                 amount,
-                Instant.parse("2026-02-23T10:15:30Z"),
-                100L,
                 null,
                 null,
-                0L,
-                10,
-                "evt-1"
+                LocalDateTime.of(2026, 2, 23, 10, 15, 30)
         );
     }
 }

--- a/src/test/java/hotspot/user/kafka/mapper/strategy/usage/UsageThresholdAlertEventMappingStrategyTest.java
+++ b/src/test/java/hotspot/user/kafka/mapper/strategy/usage/UsageThresholdAlertEventMappingStrategyTest.java
@@ -3,7 +3,7 @@ package hotspot.user.kafka.mapper.strategy.usage;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import java.time.Instant;
+import java.time.LocalDateTime;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -49,18 +49,16 @@ class UsageThresholdAlertEventMappingStrategyTest {
                 "alert-1",
                 "USAGE_THRESHOLD",
                 alertType,
+                100L,
+                null,
                 threshold,
                 null,
                 null,
                 null,
                 null,
-                Instant.parse("2026-02-23T10:15:30Z"),
-                100L,
                 null,
                 null,
-                0L,
-                10,
-                "evt-1"
+                LocalDateTime.of(2026, 2, 23, 10, 15, 30)
         );
     }
 }

--- a/src/test/java/hotspot/user/kafka/outbox/NotificationUserAlertOutboxPublisherTest.java
+++ b/src/test/java/hotspot/user/kafka/outbox/NotificationUserAlertOutboxPublisherTest.java
@@ -25,7 +25,7 @@ class NotificationUserAlertOutboxPublisherTest {
     private NotificationUserAlertOutboxPublisher publisher;
 
     @Test
-    @DisplayName("publishPolicyApplied: SCHEDULED 정책은 TIME_WINDOW_POLICY 이벤트로 저장한다")
+    @DisplayName("publishPolicyApplied emits TIME_WINDOW_POLICY event")
     void publishPolicyAppliedWithScheduledType() {
         publisher.publishPolicyApplied(101L, 11L, "study-time", PolicyType.SCHEDULED);
 
@@ -33,7 +33,7 @@ class NotificationUserAlertOutboxPublisherTest {
     }
 
     @Test
-    @DisplayName("publishPolicyReleased: ONCE 정책은 IMMEDIATE_BLOCK 이벤트로 저장한다")
+    @DisplayName("publishPolicyReleased emits IMMEDIATE_BLOCK event")
     void publishPolicyReleasedWithImmediateType() {
         publisher.publishPolicyReleased(202L, 22L, "night-block", PolicyType.ONCE);
 
@@ -41,7 +41,7 @@ class NotificationUserAlertOutboxPublisherTest {
     }
 
     @Test
-    @DisplayName("publishServiceAccessApplied: 서비스 차단 적용 이벤트를 저장한다")
+    @DisplayName("publishServiceAccessApplied emits service access applied event")
     void publishServiceAccessApplied() {
         publisher.publishServiceAccessApplied(303L, 33L, "YouTube");
 
@@ -49,7 +49,7 @@ class NotificationUserAlertOutboxPublisherTest {
     }
 
     @Test
-    @DisplayName("publishServiceAccessReleased: subId가 없으면 familyId를 aggregateId로 사용한다")
+    @DisplayName("publishServiceAccessReleased uses familyId as aggregateId when subId missing")
     void publishServiceAccessReleasedUsesFamilyIdAsAggregateIdWhenSubIdMissing() {
         publisher.publishServiceAccessReleased(null, 44L, "Instagram");
 
@@ -67,7 +67,7 @@ class NotificationUserAlertOutboxPublisherTest {
     }
 
     @Test
-    @DisplayName("publishPresentDataGifted: 선물 데이터 이벤트를 저장한다")
+    @DisplayName("publishPresentDataGifted emits present data event")
     void publishPresentDataGifted() {
         publisher.publishPresentDataGifted(505L, 55L, "Alice", "1GB", "gift-1");
 
@@ -103,8 +103,7 @@ class NotificationUserAlertOutboxPublisherTest {
 
         UserAlertEvent event = (UserAlertEvent) payloadCaptor.getValue();
         assertThat(event.alertId()).isNotBlank();
-        assertThat(event.sourceEventId()).isEqualTo(event.alertId());
-        assertThat(event.occurredAt()).isNotNull();
+        assertThat(event.createdTime()).isNotNull();
         assertThat(event.eventType()).isEqualTo(expectedEventType);
         assertThat(event.alertType()).isEqualTo(expectedAlertType);
         assertThat(event.policyName()).isEqualTo(expectedPolicyName);

--- a/src/test/java/hotspot/user/outbox/service/NotificationOutboxEventAppenderTest.java
+++ b/src/test/java/hotspot/user/outbox/service/NotificationOutboxEventAppenderTest.java
@@ -19,7 +19,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import hotspot.user.common.exception.ApplicationException;
-import hotspot.user.common.exception.code.GlobalErrorCode;
+import hotspot.user.common.exception.code.OutboxErrorCode;
 import hotspot.user.outbox.infrastructure.NotificationOutboxEventJpaRepository;
 import hotspot.user.outbox.infrastructure.entity.NotificationOutboxEventEntity;
 
@@ -36,7 +36,7 @@ class NotificationOutboxEventAppenderTest {
     private NotificationOutboxEventAppender appender;
 
     @Test
-    @DisplayName("append: payload를 JSON으로 저장한다")
+    @DisplayName("append saves serialized payload")
     void appendSavesSerializedPayload() throws Exception {
         Map<String, Object> payload = Map.of("key", "value");
         given(objectMapper.writeValueAsString(payload)).willReturn("{\"key\":\"value\"}");
@@ -56,7 +56,7 @@ class NotificationOutboxEventAppenderTest {
     }
 
     @Test
-    @DisplayName("append: 직렬화 실패 시 INTERNAL_SERVER_ERROR를 던진다")
+    @DisplayName("append throws outbox serialization error on JSON failure")
     void appendThrowsWhenSerializationFails() throws Exception {
         Object payload = new Object();
         given(objectMapper.writeValueAsString(payload)).willThrow(new JsonProcessingException("boom") {
@@ -65,7 +65,7 @@ class NotificationOutboxEventAppenderTest {
         assertThatThrownBy(() -> appender.append("user-alert", "101", "POLICY_APPLIED", payload))
                 .isInstanceOf(ApplicationException.class)
                 .satisfies(ex -> assertThat(((ApplicationException) ex).getCode())
-                        .isEqualTo(GlobalErrorCode.INTERNAL_SERVER_ERROR));
+                        .isEqualTo(OutboxErrorCode.OUTBOX_PAYLOAD_SERIALIZATION_FAILED));
 
         then(outboxEventJpaRepository).shouldHaveNoInteractions();
     }

--- a/src/test/java/hotspot/user/policy/service/UpdateBlockPolicyServiceImplTest.java
+++ b/src/test/java/hotspot/user/policy/service/UpdateBlockPolicyServiceImplTest.java
@@ -141,7 +141,7 @@ class UpdateBlockPolicyServiceImplTest {
     }
 
     @Test
-    @DisplayName("?ㅽ뙣: ?붿껌???뺤콉 以??쇰?媛 議댁옱?섏? ?딆쑝硫??덉쇅媛 諛쒖깮?쒕떎")
+    @DisplayName("실패: 요청한 정책 중 일부가 존재하지 않으면 예외가 발생한다")
     void updateBlockPolicyFailByPolicyNotFound() {
         // given
         UpdateBlockPolicyRequest request = new UpdateBlockPolicyRequest(100L, 1L, List.of(1L, 2L));


### PR DESCRIPTION
## 🎫 지라 티켓

<!-- 지라 티켓을 작성해주세요 ex) HOTSPOT-123 -->
HOTSPOT-166

---

## 🔗 GitHub 이슈
<!-- 자동 close를 원하면 아래 형식으로 작성
예) Closes #12
-->
Closes #

---


## ✅ 작업 사항

<!-- 작업한 부분을 설명해주세요. -->
- UserAlertEvent 스키마 개편
  - sourceEventId 제거 및 alertId 단일화
  - occurredAt(Instant) 제거 및 createdTime(LocalDateTime) 전환
  - remainingBytes/remainingPct 제거
  - targetName 필드 반영

- 매퍼 이벤트 ID/생성시각 로직 정비
- 컨슈머 이벤트 참조 로직 단순화
- Outbox 이벤트 생성 규격 업데이트
- UserAlertEvent 호출부 전면 동기화

- SSE 트랜잭션 범위 수정
- 예외 cause 보존 구조 추가
- BaseException 로깅 개신
- Outbox 공통 에러코드 추가/확장


---

## 📋 체크리스트

<!-- PR 제출 전 확인해주세요. 해당 항목에 [x]로 체크해주세요. -->

- [x] 코드가 정상적으로 빌드됩니다.
- [x] 관련 테스트 코드를 작성했습니다.
- [x] 기존 테스트가 모두 통과합니다.
- [x] 코드 스타일(Spotless, Checkstyle)을 준수합니다.
- [x] Jira 티켓 상태를 In Review / Done으로 변경했습니다.

---

## ⌨ 기타
