### PR TITLE
[HOTSPOT-179] 데이터 선물하기 API 구현

### DIFF
--- a/src/main/java/hotspot/user/common/exception/ErrorResponse.java
+++ b/src/main/java/hotspot/user/common/exception/ErrorResponse.java
@@ -1,3 +1,3 @@
 package hotspot.user.common.exception;
 
-public record ErrorResponse(int statusCode, String code, String message) {}
+public record ErrorResponse(int status, String code, String message) {}

--- a/src/main/java/hotspot/user/common/exception/code/GlobalErrorCode.java
+++ b/src/main/java/hotspot/user/common/exception/code/GlobalErrorCode.java
@@ -13,6 +13,7 @@ public enum GlobalErrorCode implements BaseErrorCode {
   METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "COMMON_003", "지원하지 않은 Http Method 입니다."),
   INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON_004", "서버 에러가 발생했습니다."),
   BLOCKED_API(HttpStatus.METHOD_NOT_ALLOWED, "COMMON_005", "운영 환경에서 사용할 수 없는 API 입니다."),
+  VALIDATION_FAILED(HttpStatus.BAD_REQUEST, "COMMON_006", "입력값 유효성 검증에 실패했습니다."),
   ;
 
   private final HttpStatus httpStatus;

--- a/src/main/java/hotspot/user/common/exception/code/PresentDataErrorCode.java
+++ b/src/main/java/hotspot/user/common/exception/code/PresentDataErrorCode.java
@@ -1,0 +1,21 @@
+package hotspot.user.common.exception.code;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 데이터 선물하기 도메인 관련 에러 코드
+ */
+@Getter
+@RequiredArgsConstructor
+public enum PresentDataErrorCode implements BaseErrorCode {
+    PRESENT_DATA_SELF_GIFT(HttpStatus.BAD_REQUEST, "PRESENT_001", "자신에게는 데이터를 선물할 수 없습니다."),
+    PRESENT_DATA_INVALID_AMOUNT(HttpStatus.BAD_REQUEST, "PRESENT_002", "데이터 선물은 1GB에서 5GB 사이, 1GB 단위로만 가능합니다."),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String customCode;
+    private final String message;
+}

--- a/src/main/java/hotspot/user/family/controller/port/FindFamilySubscriptionService.java
+++ b/src/main/java/hotspot/user/family/controller/port/FindFamilySubscriptionService.java
@@ -1,6 +1,5 @@
 package hotspot.user.family.controller.port;
 
-import hotspot.user.family.controller.response.FamilySubscriptionResponse;
 import hotspot.user.family.domain.FamilySubscription;
 
 /**

--- a/src/main/java/hotspot/user/family/controller/port/FindFamilySubscriptionService.java
+++ b/src/main/java/hotspot/user/family/controller/port/FindFamilySubscriptionService.java
@@ -1,10 +1,12 @@
 package hotspot.user.family.controller.port;
 
 import hotspot.user.family.controller.response.FamilySubscriptionResponse;
+import hotspot.user.family.domain.FamilySubscription;
 
 /**
  * 가족 구성원(회선) 조회 서비스 포트
  */
 public interface FindFamilySubscriptionService {
-    FamilySubscriptionResponse findBySubId(Long subId);
+    FamilySubscription findBySubId(Long subId);
+    FamilySubscription findByMemberId(Long memberId);
 }

--- a/src/main/java/hotspot/user/family/service/FindFamilySubscriptionServiceImpl.java
+++ b/src/main/java/hotspot/user/family/service/FindFamilySubscriptionServiceImpl.java
@@ -1,5 +1,6 @@
 package hotspot.user.family.service;
 
+import hotspot.user.family.domain.FamilySubscription;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,9 +22,14 @@ public class FindFamilySubscriptionServiceImpl implements FindFamilySubscription
     private final FamilySubscriptionRepository repository;
 
     @Override
-    public FamilySubscriptionResponse findBySubId(Long subId) {
+    public FamilySubscription findBySubId(Long subId) {
         return repository.findBySubId(subId)
-                .map(FamilySubscriptionResponse::from)
+                .orElseThrow(() -> new ApplicationException(FamilyErrorCode.FAMILY_SUBSCRIPTION_NOT_FOUND));
+    }
+
+    @Override
+    public FamilySubscription findByMemberId(Long memberId) {
+        return repository.findByMemberId(memberId)
                 .orElseThrow(() -> new ApplicationException(FamilyErrorCode.FAMILY_SUBSCRIPTION_NOT_FOUND));
     }
 }

--- a/src/main/java/hotspot/user/family/service/FindFamilySubscriptionServiceImpl.java
+++ b/src/main/java/hotspot/user/family/service/FindFamilySubscriptionServiceImpl.java
@@ -1,13 +1,12 @@
 package hotspot.user.family.service;
 
-import hotspot.user.family.domain.FamilySubscription;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import hotspot.user.common.exception.ApplicationException;
 import hotspot.user.common.exception.code.FamilyErrorCode;
 import hotspot.user.family.controller.port.FindFamilySubscriptionService;
-import hotspot.user.family.controller.response.FamilySubscriptionResponse;
+import hotspot.user.family.domain.FamilySubscription;
 import hotspot.user.family.service.port.FamilySubscriptionRepository;
 import lombok.RequiredArgsConstructor;
 

--- a/src/main/java/hotspot/user/presentData/controller/PresentDataController.java
+++ b/src/main/java/hotspot/user/presentData/controller/PresentDataController.java
@@ -1,10 +1,12 @@
 package hotspot.user.presentData.controller;
 
+import hotspot.user.presentData.controller.port.SendPresentDataService;
+import hotspot.user.presentData.controller.request.SendPresentDataRequest;
+import hotspot.user.presentData.controller.response.SendPresentDataResponse;
+import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import hotspot.user.common.ApiResponse;
 import hotspot.user.common.security.PrincipalDetails;
@@ -24,6 +26,8 @@ public class PresentDataController implements PresentDataApi {
     private final FindFamilyDataService findFamilyDataService;
     private final FindPresentReceiveService findPresentReceiveService;
     private final FindPresentProvideService findPresentProvideService;
+    private final SendPresentDataService sendPresentDataService; // 데이터 선물하기 서비스
+
     @GetMapping
     public ResponseEntity<ApiResponse<FamilyDataResponse>> findFamilyData(
             @AuthenticationPrincipal PrincipalDetails details) {
@@ -46,5 +50,16 @@ public class PresentDataController implements PresentDataApi {
     ) {
         return ResponseEntity.ok(ApiResponse.success(
                 findPresentProvideService.findPresentProvide(details.getId())));
+    }
+
+    // 데이터 선물하기
+    @PostMapping("/send")
+    public ResponseEntity<ApiResponse<SendPresentDataResponse>> sendPresentData(
+            @Valid @RequestBody SendPresentDataRequest request,
+            @AuthenticationPrincipal PrincipalDetails details
+    ) {
+        return ResponseEntity.ok(ApiResponse.success(
+                sendPresentDataService.sendPresentData(details.getId(), request)
+        ));
     }
 }

--- a/src/main/java/hotspot/user/presentData/controller/PresentDataController.java
+++ b/src/main/java/hotspot/user/presentData/controller/PresentDataController.java
@@ -1,20 +1,25 @@
 package hotspot.user.presentData.controller;
 
-import hotspot.user.presentData.controller.port.SendPresentDataService;
-import hotspot.user.presentData.controller.request.SendPresentDataRequest;
-import hotspot.user.presentData.controller.response.SendPresentDataResponse;
 import jakarta.validation.Valid;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 import hotspot.user.common.ApiResponse;
 import hotspot.user.common.security.PrincipalDetails;
 import hotspot.user.presentData.controller.port.FindFamilyDataService;
 import hotspot.user.presentData.controller.port.FindPresentProvideService;
 import hotspot.user.presentData.controller.port.FindPresentReceiveService;
+import hotspot.user.presentData.controller.port.SendPresentDataService;
+import hotspot.user.presentData.controller.request.SendPresentDataRequest;
 import hotspot.user.presentData.controller.response.FamilyDataResponse;
 import hotspot.user.presentData.controller.response.PresentDataResponse;
+import hotspot.user.presentData.controller.response.SendPresentDataResponse;
 import hotspot.user.presentData.controller.swagger.PresentDataApi;
 import lombok.RequiredArgsConstructor;
 

--- a/src/main/java/hotspot/user/presentData/controller/port/SendPresentDataService.java
+++ b/src/main/java/hotspot/user/presentData/controller/port/SendPresentDataService.java
@@ -1,0 +1,8 @@
+package hotspot.user.presentData.controller.port;
+
+import hotspot.user.presentData.controller.request.SendPresentDataRequest;
+import hotspot.user.presentData.controller.response.SendPresentDataResponse;
+
+public interface SendPresentDataService {
+    SendPresentDataResponse sendPresentData(Long memberId, SendPresentDataRequest request);
+}

--- a/src/main/java/hotspot/user/presentData/controller/request/SendPresentDataRequest.java
+++ b/src/main/java/hotspot/user/presentData/controller/request/SendPresentDataRequest.java
@@ -1,0 +1,12 @@
+package hotspot.user.presentData.controller.request;
+
+/**
+ * 데이터 선물하기 request dto
+ * @param targetSubId
+ * @param dataAmount
+ */
+public record SendPresentDataRequest(
+        Long targetSubId,
+        Long dataAmount
+) {
+}

--- a/src/main/java/hotspot/user/presentData/controller/request/SendPresentDataRequest.java
+++ b/src/main/java/hotspot/user/presentData/controller/request/SendPresentDataRequest.java
@@ -1,12 +1,14 @@
 package hotspot.user.presentData.controller.request;
 
+import jakarta.validation.constraints.NotNull;
+
 /**
  * 데이터 선물하기 request dto
  * @param targetSubId
  * @param dataAmount
  */
 public record SendPresentDataRequest(
-        Long targetSubId,
-        Long dataAmount
+        @NotNull Long targetSubId,
+        @NotNull Long dataAmount
 ) {
 }

--- a/src/main/java/hotspot/user/presentData/controller/response/SendPresentDataResponse.java
+++ b/src/main/java/hotspot/user/presentData/controller/response/SendPresentDataResponse.java
@@ -1,8 +1,8 @@
 package hotspot.user.presentData.controller.response;
 
-import lombok.Builder;
-
 import java.time.LocalDateTime;
+
+import lombok.Builder;
 
 /**
  * 데이터 선물하기 request dto

--- a/src/main/java/hotspot/user/presentData/controller/response/SendPresentDataResponse.java
+++ b/src/main/java/hotspot/user/presentData/controller/response/SendPresentDataResponse.java
@@ -1,0 +1,21 @@
+package hotspot.user.presentData.controller.response;
+
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+/**
+ * 데이터 선물하기 request dto
+ * @param targetSubId
+ * @param provideSubId
+ * @param dataAmount
+ * @param createdTime
+ */
+@Builder
+public record SendPresentDataResponse(
+        Long targetSubId, // 선물 대상자
+        Long provideSubId, // 선물한 사람
+        Long dataAmount,
+        LocalDateTime createdTime
+) {
+}

--- a/src/main/java/hotspot/user/presentData/controller/swagger/PresentDataApi.java
+++ b/src/main/java/hotspot/user/presentData/controller/swagger/PresentDataApi.java
@@ -1,5 +1,7 @@
 package hotspot.user.presentData.controller.swagger;
 
+import jakarta.validation.Valid;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -17,7 +19,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.Valid;
 
 @Tag(name = "PresentData", description = "가족 데이터 조회 및 선물 데이터 조회 API")
 public interface PresentDataApi {

--- a/src/main/java/hotspot/user/presentData/controller/swagger/PresentDataApi.java
+++ b/src/main/java/hotspot/user/presentData/controller/swagger/PresentDataApi.java
@@ -34,6 +34,7 @@ public interface PresentDataApi {
                     description = """
                             인증 실패
                             - AUTH_002: 유효하지 않은 토큰
+                            - AUTH_006: 토큰 만료
                             """,
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class))
             ),
@@ -41,7 +42,7 @@ public interface PresentDataApi {
                     responseCode = "404",
                     description = """
                             조회 실패
-                            - SUB_001: 회선 정보를 찾을 수 없습니다.
+                            - MEMBER_002: 회선 정보를 찾을 수 없습니다.
                             """,
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class))
             )
@@ -62,6 +63,7 @@ public interface PresentDataApi {
                     description = """
                             인증 실패
                             - AUTH_002: 유효하지 않은 토큰
+                            - AUTH_006: 토큰 만료
                             """,
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class))
             ),
@@ -69,7 +71,7 @@ public interface PresentDataApi {
                     responseCode = "404",
                     description = """
                             조회 실패
-                            - SUB_001: 회선 정보를 찾을 수 없습니다.
+                            - MEMBER_002: 회선 정보를 찾을 수 없습니다.
                             """,
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class))
             )
@@ -90,6 +92,7 @@ public interface PresentDataApi {
                     description = """
                             인증 실패
                             - AUTH_002: 유효하지 않은 토큰
+                            - AUTH_006: 토큰 만료
                             """,
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class))
             ),
@@ -97,7 +100,7 @@ public interface PresentDataApi {
                     responseCode = "404",
                     description = """
                             조회 실패
-                            - SUB_001: 회선 정보를 찾을 수 없습니다.
+                            - MEMBER_002: 회선 정보를 찾을 수 없습니다.
                             """,
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class))
             )
@@ -117,7 +120,17 @@ public interface PresentDataApi {
                     responseCode = "400",
                     description = """
                             잘못된 요청
-                            - COMMON_002: 입력값 유효성 검증 실패 (1~5GB 범위를 벗어남 등)
+                            - PRESENT_001: 자신에게는 데이터를 선물할 수 없습니다.
+                            - PRESENT_002: 데이터 선물은 1GB에서 5GB 사이, 1GB 단위로만 가능합니다.
+                            """,
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = """
+                            인증 실패
+                            - AUTH_002: 유효하지 않은 토큰
+                            - AUTH_006: 토큰 만료
                             """,
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class))
             ),
@@ -125,7 +138,7 @@ public interface PresentDataApi {
                     responseCode = "403",
                     description = """
                             권한 없음
-                            - AUTH_004: 동일 가족 구성원이 아님
+                            - AUTH_004: 해당 요청에 대한 접근 권한이 없습니다. (가족 구성원이 아님 등)
                             """,
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class))
             ),
@@ -133,8 +146,7 @@ public interface PresentDataApi {
                     responseCode = "404",
                     description = """
                             조회 실패
-                            - MEMBER_001: 회원 정보를 찾을 수 없음
-                            - SUB_001: 회선 정보를 찾을 수 없음
+                            - MEMBER_004: 회선의 가족 결합 정보를 찾을 수 없습니다.
                             """,
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class))
             )

--- a/src/main/java/hotspot/user/presentData/controller/swagger/PresentDataApi.java
+++ b/src/main/java/hotspot/user/presentData/controller/swagger/PresentDataApi.java
@@ -2,18 +2,22 @@ package hotspot.user.presentData.controller.swagger;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.RequestBody;
 
-import hotspot.user.common.ApiResponse;
 import hotspot.user.common.exception.ErrorResponse;
 import hotspot.user.common.security.PrincipalDetails;
+import hotspot.user.presentData.controller.request.SendPresentDataRequest;
 import hotspot.user.presentData.controller.response.FamilyDataResponse;
 import hotspot.user.presentData.controller.response.PresentDataResponse;
+import hotspot.user.presentData.controller.response.SendPresentDataResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 
 @Tag(name = "PresentData", description = "가족 데이터 조회 및 선물 데이터 조회 API")
 public interface PresentDataApi {
@@ -23,21 +27,25 @@ public interface PresentDataApi {
             description = "로그인 사용자가 속한 가족의 데이터 사용 현황을 조회합니다."
     )
     @ApiResponses(value = {
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                    responseCode = "200", description = "조회 성공"
-            ),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(
                     responseCode = "401",
-                    description = "인증 실패\n- AUTH_002: 유효하지 않은 토큰",
+                    description = """
+                            인증 실패
+                            - AUTH_002: 유효하지 않은 토큰
+                            """,
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class))
             ),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            @ApiResponse(
                     responseCode = "404",
-                    description = "조회 실패\n- SUB_001: 회선 정보를 찾을 수 없습니다.",
+                    description = """
+                            조회 실패
+                            - SUB_001: 회선 정보를 찾을 수 없습니다.
+                            """,
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class))
             )
     })
-    ResponseEntity<ApiResponse<FamilyDataResponse>> findFamilyData(
+    ResponseEntity<hotspot.user.common.ApiResponse<FamilyDataResponse>> findFamilyData(
             @Parameter(hidden = true)
             @AuthenticationPrincipal PrincipalDetails details
     );
@@ -47,21 +55,25 @@ public interface PresentDataApi {
             description = "사용자가 받은 선물 데이터 목록을 조회합니다."
     )
     @ApiResponses(value = {
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                    responseCode = "200", description = "조회 성공"
-            ),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(
                     responseCode = "401",
-                    description = "인증 실패\n- AUTH_002: 유효하지 않은 토큰",
+                    description = """
+                            인증 실패
+                            - AUTH_002: 유효하지 않은 토큰
+                            """,
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class))
             ),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            @ApiResponse(
                     responseCode = "404",
-                    description = "조회 실패\n- SUB_001: 회선 정보를 찾을 수 없습니다.",
+                    description = """
+                            조회 실패
+                            - SUB_001: 회선 정보를 찾을 수 없습니다.
+                            """,
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class))
             )
     })
-    ResponseEntity<ApiResponse<PresentDataResponse>> findPresentReceive(
+    ResponseEntity<hotspot.user.common.ApiResponse<PresentDataResponse>> findPresentReceive(
             @Parameter(hidden = true)
             @AuthenticationPrincipal PrincipalDetails details
     );
@@ -71,22 +83,63 @@ public interface PresentDataApi {
             description = "사용자가 제공한 선물 데이터 목록을 조회합니다."
     )
     @ApiResponses(value = {
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                    responseCode = "200", description = "조회 성공"
-            ),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(
                     responseCode = "401",
-                    description = "인증 실패\n- AUTH_002: 유효하지 않은 토큰",
+                    description = """
+                            인증 실패
+                            - AUTH_002: 유효하지 않은 토큰
+                            """,
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class))
             ),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            @ApiResponse(
                     responseCode = "404",
-                    description = "조회 실패\n- SUB_001: 회선 정보를 찾을 수 없습니다.",
+                    description = """
+                            조회 실패
+                            - SUB_001: 회선 정보를 찾을 수 없습니다.
+                            """,
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class))
             )
     })
-    ResponseEntity<ApiResponse<PresentDataResponse>> findPresentProvide(
+    ResponseEntity<hotspot.user.common.ApiResponse<PresentDataResponse>> findPresentProvide(
             @Parameter(hidden = true)
             @AuthenticationPrincipal PrincipalDetails details
+    );
+
+    @Operation(
+            summary = "데이터 선물하기",
+            description = "같은 가족 구성원에게 데이터를 선물합니다. (1GB ~ 5GB 단위)"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "선물하기 성공"),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = """
+                            잘못된 요청
+                            - COMMON_002: 입력값 유효성 검증 실패 (1~5GB 범위를 벗어남 등)
+                            """,
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            ),
+            @ApiResponse(
+                    responseCode = "403",
+                    description = """
+                            권한 없음
+                            - AUTH_004: 동일 가족 구성원이 아님
+                            """,
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = """
+                            조회 실패
+                            - MEMBER_001: 회원 정보를 찾을 수 없음
+                            - SUB_001: 회선 정보를 찾을 수 없음
+                            """,
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            )
+    })
+    ResponseEntity<hotspot.user.common.ApiResponse<SendPresentDataResponse>> sendPresentData(
+            @Valid @RequestBody SendPresentDataRequest request,
+            @Parameter(hidden = true) @AuthenticationPrincipal PrincipalDetails details
     );
 }

--- a/src/main/java/hotspot/user/presentData/domain/PresentData.java
+++ b/src/main/java/hotspot/user/presentData/domain/PresentData.java
@@ -2,6 +2,8 @@ package hotspot.user.presentData.domain;
 
 import java.time.LocalDateTime;
 
+import hotspot.user.common.exception.ApplicationException;
+import hotspot.user.common.exception.code.PresentDataErrorCode;
 import hotspot.user.subscription.domain.Subscription;
 import lombok.Builder;
 import lombok.Getter;
@@ -20,10 +22,21 @@ public class PresentData {
                        Subscription targetSubscription,
                        Subscription provideSubscription,
                        Long dataAmount, LocalDateTime createdTime) {
+
+        // 생성 시점에 비즈니스 로직 검증
+        validateNotSelfGift(provideSubscription, targetSubscription);
+
         this.presentDataId = presentDataId;
         this.targetSubscription = targetSubscription;
         this.provideSubscription = provideSubscription;
         this.dataAmount = dataAmount;
         this.createdTime = createdTime;
+    }
+
+    // 본인에게 선물하는지 검증
+    private void validateNotSelfGift(Subscription provider, Subscription target) {
+        if (provider != null && target != null && provider.getId().equals(target.getId())) {
+            throw new ApplicationException(PresentDataErrorCode.PRESENT_DATA_SELF_GIFT);
+        }
     }
 }

--- a/src/main/java/hotspot/user/presentData/domain/mapper/SendPresentDataMapper.java
+++ b/src/main/java/hotspot/user/presentData/domain/mapper/SendPresentDataMapper.java
@@ -1,7 +1,5 @@
 package hotspot.user.presentData.domain.mapper;
 
-import java.time.LocalDateTime;
-
 import hotspot.user.presentData.controller.response.SendPresentDataResponse;
 import hotspot.user.presentData.domain.PresentData;
 import hotspot.user.subscription.domain.Subscription;
@@ -21,7 +19,6 @@ public class SendPresentDataMapper {
                 .provideSubscription(provideSubscription)
                 .targetSubscription(targetSubscription)
                 .dataAmount(dataAmount)
-                .createdTime(LocalDateTime.now())
                 .build();
     }
 

--- a/src/main/java/hotspot/user/presentData/domain/mapper/SendPresentDataMapper.java
+++ b/src/main/java/hotspot/user/presentData/domain/mapper/SendPresentDataMapper.java
@@ -12,7 +12,11 @@ import hotspot.user.subscription.domain.Subscription;
 public class SendPresentDataMapper {
 
     // requst -> domain
-    public static PresentData toPresentData(Subscription provideSubscription, Subscription targetSubscription, Long dataAmount) {
+    public static PresentData toPresentData(
+            Subscription provideSubscription,
+            Subscription targetSubscription,
+            Long dataAmount
+    ) {
         return PresentData.builder()
                 .provideSubscription(provideSubscription)
                 .targetSubscription(targetSubscription)

--- a/src/main/java/hotspot/user/presentData/domain/mapper/SendPresentDataMapper.java
+++ b/src/main/java/hotspot/user/presentData/domain/mapper/SendPresentDataMapper.java
@@ -1,10 +1,10 @@
 package hotspot.user.presentData.domain.mapper;
 
+import java.time.LocalDateTime;
+
 import hotspot.user.presentData.controller.response.SendPresentDataResponse;
 import hotspot.user.presentData.domain.PresentData;
 import hotspot.user.subscription.domain.Subscription;
-
-import java.time.LocalDateTime;
 
 /**
  * 데이터 선물하기 dto <-> domain

--- a/src/main/java/hotspot/user/presentData/domain/mapper/SendPresentDataMapper.java
+++ b/src/main/java/hotspot/user/presentData/domain/mapper/SendPresentDataMapper.java
@@ -4,6 +4,8 @@ import hotspot.user.presentData.controller.response.SendPresentDataResponse;
 import hotspot.user.presentData.domain.PresentData;
 import hotspot.user.subscription.domain.Subscription;
 
+import java.time.LocalDateTime;
+
 /**
  * 데이터 선물하기 dto <-> domain
  */
@@ -19,6 +21,7 @@ public class SendPresentDataMapper {
                 .provideSubscription(provideSubscription)
                 .targetSubscription(targetSubscription)
                 .dataAmount(dataAmount)
+                .createdTime(LocalDateTime.now())
                 .build();
     }
 

--- a/src/main/java/hotspot/user/presentData/domain/mapper/SendPresentDataMapper.java
+++ b/src/main/java/hotspot/user/presentData/domain/mapper/SendPresentDataMapper.java
@@ -1,4 +1,6 @@
-package hotspot.user.presentData.infrastructure.mapper;
+package hotspot.user.presentData.domain.mapper;
+
+import java.time.LocalDateTime;
 
 import hotspot.user.presentData.controller.response.SendPresentDataResponse;
 import hotspot.user.presentData.domain.PresentData;
@@ -15,6 +17,7 @@ public class SendPresentDataMapper {
                 .provideSubscription(provideSubscription)
                 .targetSubscription(targetSubscription)
                 .dataAmount(dataAmount)
+                .createdTime(LocalDateTime.now())
                 .build();
     }
 

--- a/src/main/java/hotspot/user/presentData/infrastructure/PresentDataRepositoryImpl.java
+++ b/src/main/java/hotspot/user/presentData/infrastructure/PresentDataRepositoryImpl.java
@@ -58,4 +58,14 @@ public class PresentDataRepositoryImpl implements PresentDataRepository {
     ) {
         return redisRepository.findUsageAndLimit(subPeriodMap);
     }
+
+    // 데이터 선물하기
+    @Override
+    public PresentData sendPresentData(PresentData presentData) {
+        PresentDataEntity entity = PresentDataEntity.domainToEntity(presentData);
+        PresentDataEntity savedEntity = presentDataJpaRepository.save(entity);
+        return savedEntity.entityToDomain();
+
+
+    }
 }

--- a/src/main/java/hotspot/user/presentData/infrastructure/entity/PresentDataEntity.java
+++ b/src/main/java/hotspot/user/presentData/infrastructure/entity/PresentDataEntity.java
@@ -1,5 +1,7 @@
 package hotspot.user.presentData.infrastructure.entity;
 
+import java.time.LocalDateTime;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -10,7 +12,6 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 
-import hotspot.user.common.BaseEntity;
 import hotspot.user.presentData.domain.PresentData;
 import hotspot.user.subscription.infrastructure.entity.SubscriptionEntity;
 import lombok.AccessLevel;
@@ -18,8 +19,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.time.LocalDateTime;
 
 @Entity
 @Getter

--- a/src/main/java/hotspot/user/presentData/infrastructure/entity/PresentDataEntity.java
+++ b/src/main/java/hotspot/user/presentData/infrastructure/entity/PresentDataEntity.java
@@ -1,12 +1,25 @@
 package hotspot.user.presentData.infrastructure.entity;
 
-import java.time.LocalDateTime;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 
-import jakarta.persistence.*;
-
+import hotspot.user.common.BaseEntity;
 import hotspot.user.presentData.domain.PresentData;
 import hotspot.user.subscription.infrastructure.entity.SubscriptionEntity;
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
 
 @Entity
 @Getter

--- a/src/main/java/hotspot/user/presentData/infrastructure/entity/PresentDataEntity.java
+++ b/src/main/java/hotspot/user/presentData/infrastructure/entity/PresentDataEntity.java
@@ -2,21 +2,11 @@ package hotspot.user.presentData.infrastructure.entity;
 
 import java.time.LocalDateTime;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 
 import hotspot.user.presentData.domain.PresentData;
 import hotspot.user.subscription.infrastructure.entity.SubscriptionEntity;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Entity
 @Getter
@@ -27,6 +17,7 @@ import lombok.NoArgsConstructor;
 public class PresentDataEntity {
 
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "present_data_id")
     private Long presentDataId;
 

--- a/src/main/java/hotspot/user/presentData/infrastructure/mapper/SendPresentDataMapper.java
+++ b/src/main/java/hotspot/user/presentData/infrastructure/mapper/SendPresentDataMapper.java
@@ -1,0 +1,30 @@
+package hotspot.user.presentData.infrastructure.mapper;
+
+import hotspot.user.presentData.controller.response.SendPresentDataResponse;
+import hotspot.user.presentData.domain.PresentData;
+import hotspot.user.subscription.domain.Subscription;
+
+/**
+ * 데이터 선물하기 dto <-> domain
+ */
+public class SendPresentDataMapper {
+
+    // requst -> domain
+    public static PresentData toPresentData(Subscription provideSubscription, Subscription targetSubscription, Long dataAmount) {
+        return PresentData.builder()
+                .provideSubscription(provideSubscription)
+                .targetSubscription(targetSubscription)
+                .dataAmount(dataAmount)
+                .build();
+    }
+
+    // domain -> response
+    public static SendPresentDataResponse toSendPresentDataResponse(PresentData presentData) {
+        return SendPresentDataResponse.builder()
+                .targetSubId(presentData.getTargetSubscription().getId())
+                .provideSubId(presentData.getProvideSubscription().getId())
+                .dataAmount(presentData.getDataAmount())
+                .createdTime(presentData.getCreatedTime())
+                .build();
+    }
+}

--- a/src/main/java/hotspot/user/presentData/service/SendPresentDataServiceImpl.java
+++ b/src/main/java/hotspot/user/presentData/service/SendPresentDataServiceImpl.java
@@ -26,6 +26,12 @@ import lombok.extern.slf4j.Slf4j;
 @Service
 @RequiredArgsConstructor
 public class SendPresentDataServiceImpl implements SendPresentDataService {
+
+    // 선물 데이터 GB => KB 변하기 위해 필요한 상수
+    private static final long MIN_PRESENT_AMOUNT_GB = 1L;
+    private static final long MAX_PRESENT_AMOUNT_GB = 5L;
+    private static final long GB_TO_KB_UNIT = 1048576L;
+
     private final PresentDataRepository presentDataRepository;
     private final FamilySubscriptionRepository familySubscriptionRepository;
 
@@ -57,13 +63,16 @@ public class SendPresentDataServiceImpl implements SendPresentDataService {
         // 4. 선물 가능 단위 및 범위 확인 (1GB ~ 5GB, 1GB 단위)
         validateDataAmount(request.dataAmount());
 
+        // KB 단위로 변환 (1GB = 1,048,576 KB)
+        long dataAmountInKb = request.dataAmount() * GB_TO_KB_UNIT;
+
         // [To-Do] 5. 현재 남은 데이터 양보다 더 많이 보내는지 확인
 
         // 6. DB 기록 저장
         PresentData presentData = SendPresentDataMapper.toPresentData(
                 providerFamilySub.getSubscription(),
                 targetFamilySub.getSubscription(),
-                request.dataAmount()
+                dataAmountInKb
         );
         PresentData sentPresentData = presentDataRepository.sendPresentData(presentData);
 
@@ -73,13 +82,9 @@ public class SendPresentDataServiceImpl implements SendPresentDataService {
         return SendPresentDataMapper.toSendPresentDataResponse(sentPresentData);
     }
 
-    private void validateDataAmount(Long amount) {
-        long oneGbInKb = 1048576L; // 1GB in KB
-        long minAmount = oneGbInKb;
-        long maxAmount = oneGbInKb * 5;
-
-        if (amount == null || amount < minAmount || amount > maxAmount || amount % oneGbInKb != 0) {
-            log.warn("데이터 선물 유효성 검증 실패: 요청량={}KB", amount);
+    private void validateDataAmount(Long amountGb) {
+        if (amountGb == null || amountGb < MIN_PRESENT_AMOUNT_GB || amountGb > MAX_PRESENT_AMOUNT_GB) {
+            log.warn("데이터 선물 유효성 검증 실패: 요청량={}GB", amountGb);
             throw new ApplicationException(PresentDataErrorCode.PRESENT_DATA_INVALID_AMOUNT);
         }
     }

--- a/src/main/java/hotspot/user/presentData/service/SendPresentDataServiceImpl.java
+++ b/src/main/java/hotspot/user/presentData/service/SendPresentDataServiceImpl.java
@@ -60,7 +60,11 @@ public class SendPresentDataServiceImpl implements SendPresentDataService {
         // [To-Do] 5. 현재 남은 데이터 양보다 더 많이 보내는지 확인
 
         // 6. DB 기록 저장
-        PresentData presentData = SendPresentDataMapper.toPresentData(providerFamilySub.getSubscription(), targetFamilySub.getSubscription(), request.dataAmount());
+        PresentData presentData = SendPresentDataMapper.toPresentData(
+                providerFamilySub.getSubscription(),
+                targetFamilySub.getSubscription(),
+                request.dataAmount()
+        );
         PresentData sentPresentData = presentDataRepository.sendPresentData(presentData);
 
         // 6. [To-Do] Redis 사용량 업데이트

--- a/src/main/java/hotspot/user/presentData/service/SendPresentDataServiceImpl.java
+++ b/src/main/java/hotspot/user/presentData/service/SendPresentDataServiceImpl.java
@@ -5,11 +5,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 import hotspot.user.common.exception.ApplicationException;
 import hotspot.user.common.exception.code.AuthErrorCode;
-import hotspot.user.common.exception.code.MemberErrorCode;
 import hotspot.user.common.exception.code.PresentDataErrorCode;
 import hotspot.user.family.controller.port.FindFamilySubscriptionService;
 import hotspot.user.family.domain.FamilySubscription;
-import hotspot.user.family.service.port.FamilySubscriptionRepository;
 import hotspot.user.presentData.controller.port.SendPresentDataService;
 import hotspot.user.presentData.controller.request.SendPresentDataRequest;
 import hotspot.user.presentData.controller.response.SendPresentDataResponse;
@@ -34,7 +32,6 @@ public class SendPresentDataServiceImpl implements SendPresentDataService {
     private static final long GB_TO_KB_UNIT = 1048576L;
 
     private final PresentDataRepository presentDataRepository;
-    private final FamilySubscriptionRepository familySubscriptionRepository;
     private final FindFamilySubscriptionService findFamilySubscriptionService;
 
     @Override

--- a/src/main/java/hotspot/user/presentData/service/SendPresentDataServiceImpl.java
+++ b/src/main/java/hotspot/user/presentData/service/SendPresentDataServiceImpl.java
@@ -7,6 +7,7 @@ import hotspot.user.common.exception.ApplicationException;
 import hotspot.user.common.exception.code.AuthErrorCode;
 import hotspot.user.common.exception.code.MemberErrorCode;
 import hotspot.user.common.exception.code.PresentDataErrorCode;
+import hotspot.user.family.controller.port.FindFamilySubscriptionService;
 import hotspot.user.family.domain.FamilySubscription;
 import hotspot.user.family.service.port.FamilySubscriptionRepository;
 import hotspot.user.presentData.controller.port.SendPresentDataService;
@@ -34,6 +35,7 @@ public class SendPresentDataServiceImpl implements SendPresentDataService {
 
     private final PresentDataRepository presentDataRepository;
     private final FamilySubscriptionRepository familySubscriptionRepository;
+    private final FindFamilySubscriptionService findFamilySubscriptionService;
 
     @Override
     @Transactional
@@ -43,30 +45,23 @@ public class SendPresentDataServiceImpl implements SendPresentDataService {
 
         // 1. 보내는 사람과 받는 사람의 가족 정보 조회
         // 보내는 사람: memberId 기반 조회
-        FamilySubscription providerFamilySub = familySubscriptionRepository.findByMemberId(memberId)
-                .orElseThrow(() -> new ApplicationException(MemberErrorCode.FAMILY_SUBSCRIPTION_NOT_FOUND));
+        FamilySubscription providerFamilySub = findFamilySubscriptionService.findByMemberId(memberId);
 
         // 받는 사람: subId 기반 조회
-        FamilySubscription targetFamilySub = familySubscriptionRepository.findBySubId(request.targetSubId())
-                .orElseThrow(() -> new ApplicationException(MemberErrorCode.FAMILY_SUBSCRIPTION_NOT_FOUND));
+        FamilySubscription targetFamilySub = findFamilySubscriptionService.findBySubId(request.targetSubId());
 
-        // 2. 같은 가족 구성원인지 확인
-        if (!providerFamilySub.getFamily().getId().equals(targetFamilySub.getFamily().getId())) {
-            throw new ApplicationException(AuthErrorCode.ACCESS_DENIED);
-        }
-
-        // 3. 자신에게 선물하는지 확인
-        if (providerFamilySub.getSubscription().getId().equals(targetFamilySub.getSubscription().getId())) {
-            throw new ApplicationException(PresentDataErrorCode.PRESENT_DATA_SELF_GIFT);
-        }
-
-        // 4. 선물 가능 단위 및 범위 확인 (1GB ~ 5GB, 1GB 단위)
+        // 3. 선물 가능 단위 및 범위 확인 (1GB ~ 5GB, 1GB 단위)
         validateDataAmount(request.dataAmount());
 
         // KB 단위로 변환 (1GB = 1,048,576 KB)
         long dataAmountInKb = request.dataAmount() * GB_TO_KB_UNIT;
 
-        // [To-Do] 5. 현재 남은 데이터 양보다 더 많이 보내는지 확인
+        // [To-Do] 4. 현재 남은 데이터 양보다 더 많이 보내는지 확인
+
+        // 5. 같은 가족 구성원인지 확인 (가족 정보 기반 검증)
+        if (!providerFamilySub.getFamily().getId().equals(targetFamilySub.getFamily().getId())) {
+            throw new ApplicationException(AuthErrorCode.ACCESS_DENIED);
+        }
 
         // 6. DB 기록 저장
         PresentData presentData = SendPresentDataMapper.toPresentData(

--- a/src/main/java/hotspot/user/presentData/service/SendPresentDataServiceImpl.java
+++ b/src/main/java/hotspot/user/presentData/service/SendPresentDataServiceImpl.java
@@ -1,0 +1,74 @@
+package hotspot.user.presentData.service;
+
+import hotspot.user.common.exception.ApplicationException;
+import hotspot.user.common.exception.code.AuthErrorCode;
+import hotspot.user.common.exception.code.GlobalErrorCode;
+import hotspot.user.common.exception.code.MemberErrorCode;
+import hotspot.user.family.domain.FamilySubscription;
+import hotspot.user.family.service.port.FamilySubscriptionRepository;
+import hotspot.user.presentData.controller.port.SendPresentDataService;
+import hotspot.user.presentData.controller.request.SendPresentDataRequest;
+import hotspot.user.presentData.controller.response.SendPresentDataResponse;
+import hotspot.user.presentData.domain.PresentData;
+import hotspot.user.presentData.infrastructure.mapper.SendPresentDataMapper;
+import hotspot.user.presentData.service.port.PresentDataRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+/**
+ * 데이터 선물하기 서비스 구현체
+ */
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SendPresentDataServiceImpl implements SendPresentDataService {
+    private final PresentDataRepository presentDataRepository;
+    private final FamilySubscriptionRepository familySubscriptionRepository;
+
+    @Override
+    @Transactional
+    public SendPresentDataResponse sendPresentData(Long memberId, SendPresentDataRequest request) {
+
+        log.info("전달 받은 memberId: {}, 전닫ㄹ 받은 subId: {}", memberId, request.targetSubId());
+
+        // 1. 보내는 사람과 받는 사람의 가족 정보 조회
+        // 보내는 사람: memberId 기반 조회
+        FamilySubscription providerFamilySub = familySubscriptionRepository.findByMemberId(memberId)
+                .orElseThrow(() -> new ApplicationException(MemberErrorCode.FAMILY_SUBSCRIPTION_NOT_FOUND));
+
+        // 받는 사람: subId 기반 조회
+        FamilySubscription targetFamilySub = familySubscriptionRepository.findBySubId(request.targetSubId())
+                .orElseThrow(() -> new ApplicationException(MemberErrorCode.FAMILY_SUBSCRIPTION_NOT_FOUND));
+
+        // 2. 같은 가족 구성원인지 확인
+        if (!providerFamilySub.getFamily().getId().equals(targetFamilySub.getFamily().getId())) {
+            throw new ApplicationException(AuthErrorCode.ACCESS_DENIED);
+        }
+
+        // 3. 선물 가능 단위 및 범위 확인 (1GB ~ 5GB, 1GB 단위)
+        validateDataAmount(request.dataAmount());
+
+        // [To-Do] 4. 현재 남은 데이터 양보다 더 많이 보내는지 확인
+
+        // 5. DB 기록 저장
+        PresentData presentData = SendPresentDataMapper.toPresentData(providerFamilySub.getSubscription(), targetFamilySub.getSubscription(), request.dataAmount());
+        PresentData sentPresentData = presentDataRepository.sendPresentData(presentData);
+
+        // 6. [To-Do] Redis 사용량 업데이트
+        // 주는 사람: 사용량 증가, 받는 사람: 선물 받은 데이터 양 증가?
+
+        return SendPresentDataMapper.toSendPresentDataResponse(sentPresentData);
+    }
+
+    private void validateDataAmount(Long amount) {
+        if (amount == null || amount < 1 || amount > 5) {
+            log.warn("데이터 선물 유효성 검증 실패: 요청량={}GB", amount);
+            throw new ApplicationException(GlobalErrorCode.VALIDATION_FAILED);
+        }
+    }
+}

--- a/src/main/java/hotspot/user/presentData/service/SendPresentDataServiceImpl.java
+++ b/src/main/java/hotspot/user/presentData/service/SendPresentDataServiceImpl.java
@@ -1,23 +1,22 @@
 package hotspot.user.presentData.service;
 
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import hotspot.user.common.exception.ApplicationException;
 import hotspot.user.common.exception.code.AuthErrorCode;
-import hotspot.user.common.exception.code.GlobalErrorCode;
 import hotspot.user.common.exception.code.MemberErrorCode;
+import hotspot.user.common.exception.code.PresentDataErrorCode;
 import hotspot.user.family.domain.FamilySubscription;
 import hotspot.user.family.service.port.FamilySubscriptionRepository;
 import hotspot.user.presentData.controller.port.SendPresentDataService;
 import hotspot.user.presentData.controller.request.SendPresentDataRequest;
 import hotspot.user.presentData.controller.response.SendPresentDataResponse;
 import hotspot.user.presentData.domain.PresentData;
-import hotspot.user.presentData.infrastructure.mapper.SendPresentDataMapper;
+import hotspot.user.presentData.domain.mapper.SendPresentDataMapper;
 import hotspot.user.presentData.service.port.PresentDataRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
-import java.time.LocalDateTime;
 
 /**
  * 데이터 선물하기 서비스 구현체
@@ -34,7 +33,7 @@ public class SendPresentDataServiceImpl implements SendPresentDataService {
     @Transactional
     public SendPresentDataResponse sendPresentData(Long memberId, SendPresentDataRequest request) {
 
-        log.info("전달 받은 memberId: {}, 전닫ㄹ 받은 subId: {}", memberId, request.targetSubId());
+        log.info("전달 받은 memberId: {}, 전달 받은 subId: {}", memberId, request.targetSubId());
 
         // 1. 보내는 사람과 받는 사람의 가족 정보 조회
         // 보내는 사람: memberId 기반 조회
@@ -50,12 +49,17 @@ public class SendPresentDataServiceImpl implements SendPresentDataService {
             throw new ApplicationException(AuthErrorCode.ACCESS_DENIED);
         }
 
-        // 3. 선물 가능 단위 및 범위 확인 (1GB ~ 5GB, 1GB 단위)
+        // 3. 자신에게 선물하는지 확인
+        if (providerFamilySub.getSubscription().getId().equals(targetFamilySub.getSubscription().getId())) {
+            throw new ApplicationException(PresentDataErrorCode.PRESENT_DATA_SELF_GIFT);
+        }
+
+        // 4. 선물 가능 단위 및 범위 확인 (1GB ~ 5GB, 1GB 단위)
         validateDataAmount(request.dataAmount());
 
-        // [To-Do] 4. 현재 남은 데이터 양보다 더 많이 보내는지 확인
+        // [To-Do] 5. 현재 남은 데이터 양보다 더 많이 보내는지 확인
 
-        // 5. DB 기록 저장
+        // 6. DB 기록 저장
         PresentData presentData = SendPresentDataMapper.toPresentData(providerFamilySub.getSubscription(), targetFamilySub.getSubscription(), request.dataAmount());
         PresentData sentPresentData = presentDataRepository.sendPresentData(presentData);
 
@@ -66,9 +70,13 @@ public class SendPresentDataServiceImpl implements SendPresentDataService {
     }
 
     private void validateDataAmount(Long amount) {
-        if (amount == null || amount < 1 || amount > 5) {
-            log.warn("데이터 선물 유효성 검증 실패: 요청량={}GB", amount);
-            throw new ApplicationException(GlobalErrorCode.VALIDATION_FAILED);
+        long oneGbInKb = 1048576L; // 1GB in KB
+        long minAmount = oneGbInKb;
+        long maxAmount = oneGbInKb * 5;
+
+        if (amount == null || amount < minAmount || amount > maxAmount || amount % oneGbInKb != 0) {
+            log.warn("데이터 선물 유효성 검증 실패: 요청량={}KB", amount);
+            throw new ApplicationException(PresentDataErrorCode.PRESENT_DATA_INVALID_AMOUNT);
         }
     }
 }

--- a/src/main/java/hotspot/user/presentData/service/port/PresentDataRepository.java
+++ b/src/main/java/hotspot/user/presentData/service/port/PresentDataRepository.java
@@ -18,4 +18,6 @@ public interface PresentDataRepository {
     Map<Long, SubUsage> findSubUsage(
             Map<Long, DataPeriod> subPeriodMap
     );
+
+    PresentData sendPresentData(PresentData presentData); // 데이터 선물하기
 }

--- a/src/test/java/hotspot/user/family/service/FindFamilySubscriptionServiceImplTest.java
+++ b/src/test/java/hotspot/user/family/service/FindFamilySubscriptionServiceImplTest.java
@@ -15,7 +15,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import hotspot.user.common.exception.ApplicationException;
 import hotspot.user.common.exception.code.FamilyErrorCode;
-import hotspot.user.family.controller.response.FamilySubscriptionResponse;
 import hotspot.user.family.domain.Family;
 import hotspot.user.family.domain.FamilySubscription;
 import hotspot.user.family.service.port.FamilySubscriptionRepository;
@@ -35,7 +34,7 @@ class FindFamilySubscriptionServiceImplTest {
     private FindFamilySubscriptionServiceImpl service;
 
     @Test
-    @DisplayName("회선 ID로 가족 가입 정보를 조회하면 FamilySubscriptionResponse를 반환한다")
+    @DisplayName("회선 ID로 가족 가입 정보를 조회하면 FamilySubscription 도메인을 반환한다")
     void findBySubIdSuccess() {
         // given
         Long subId = 1L;
@@ -62,13 +61,13 @@ class FindFamilySubscriptionServiceImplTest {
         given(repository.findBySubId(subId)).willReturn(Optional.of(familySubscription));
 
         // when
-        FamilySubscriptionResponse response = service.findBySubId(subId);
+        FamilySubscription response = service.findBySubId(subId);
 
         // then
-        assertThat(response.id()).isEqualTo(familySubId);
-        assertThat(response.subscriptionId()).isEqualTo(subId);
-        assertThat(response.familyId()).isEqualTo(familyId);
-        assertThat(response.role()).isEqualTo(FamilyRole.PARENT);
+        assertThat(response.getId()).isEqualTo(familySubId);
+        assertThat(response.getSubscription().getId()).isEqualTo(subId);
+        assertThat(response.getFamily().getId()).isEqualTo(familyId);
+        assertThat(response.getFamilyRole()).isEqualTo(FamilyRole.PARENT);
     }
 
     @Test
@@ -82,5 +81,41 @@ class FindFamilySubscriptionServiceImplTest {
         assertThatThrownBy(() -> service.findBySubId(subId))
                 .isInstanceOf(ApplicationException.class)
                 .hasMessage(FamilyErrorCode.FAMILY_SUBSCRIPTION_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("회원 ID로 가족 가입 정보를 조회하면 FamilySubscription 도메인을 반환한다")
+    void findByMemberIdSuccess() {
+        // given
+        Long memberId = 1L;
+        Long subId = 2L;
+        Long familyId = 10L;
+        Long familySubId = 100L;
+
+        Subscription subscription = Subscription.builder()
+                .id(subId)
+                .build();
+
+        Family family = Family.builder()
+                .id(familyId)
+                .build();
+
+        FamilySubscription familySubscription = FamilySubscription.builder()
+                .id(familySubId)
+                .subscription(subscription)
+                .family(family)
+                .familyRole(FamilyRole.PARENT)
+                .priority(-1)
+                .dataLimit(10000)
+                .build();
+
+        given(repository.findByMemberId(memberId)).willReturn(Optional.of(familySubscription));
+
+        // when
+        FamilySubscription response = service.findByMemberId(memberId);
+
+        // then
+        assertThat(response.getId()).isEqualTo(familySubId);
+        assertThat(response.getSubscription().getId()).isEqualTo(subId);
     }
 }

--- a/src/test/java/hotspot/user/presentData/controller/PresentDataControllerTest.java
+++ b/src/test/java/hotspot/user/presentData/controller/PresentDataControllerTest.java
@@ -23,6 +23,7 @@ import hotspot.user.member.domain.FamilyRole;
 import hotspot.user.presentData.controller.port.FindFamilyDataService;
 import hotspot.user.presentData.controller.port.FindPresentProvideService;
 import hotspot.user.presentData.controller.port.FindPresentReceiveService;
+import hotspot.user.presentData.controller.port.SendPresentDataService;
 import hotspot.user.presentData.controller.response.FamilyDataResponse;
 import hotspot.user.presentData.controller.response.PresentDataResponse;
 
@@ -43,6 +44,9 @@ class PresentDataControllerTest {
     FindPresentProvideService findPresentProvideService;
 
     @MockBean
+    SendPresentDataService sendPresentDataService;
+
+    @MockBean
     JwtFilter jwtFilter;
 
     @MockBean
@@ -55,7 +59,7 @@ class PresentDataControllerTest {
     @DisplayName("가족 선물 데이터 조회 성공")
     void shouldReturnFamilyPresentDataSuccessfully() throws Exception {
 
-        // 🔥 Security Context 직접 세팅
+        // Security Context 직접 세팅
         setAuthentication(1L, 10L, FamilyRole.OWNER);
 
         FamilyDataResponse.SubUsageResponse sub1 =

--- a/src/test/java/hotspot/user/presentData/domain/PresentDataTest.java
+++ b/src/test/java/hotspot/user/presentData/domain/PresentDataTest.java
@@ -1,14 +1,18 @@
 package hotspot.user.presentData.domain;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.time.LocalDateTime;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import hotspot.user.common.exception.ApplicationException;
+import hotspot.user.common.exception.code.PresentDataErrorCode;
 import hotspot.user.subscription.domain.Subscription;
 
 class PresentDataTest {
@@ -20,6 +24,9 @@ class PresentDataTest {
         // given
         Subscription targetSubscription = mock(Subscription.class);
         Subscription provideSubscription = mock(Subscription.class);
+
+        when(targetSubscription.getId()).thenReturn(1L);
+        when(provideSubscription.getId()).thenReturn(2L);
 
         LocalDateTime now = LocalDateTime.now();
 
@@ -39,5 +46,23 @@ class PresentDataTest {
         assertEquals(provideSubscription, presentData.getProvideSubscription());
         assertEquals(1048576L, presentData.getDataAmount());
         assertEquals(now, presentData.getCreatedTime());
+    }
+
+    @Test
+    @DisplayName("자가 선물 시 생성자에서 예외 발생")
+    void shouldThrowExceptionWhenSelfGifting() {
+        // given
+        Subscription subscription = mock(Subscription.class);
+        when(subscription.getId()).thenReturn(1L);
+
+        // when & then
+        assertThatThrownBy(() -> PresentData.builder()
+                .presentDataId(1L)
+                .targetSubscription(subscription)
+                .provideSubscription(subscription)
+                .dataAmount(1048576L)
+                .build())
+                .isInstanceOf(ApplicationException.class)
+                .hasFieldOrPropertyWithValue("code", PresentDataErrorCode.PRESENT_DATA_SELF_GIFT);
     }
 }

--- a/src/test/java/hotspot/user/presentData/service/SendPresentDataServiceImplTest.java
+++ b/src/test/java/hotspot/user/presentData/service/SendPresentDataServiceImplTest.java
@@ -5,8 +5,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
-import java.util.Optional;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -17,11 +15,11 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import hotspot.user.common.exception.ApplicationException;
 import hotspot.user.common.exception.code.AuthErrorCode;
-import hotspot.user.common.exception.code.MemberErrorCode;
+import hotspot.user.common.exception.code.FamilyErrorCode;
 import hotspot.user.common.exception.code.PresentDataErrorCode;
+import hotspot.user.family.controller.port.FindFamilySubscriptionService;
 import hotspot.user.family.domain.Family;
 import hotspot.user.family.domain.FamilySubscription;
-import hotspot.user.family.service.port.FamilySubscriptionRepository;
 import hotspot.user.presentData.controller.request.SendPresentDataRequest;
 import hotspot.user.presentData.controller.response.SendPresentDataResponse;
 import hotspot.user.presentData.domain.PresentData;
@@ -37,7 +35,7 @@ class SendPresentDataServiceImplTest {
     private PresentDataRepository presentDataRepository;
 
     @Mock
-    private FamilySubscriptionRepository familySubscriptionRepository;
+    private FindFamilySubscriptionService findFamilySubscriptionService;
 
     @InjectMocks
     private SendPresentDataServiceImpl sendPresentDataService;
@@ -91,8 +89,8 @@ class SendPresentDataServiceImplTest {
                 .dataAmount(ONE_GB_IN_KB) // 저장된 값 (KB)
                 .build();
 
-        when(familySubscriptionRepository.findByMemberId(memberId)).thenReturn(Optional.of(providerFamilySub));
-        when(familySubscriptionRepository.findBySubId(targetSubId)).thenReturn(Optional.of(targetFamilySub));
+        when(findFamilySubscriptionService.findByMemberId(memberId)).thenReturn(providerFamilySub);
+        when(findFamilySubscriptionService.findBySubId(targetSubId)).thenReturn(targetFamilySub);
         when(presentDataRepository.sendPresentData(any(PresentData.class))).thenReturn(savedPresentData);
 
         // when
@@ -109,12 +107,13 @@ class SendPresentDataServiceImplTest {
     void sendPresentDataProviderFamilyNotFound() {
         // given
         SendPresentDataRequest request = new SendPresentDataRequest(targetSubId, 1L);
-        when(familySubscriptionRepository.findByMemberId(memberId)).thenReturn(Optional.empty());
+        when(findFamilySubscriptionService.findByMemberId(memberId))
+                .thenThrow(new ApplicationException(FamilyErrorCode.FAMILY_SUBSCRIPTION_NOT_FOUND));
 
         // when & then
         assertThatThrownBy(() -> sendPresentDataService.sendPresentData(memberId, request))
                 .isInstanceOf(ApplicationException.class)
-                .hasFieldOrPropertyWithValue("code", MemberErrorCode.FAMILY_SUBSCRIPTION_NOT_FOUND);
+                .hasFieldOrPropertyWithValue("code", FamilyErrorCode.FAMILY_SUBSCRIPTION_NOT_FOUND);
     }
 
     @Test
@@ -122,13 +121,14 @@ class SendPresentDataServiceImplTest {
     void sendPresentDataTargetFamilyNotFound() {
         // given
         SendPresentDataRequest request = new SendPresentDataRequest(targetSubId, 1L);
-        when(familySubscriptionRepository.findByMemberId(memberId)).thenReturn(Optional.of(providerFamilySub));
-        when(familySubscriptionRepository.findBySubId(targetSubId)).thenReturn(Optional.empty());
+        when(findFamilySubscriptionService.findByMemberId(memberId)).thenReturn(providerFamilySub);
+        when(findFamilySubscriptionService.findBySubId(targetSubId))
+                .thenThrow(new ApplicationException(FamilyErrorCode.FAMILY_SUBSCRIPTION_NOT_FOUND));
 
         // when & then
         assertThatThrownBy(() -> sendPresentDataService.sendPresentData(memberId, request))
                 .isInstanceOf(ApplicationException.class)
-                .hasFieldOrPropertyWithValue("code", MemberErrorCode.FAMILY_SUBSCRIPTION_NOT_FOUND);
+                .hasFieldOrPropertyWithValue("code", FamilyErrorCode.FAMILY_SUBSCRIPTION_NOT_FOUND);
     }
 
     @Test
@@ -142,8 +142,8 @@ class SendPresentDataServiceImplTest {
                 .build();
 
         SendPresentDataRequest request = new SendPresentDataRequest(targetSubId, 1L);
-        when(familySubscriptionRepository.findByMemberId(memberId)).thenReturn(Optional.of(providerFamilySub));
-        when(familySubscriptionRepository.findBySubId(targetSubId)).thenReturn(Optional.of(otherFamilySub));
+        when(findFamilySubscriptionService.findByMemberId(memberId)).thenReturn(providerFamilySub);
+        when(findFamilySubscriptionService.findBySubId(targetSubId)).thenReturn(otherFamilySub);
 
         // when & then
         assertThatThrownBy(() -> sendPresentDataService.sendPresentData(memberId, request))
@@ -156,8 +156,8 @@ class SendPresentDataServiceImplTest {
     void sendPresentDataSelfGift() {
         // given
         SendPresentDataRequest request = new SendPresentDataRequest(providerSub.getId(), 1L);
-        when(familySubscriptionRepository.findByMemberId(memberId)).thenReturn(Optional.of(providerFamilySub));
-        when(familySubscriptionRepository.findBySubId(providerSub.getId())).thenReturn(Optional.of(providerFamilySub));
+        when(findFamilySubscriptionService.findByMemberId(memberId)).thenReturn(providerFamilySub);
+        when(findFamilySubscriptionService.findBySubId(providerSub.getId())).thenReturn(providerFamilySub);
 
         // when & then
         assertThatThrownBy(() -> sendPresentDataService.sendPresentData(memberId, request))
@@ -170,8 +170,8 @@ class SendPresentDataServiceImplTest {
     void sendPresentDataInvalidAmountTooSmall() {
         // given
         SendPresentDataRequest request = new SendPresentDataRequest(targetSubId, 0L);
-        when(familySubscriptionRepository.findByMemberId(memberId)).thenReturn(Optional.of(providerFamilySub));
-        when(familySubscriptionRepository.findBySubId(targetSubId)).thenReturn(Optional.of(targetFamilySub));
+        when(findFamilySubscriptionService.findByMemberId(memberId)).thenReturn(providerFamilySub);
+        when(findFamilySubscriptionService.findBySubId(targetSubId)).thenReturn(targetFamilySub);
 
         // when & then
         assertThatThrownBy(() -> sendPresentDataService.sendPresentData(memberId, request))
@@ -184,8 +184,8 @@ class SendPresentDataServiceImplTest {
     void sendPresentDataInvalidAmountTooLarge() {
         // given
         SendPresentDataRequest request = new SendPresentDataRequest(targetSubId, 6L);
-        when(familySubscriptionRepository.findByMemberId(memberId)).thenReturn(Optional.of(providerFamilySub));
-        when(familySubscriptionRepository.findBySubId(targetSubId)).thenReturn(Optional.of(targetFamilySub));
+        when(findFamilySubscriptionService.findByMemberId(memberId)).thenReturn(providerFamilySub);
+        when(findFamilySubscriptionService.findBySubId(targetSubId)).thenReturn(targetFamilySub);
 
         // when & then
         assertThatThrownBy(() -> sendPresentDataService.sendPresentData(memberId, request))

--- a/src/test/java/hotspot/user/presentData/service/SendPresentDataServiceImplTest.java
+++ b/src/test/java/hotspot/user/presentData/service/SendPresentDataServiceImplTest.java
@@ -1,0 +1,208 @@
+package hotspot.user.presentData.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import hotspot.user.common.exception.ApplicationException;
+import hotspot.user.common.exception.code.AuthErrorCode;
+import hotspot.user.common.exception.code.MemberErrorCode;
+import hotspot.user.common.exception.code.PresentDataErrorCode;
+import hotspot.user.family.domain.Family;
+import hotspot.user.family.domain.FamilySubscription;
+import hotspot.user.family.service.port.FamilySubscriptionRepository;
+import hotspot.user.presentData.controller.request.SendPresentDataRequest;
+import hotspot.user.presentData.controller.response.SendPresentDataResponse;
+import hotspot.user.presentData.domain.PresentData;
+import hotspot.user.presentData.service.port.PresentDataRepository;
+import hotspot.user.subscription.domain.Subscription;
+
+@ExtendWith(MockitoExtension.class)
+class SendPresentDataServiceImplTest {
+
+    @Mock
+    private PresentDataRepository presentDataRepository;
+
+    @Mock
+    private FamilySubscriptionRepository familySubscriptionRepository;
+
+    @InjectMocks
+    private SendPresentDataServiceImpl sendPresentDataService;
+
+    private Long memberId;
+    private Long targetSubId;
+    private Long oneGb;
+    private Family family;
+    private Subscription providerSub;
+    private Subscription targetSub;
+    private FamilySubscription providerFamilySub;
+    private FamilySubscription targetFamilySub;
+
+    @BeforeEach
+    void setUp() {
+        memberId = 1L;
+        targetSubId = 2L;
+        oneGb = 1048576L;
+
+        family = Family.builder()
+                .id(10L)
+                .build();
+
+        providerSub = Subscription.builder()
+                .id(1L)
+                .build();
+
+        targetSub = Subscription.builder()
+                .id(2L)
+                .build();
+
+        providerFamilySub = FamilySubscription.builder()
+                .family(family)
+                .subscription(providerSub)
+                .build();
+
+        targetFamilySub = FamilySubscription.builder()
+                .family(family)
+                .subscription(targetSub)
+                .build();
+    }
+
+    @Test
+    @DisplayName("데이터 선물하기 성공")
+    void sendPresentDataSuccess() {
+        // given
+        SendPresentDataRequest request = new SendPresentDataRequest(targetSubId, oneGb);
+        PresentData presentData = PresentData.builder()
+                .provideSubscription(providerSub)
+                .targetSubscription(targetSub)
+                .dataAmount(oneGb)
+                .build();
+
+        when(familySubscriptionRepository.findByMemberId(memberId)).thenReturn(Optional.of(providerFamilySub));
+        when(familySubscriptionRepository.findBySubId(targetSubId)).thenReturn(Optional.of(targetFamilySub));
+        when(presentDataRepository.sendPresentData(any(PresentData.class))).thenReturn(presentData);
+
+        // when
+        SendPresentDataResponse response = sendPresentDataService.sendPresentData(memberId, request);
+
+        // then
+        assertThat(response.provideSubId()).isEqualTo(providerSub.getId());
+        assertThat(response.targetSubId()).isEqualTo(targetSub.getId());
+        assertThat(response.dataAmount()).isEqualTo(oneGb);
+    }
+
+    @Test
+    @DisplayName("보내는 사람의 가족 결합 정보를 찾을 수 없을 때 예외 발생")
+    void sendPresentDataProviderFamilyNotFound() {
+        // given
+        SendPresentDataRequest request = new SendPresentDataRequest(targetSubId, oneGb);
+        when(familySubscriptionRepository.findByMemberId(memberId)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> sendPresentDataService.sendPresentData(memberId, request))
+                .isInstanceOf(ApplicationException.class)
+                .hasFieldOrPropertyWithValue("code", MemberErrorCode.FAMILY_SUBSCRIPTION_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("받는 사람의 가족 결합 정보를 찾을 수 없을 때 예외 발생")
+    void sendPresentDataTargetFamilyNotFound() {
+        // given
+        SendPresentDataRequest request = new SendPresentDataRequest(targetSubId, oneGb);
+        when(familySubscriptionRepository.findByMemberId(memberId)).thenReturn(Optional.of(providerFamilySub));
+        when(familySubscriptionRepository.findBySubId(targetSubId)).thenReturn(Optional.of(targetFamilySub));
+        when(familySubscriptionRepository.findBySubId(targetSubId)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> sendPresentDataService.sendPresentData(memberId, request))
+                .isInstanceOf(ApplicationException.class)
+                .hasFieldOrPropertyWithValue("code", MemberErrorCode.FAMILY_SUBSCRIPTION_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("같은 가족 구성원이 아닐 때 예외 발생")
+    void sendPresentDataNotSameFamily() {
+        // given
+        Family otherFamily = Family.builder().id(20L).build();
+        FamilySubscription otherFamilySub = FamilySubscription.builder()
+                .family(otherFamily)
+                .subscription(targetSub)
+                .build();
+
+        SendPresentDataRequest request = new SendPresentDataRequest(targetSubId, oneGb);
+        when(familySubscriptionRepository.findByMemberId(memberId)).thenReturn(Optional.of(providerFamilySub));
+        when(familySubscriptionRepository.findBySubId(targetSubId)).thenReturn(Optional.of(otherFamilySub));
+
+        // when & then
+        assertThatThrownBy(() -> sendPresentDataService.sendPresentData(memberId, request))
+                .isInstanceOf(ApplicationException.class)
+                .hasFieldOrPropertyWithValue("code", AuthErrorCode.ACCESS_DENIED);
+    }
+
+    @Test
+    @DisplayName("자신에게 선물할 때 예외 발생")
+    void sendPresentDataSelfGift() {
+        // given
+        SendPresentDataRequest request = new SendPresentDataRequest(providerSub.getId(), oneGb);
+        when(familySubscriptionRepository.findByMemberId(memberId)).thenReturn(Optional.of(providerFamilySub));
+        when(familySubscriptionRepository.findBySubId(providerSub.getId())).thenReturn(Optional.of(providerFamilySub));
+
+        // when & then
+        assertThatThrownBy(() -> sendPresentDataService.sendPresentData(memberId, request))
+                .isInstanceOf(ApplicationException.class)
+                .hasFieldOrPropertyWithValue("code", PresentDataErrorCode.PRESENT_DATA_SELF_GIFT);
+    }
+
+    @Test
+    @DisplayName("데이터 선물 요청량이 1GB 미만일 때 예외 발생")
+    void sendPresentDataInvalidAmountTooSmall() {
+        // given
+        SendPresentDataRequest request = new SendPresentDataRequest(targetSubId, 500L);
+        when(familySubscriptionRepository.findByMemberId(memberId)).thenReturn(Optional.of(providerFamilySub));
+        when(familySubscriptionRepository.findBySubId(targetSubId)).thenReturn(Optional.of(targetFamilySub));
+
+        // when & then
+        assertThatThrownBy(() -> sendPresentDataService.sendPresentData(memberId, request))
+                .isInstanceOf(ApplicationException.class)
+                .hasFieldOrPropertyWithValue("code", PresentDataErrorCode.PRESENT_DATA_INVALID_AMOUNT);
+    }
+
+    @Test
+    @DisplayName("데이터 선물 요청량이 5GB 초과일 때 예외 발생")
+    void sendPresentDataInvalidAmountTooLarge() {
+        // given
+        SendPresentDataRequest request = new SendPresentDataRequest(targetSubId, oneGb * 6);
+        when(familySubscriptionRepository.findByMemberId(memberId)).thenReturn(Optional.of(providerFamilySub));
+        when(familySubscriptionRepository.findBySubId(targetSubId)).thenReturn(Optional.of(targetFamilySub));
+
+        // when & then
+        assertThatThrownBy(() -> sendPresentDataService.sendPresentData(memberId, request))
+                .isInstanceOf(ApplicationException.class)
+                .hasFieldOrPropertyWithValue("code", PresentDataErrorCode.PRESENT_DATA_INVALID_AMOUNT);
+    }
+
+    @Test
+    @DisplayName("데이터 선물 요청량이 1GB 단위가 아닐 때 예외 발생")
+    void sendPresentDataInvalidAmountNotStep() {
+        // given
+        SendPresentDataRequest request = new SendPresentDataRequest(targetSubId, oneGb + 100L);
+        when(familySubscriptionRepository.findByMemberId(memberId)).thenReturn(Optional.of(providerFamilySub));
+        when(familySubscriptionRepository.findBySubId(targetSubId)).thenReturn(Optional.of(targetFamilySub));
+
+        // when & then
+        assertThatThrownBy(() -> sendPresentDataService.sendPresentData(memberId, request))
+                .isInstanceOf(ApplicationException.class)
+                .hasFieldOrPropertyWithValue("code", PresentDataErrorCode.PRESENT_DATA_INVALID_AMOUNT);
+    }
+}

--- a/src/test/java/hotspot/user/presentData/service/SendPresentDataServiceImplTest.java
+++ b/src/test/java/hotspot/user/presentData/service/SendPresentDataServiceImplTest.java
@@ -31,6 +31,8 @@ import hotspot.user.subscription.domain.Subscription;
 @ExtendWith(MockitoExtension.class)
 class SendPresentDataServiceImplTest {
 
+    private static final long ONE_GB_IN_KB = 1048576L;
+
     @Mock
     private PresentDataRepository presentDataRepository;
 
@@ -42,7 +44,6 @@ class SendPresentDataServiceImplTest {
 
     private Long memberId;
     private Long targetSubId;
-    private Long oneGb;
     private Family family;
     private Subscription providerSub;
     private Subscription targetSub;
@@ -53,7 +54,6 @@ class SendPresentDataServiceImplTest {
     void setUp() {
         memberId = 1L;
         targetSubId = 2L;
-        oneGb = 1048576L;
 
         family = Family.builder()
                 .id(10L)
@@ -79,19 +79,21 @@ class SendPresentDataServiceImplTest {
     }
 
     @Test
-    @DisplayName("데이터 선물하기 성공")
+    @DisplayName("데이터 선물하기 성공 (1GB 요청 시 내부적으로 KB 변환 확인)")
     void sendPresentDataSuccess() {
         // given
-        SendPresentDataRequest request = new SendPresentDataRequest(targetSubId, oneGb);
-        PresentData presentData = PresentData.builder()
+        Long requestAmountGb = 1L; // 프론트에서 보내는 값 (GB)
+        SendPresentDataRequest request = new SendPresentDataRequest(targetSubId, requestAmountGb);
+
+        PresentData savedPresentData = PresentData.builder()
                 .provideSubscription(providerSub)
                 .targetSubscription(targetSub)
-                .dataAmount(oneGb)
+                .dataAmount(ONE_GB_IN_KB) // 저장된 값 (KB)
                 .build();
 
         when(familySubscriptionRepository.findByMemberId(memberId)).thenReturn(Optional.of(providerFamilySub));
         when(familySubscriptionRepository.findBySubId(targetSubId)).thenReturn(Optional.of(targetFamilySub));
-        when(presentDataRepository.sendPresentData(any(PresentData.class))).thenReturn(presentData);
+        when(presentDataRepository.sendPresentData(any(PresentData.class))).thenReturn(savedPresentData);
 
         // when
         SendPresentDataResponse response = sendPresentDataService.sendPresentData(memberId, request);
@@ -99,14 +101,14 @@ class SendPresentDataServiceImplTest {
         // then
         assertThat(response.provideSubId()).isEqualTo(providerSub.getId());
         assertThat(response.targetSubId()).isEqualTo(targetSub.getId());
-        assertThat(response.dataAmount()).isEqualTo(oneGb);
+        assertThat(response.dataAmount()).isEqualTo(ONE_GB_IN_KB);
     }
 
     @Test
     @DisplayName("보내는 사람의 가족 결합 정보를 찾을 수 없을 때 예외 발생")
     void sendPresentDataProviderFamilyNotFound() {
         // given
-        SendPresentDataRequest request = new SendPresentDataRequest(targetSubId, oneGb);
+        SendPresentDataRequest request = new SendPresentDataRequest(targetSubId, 1L);
         when(familySubscriptionRepository.findByMemberId(memberId)).thenReturn(Optional.empty());
 
         // when & then
@@ -119,9 +121,8 @@ class SendPresentDataServiceImplTest {
     @DisplayName("받는 사람의 가족 결합 정보를 찾을 수 없을 때 예외 발생")
     void sendPresentDataTargetFamilyNotFound() {
         // given
-        SendPresentDataRequest request = new SendPresentDataRequest(targetSubId, oneGb);
+        SendPresentDataRequest request = new SendPresentDataRequest(targetSubId, 1L);
         when(familySubscriptionRepository.findByMemberId(memberId)).thenReturn(Optional.of(providerFamilySub));
-        when(familySubscriptionRepository.findBySubId(targetSubId)).thenReturn(Optional.of(targetFamilySub));
         when(familySubscriptionRepository.findBySubId(targetSubId)).thenReturn(Optional.empty());
 
         // when & then
@@ -140,7 +141,7 @@ class SendPresentDataServiceImplTest {
                 .subscription(targetSub)
                 .build();
 
-        SendPresentDataRequest request = new SendPresentDataRequest(targetSubId, oneGb);
+        SendPresentDataRequest request = new SendPresentDataRequest(targetSubId, 1L);
         when(familySubscriptionRepository.findByMemberId(memberId)).thenReturn(Optional.of(providerFamilySub));
         when(familySubscriptionRepository.findBySubId(targetSubId)).thenReturn(Optional.of(otherFamilySub));
 
@@ -154,7 +155,7 @@ class SendPresentDataServiceImplTest {
     @DisplayName("자신에게 선물할 때 예외 발생")
     void sendPresentDataSelfGift() {
         // given
-        SendPresentDataRequest request = new SendPresentDataRequest(providerSub.getId(), oneGb);
+        SendPresentDataRequest request = new SendPresentDataRequest(providerSub.getId(), 1L);
         when(familySubscriptionRepository.findByMemberId(memberId)).thenReturn(Optional.of(providerFamilySub));
         when(familySubscriptionRepository.findBySubId(providerSub.getId())).thenReturn(Optional.of(providerFamilySub));
 
@@ -168,7 +169,7 @@ class SendPresentDataServiceImplTest {
     @DisplayName("데이터 선물 요청량이 1GB 미만일 때 예외 발생")
     void sendPresentDataInvalidAmountTooSmall() {
         // given
-        SendPresentDataRequest request = new SendPresentDataRequest(targetSubId, 500L);
+        SendPresentDataRequest request = new SendPresentDataRequest(targetSubId, 0L);
         when(familySubscriptionRepository.findByMemberId(memberId)).thenReturn(Optional.of(providerFamilySub));
         when(familySubscriptionRepository.findBySubId(targetSubId)).thenReturn(Optional.of(targetFamilySub));
 
@@ -182,21 +183,7 @@ class SendPresentDataServiceImplTest {
     @DisplayName("데이터 선물 요청량이 5GB 초과일 때 예외 발생")
     void sendPresentDataInvalidAmountTooLarge() {
         // given
-        SendPresentDataRequest request = new SendPresentDataRequest(targetSubId, oneGb * 6);
-        when(familySubscriptionRepository.findByMemberId(memberId)).thenReturn(Optional.of(providerFamilySub));
-        when(familySubscriptionRepository.findBySubId(targetSubId)).thenReturn(Optional.of(targetFamilySub));
-
-        // when & then
-        assertThatThrownBy(() -> sendPresentDataService.sendPresentData(memberId, request))
-                .isInstanceOf(ApplicationException.class)
-                .hasFieldOrPropertyWithValue("code", PresentDataErrorCode.PRESENT_DATA_INVALID_AMOUNT);
-    }
-
-    @Test
-    @DisplayName("데이터 선물 요청량이 1GB 단위가 아닐 때 예외 발생")
-    void sendPresentDataInvalidAmountNotStep() {
-        // given
-        SendPresentDataRequest request = new SendPresentDataRequest(targetSubId, oneGb + 100L);
+        SendPresentDataRequest request = new SendPresentDataRequest(targetSubId, 6L);
         when(familySubscriptionRepository.findByMemberId(memberId)).thenReturn(Optional.of(providerFamilySub));
         when(familySubscriptionRepository.findBySubId(targetSubId)).thenReturn(Optional.of(targetFamilySub));
 


### PR DESCRIPTION
## 🎫 지라 티켓

<!-- 지라 티켓을 작성해주세요 ex) HOTSPOT-123 -->
HOTSPOT-179

---

## 🔗 GitHub 이슈
<!-- 자동 close를 원하면 아래 형식으로 작성
예) Closes #12
-->
Closes #83 

---


## ✅ 작업 사항

<!-- 작업한 부분을 설명해주세요. -->

데이터 선물하기 API 구현

---

  1. Service Layer `SendPresentDataServiceImpl`
   * 데이터 선물하기 로직 개발 및 에러 코드 분리
   * 로직 설명:
       * 단위 변환: 모든 데이터 계산을 KB 단위(1GB = 1,048,576 KB)로 처리하도록 변경
       * 자가 선물 제한: 보내는 이와 받는 이의 회선 ID를 비교하여 동일인일 경우 PRESENT_DATA_SELF_GIFT 예외를 발생
       * 금액 유효성 검증: 선물 금액이 1GB~5GB 범위 내에 있는지, 그리고 1GB 단위로 떨어지는지 검증
       * 에러 코드 분리: 선물하기 전용 에러 코드`PresentDataErrorCode` 추가

<br/>

  2. Repository & Entity Layer
   * JPA 저장 에러 해결 및 엔티티 구조 개선
   * 로직 설명:
       * ID 생성 전략 추가: `PresentDataEntity`에 @GeneratedValue(strategy = GenerationType.IDENTITY)를 적용

---

## 📋 체크리스트

<!-- PR 제출 전 확인해주세요. 해당 항목에 [x]로 체크해주세요. -->

- [x] 코드가 정상적으로 빌드됩니다.
- [x] 관련 테스트 코드를 작성했습니다.
- [x] 기존 테스트가 모두 통과합니다.
- [x] 코드 스타일(Spotless, Checkstyle)을 준수합니다.
- [x] Jira 티켓 상태를 In Review / Done으로 변경했습니다.

---

## ⌨ 기타
