### PR TITLE
[HOTSPOT-180] 구성원별 데이터 한도 조회 및 즉시 차단 여부 조회 API 구현

### DIFF
--- a/src/main/java/hotspot/user/family/controller/FamilySubscriptionController.java
+++ b/src/main/java/hotspot/user/family/controller/FamilySubscriptionController.java
@@ -4,6 +4,7 @@ import jakarta.validation.Valid;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -12,12 +13,14 @@ import org.springframework.web.bind.annotation.RestController;
 
 import hotspot.user.common.ApiResponse;
 import hotspot.user.common.security.PrincipalDetails;
+import hotspot.user.family.controller.port.FindDataLimitService;
 import hotspot.user.family.controller.port.UpdateDataLimitService;
 import hotspot.user.family.controller.port.UpdateFamilyPriorityService;
 import hotspot.user.family.controller.port.UpdateFamilyRoleService;
 import hotspot.user.family.controller.request.UpdateDataLimitRequest;
 import hotspot.user.family.controller.request.UpdateFamilyPriorityRequest;
 import hotspot.user.family.controller.request.UpdateFamilyRoleRequest;
+import hotspot.user.family.controller.response.FindDataLimitResponse;
 import hotspot.user.family.controller.response.UpdateDataLimitResponse;
 import hotspot.user.family.controller.response.UpdateFamilyPriorityResponse;
 import hotspot.user.family.controller.response.UpdateFamilyRoleResponse;
@@ -35,6 +38,7 @@ public class FamilySubscriptionController implements FamilySubscriptionApi {
     private final UpdateDataLimitService updateDataLimitService;
     private final UpdateFamilyPriorityService updateFamilyPriorityService;
     private final UpdateFamilyRoleService updateFamilyRoleService; // 가족 역할 업데이트 서비스
+    private final FindDataLimitService findDataLimitService; // 가족 데이터 한도 조회 서비스
 
     // 구성원의 가족 공유 데이터 한도 조정
     @Override
@@ -50,6 +54,22 @@ public class FamilySubscriptionController implements FamilySubscriptionApi {
         );
         return ResponseEntity.ok(ApiResponse.success(response));
     }
+
+    // 구성원 데이터 한도 및 즉시 차단 여부 조회 서비스
+    @GetMapping("/data-limit/{subId}")
+    public ResponseEntity<ApiResponse<FindDataLimitResponse>> findDataLimit(
+            @PathVariable Long subId,
+            @AuthenticationPrincipal PrincipalDetails principal) {
+
+        FindDataLimitResponse response = findDataLimitService.findDataLimit(
+                subId,
+                principal.getFamilyId(),
+                principal.getRole()
+        );
+
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
 
     // 가족 우선순위 정책 및 구성원 순위 업데이트
     @Override

--- a/src/main/java/hotspot/user/family/controller/port/FindDataLimitService.java
+++ b/src/main/java/hotspot/user/family/controller/port/FindDataLimitService.java
@@ -1,0 +1,13 @@
+package hotspot.user.family.controller.port;
+
+import hotspot.user.family.controller.response.FindDataLimitResponse;
+import hotspot.user.member.domain.FamilyRole;
+
+/**
+ * 특정 구성원의 데이터 한도 업데이트
+ */
+public interface FindDataLimitService {
+    FindDataLimitResponse findDataLimit(Long targetSubId,
+                                          Long requesterFamilyId,
+                                          FamilyRole requesterRole);
+}

--- a/src/main/java/hotspot/user/family/controller/port/FindDataLimitService.java
+++ b/src/main/java/hotspot/user/family/controller/port/FindDataLimitService.java
@@ -4,7 +4,7 @@ import hotspot.user.family.controller.response.FindDataLimitResponse;
 import hotspot.user.member.domain.FamilyRole;
 
 /**
- * 특정 구성원의 데이터 한도 업데이트
+ * 특정 구성원의 데이터 한도 조회 서비스
  */
 public interface FindDataLimitService {
     FindDataLimitResponse findDataLimit(Long targetSubId,

--- a/src/main/java/hotspot/user/family/controller/response/FindDataLimitResponse.java
+++ b/src/main/java/hotspot/user/family/controller/response/FindDataLimitResponse.java
@@ -3,7 +3,7 @@ package hotspot.user.family.controller.response;
 import lombok.Builder;
 
 /**
- * 구성원 데이터 한도 업데이트 response dto
+ * 구성원 데이터 한도 조회 response dto
  * @param name
  * @param isLocked
  * @param dataLimit

--- a/src/main/java/hotspot/user/family/controller/response/FindDataLimitResponse.java
+++ b/src/main/java/hotspot/user/family/controller/response/FindDataLimitResponse.java
@@ -1,0 +1,20 @@
+package hotspot.user.family.controller.response;
+
+import lombok.Builder;
+
+/**
+ * 구성원 데이터 한도 업데이트 response dto
+ * @param name
+ * @param isLocked
+ * @param dataLimit
+ * @param familyDataAmount
+ */
+@Builder
+public record FindDataLimitResponse(
+        String name,
+        boolean isLocked,
+        double dataLimit,
+        double familyDataAmount
+
+) {
+}

--- a/src/main/java/hotspot/user/family/controller/swagger/FamilySubscriptionApi.java
+++ b/src/main/java/hotspot/user/family/controller/swagger/FamilySubscriptionApi.java
@@ -13,6 +13,7 @@ import hotspot.user.common.security.PrincipalDetails;
 import hotspot.user.family.controller.request.UpdateDataLimitRequest;
 import hotspot.user.family.controller.request.UpdateFamilyPriorityRequest;
 import hotspot.user.family.controller.request.UpdateFamilyRoleRequest;
+import hotspot.user.family.controller.response.FindDataLimitResponse;
 import hotspot.user.family.controller.response.UpdateDataLimitResponse;
 import hotspot.user.family.controller.response.UpdateFamilyPriorityResponse;
 import hotspot.user.family.controller.response.UpdateFamilyRoleResponse;
@@ -87,5 +88,25 @@ public interface FamilySubscriptionApi {
     ResponseEntity<ApiResponse<UpdateFamilyRoleResponse>> updateFamilyRole(
             @Parameter(description = "대상 회선 ID", example = "10") @PathVariable Long subId,
             @Valid @RequestBody UpdateFamilyRoleRequest request,
+            @Parameter(hidden = true) @AuthenticationPrincipal PrincipalDetails principal);
+
+    @Operation(summary = "구성원 데이터 한도 정보 조회",
+               description = "가족 OWNER가 특정 구성원의 데이터 한도 정보 및 차단 상태를 조회합니다.")
+    @ApiResponses(value = {
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 실패\n"
+                                         + "- AUTH_002: 유효하지 않은 토큰\n"
+                                         + "- AUTH_006: 토큰 만료",
+                     content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "권한 없음\n"
+                                         + "- FAMILY_010: 가족 관리자(OWNER)만 조회 가능합니다.\n"
+                                         + "- FAMILY_003: 동일 가족 구성원이 아닙니다.",
+                     content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "찾을 수 없음\n"
+                                         + "- FAMILY_002: 가족에 가입된 회선 정보를 찾을 수 없습니다.",
+                     content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    ResponseEntity<ApiResponse<FindDataLimitResponse>> findDataLimit(
+            @Parameter(description = "대상 회선 ID", example = "10") @PathVariable Long subId,
             @Parameter(hidden = true) @AuthenticationPrincipal PrincipalDetails principal);
 }

--- a/src/main/java/hotspot/user/family/domain/FamilySubDataLimit.java
+++ b/src/main/java/hotspot/user/family/domain/FamilySubDataLimit.java
@@ -1,0 +1,18 @@
+package hotspot.user.family.domain;
+
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 가족 구성원의 공유 데이터 한도 및 즉시 차단 여부 도메인
+ */
+@Getter
+@Builder
+public class FamilySubDataLimit {
+    String name;
+    Boolean isLocked;
+    Long dataLimit;
+    Long familyDataAmount;
+
+
+}

--- a/src/main/java/hotspot/user/family/domain/FamilySubDataLimit.java
+++ b/src/main/java/hotspot/user/family/domain/FamilySubDataLimit.java
@@ -9,6 +9,7 @@ import lombok.Getter;
 @Getter
 @Builder
 public class FamilySubDataLimit {
+    Long familyId;
     String name;
     Boolean isLocked;
     Long dataLimit;

--- a/src/main/java/hotspot/user/family/domain/FamilySubscription.java
+++ b/src/main/java/hotspot/user/family/domain/FamilySubscription.java
@@ -23,6 +23,15 @@ public class FamilySubscription {
     private int priority;
     private int dataLimit;
 
+    /**
+     * 같은 가족 구성원인지 검증
+     */
+    public void validateSameFamily(FamilySubscription target) {
+        if (!this.family.getId().equals(target.getFamily().getId())) {
+            throw new ApplicationException(FamilyErrorCode.NOT_FAMILY_MEMBER);
+        }
+    }
+
     // 데이터 한도 업데이트
     public void updateDataLimit(int dataLimit) {
         if (dataLimit < FamilyConstant.UNLIMITED_DATA_LIMIT) {

--- a/src/main/java/hotspot/user/family/domain/mapper/FamilySubDataLimitMapper.java
+++ b/src/main/java/hotspot/user/family/domain/mapper/FamilySubDataLimitMapper.java
@@ -5,7 +5,7 @@ import hotspot.user.family.controller.response.FindDataLimitResponse;
 import hotspot.user.family.domain.FamilySubDataLimit;
 
 /**
- * 구성원 데이터 한도 도메인 <-> dto 변</->
+ * 구성원 데이터 한도 도메인 <-> dto
  */
 public class FamilySubDataLimitMapper {
 

--- a/src/main/java/hotspot/user/family/domain/mapper/FamilySubDataLimitMapper.java
+++ b/src/main/java/hotspot/user/family/domain/mapper/FamilySubDataLimitMapper.java
@@ -1,0 +1,21 @@
+package hotspot.user.family.domain.mapper;
+
+import hotspot.user.common.util.redis.RedisUsageCalculator;
+import hotspot.user.family.controller.response.FindDataLimitResponse;
+import hotspot.user.family.domain.FamilySubDataLimit;
+
+/**
+ * 구성원 데이터 한도 도메인 <-> dto 변</->
+ */
+public class FamilySubDataLimitMapper {
+
+    public static FindDataLimitResponse toFindDataLimitResponse(FamilySubDataLimit familySubDataLimit) {
+        return FindDataLimitResponse.builder()
+                .name(familySubDataLimit.getName())
+                .isLocked(familySubDataLimit.getIsLocked())
+                .dataLimit(RedisUsageCalculator.kbToGb(familySubDataLimit.getDataLimit()))
+                .familyDataAmount(RedisUsageCalculator.kbToGb(familySubDataLimit.getFamilyDataAmount()))
+                .build();
+
+    }
+}

--- a/src/main/java/hotspot/user/family/infrastructure/FamilySubscriptionJpaRepository.java
+++ b/src/main/java/hotspot/user/family/infrastructure/FamilySubscriptionJpaRepository.java
@@ -29,4 +29,29 @@ public interface FamilySubscriptionJpaRepository extends JpaRepository<FamilySub
     @Modifying(clearAutomatically = true)
     @Query("UPDATE FamilySubscriptionEntity fs SET fs.priority = :priority WHERE fs.subscription.subId = :subId")
     void updatePriority(@Param("subId") Long subId, @Param("priority") int priority);
+
+    @Query("""
+             SELECT
+                 m.name as name,
+                 s.isLocked as isLocked,
+                 fs.dataLimit as dataLimit,
+                 f.familyDataAmount as familyDataAmount
+             FROM FamilySubscriptionEntity fs
+             JOIN fs.subscription s
+             JOIN s.member m
+            JOIN fs.family f
+            WHERE s.subId = :subId
+        """)
+    Optional<FamilySubDataLimitRow> findDataLimitBySubId(@Param("subId") Long subId);
+
+    /**
+     * 조회 전용 Projection 인터페이스
+     */
+    interface FamilySubDataLimitRow {
+        String getName();
+        Boolean getIsLocked();
+        Long getDataLimit();
+        Long getFamilyDataAmount();
+    }
+
 }

--- a/src/main/java/hotspot/user/family/infrastructure/FamilySubscriptionJpaRepository.java
+++ b/src/main/java/hotspot/user/family/infrastructure/FamilySubscriptionJpaRepository.java
@@ -32,6 +32,7 @@ public interface FamilySubscriptionJpaRepository extends JpaRepository<FamilySub
 
     @Query("""
              SELECT
+                 f.familyId as familyId,
                  m.name as name,
                  s.isLocked as isLocked,
                  fs.dataLimit as dataLimit,

--- a/src/main/java/hotspot/user/family/infrastructure/FamilySubscriptionJpaRepository.java
+++ b/src/main/java/hotspot/user/family/infrastructure/FamilySubscriptionJpaRepository.java
@@ -48,6 +48,7 @@ public interface FamilySubscriptionJpaRepository extends JpaRepository<FamilySub
      * 조회 전용 Projection 인터페이스
      */
     interface FamilySubDataLimitRow {
+        Long getFamilyId();
         String getName();
         Boolean getIsLocked();
         Long getDataLimit();

--- a/src/main/java/hotspot/user/family/infrastructure/FamilySubscriptionRepositoryImpl.java
+++ b/src/main/java/hotspot/user/family/infrastructure/FamilySubscriptionRepositoryImpl.java
@@ -5,6 +5,9 @@ import java.util.Optional;
 
 import org.springframework.stereotype.Repository;
 
+import hotspot.user.common.exception.ApplicationException;
+import hotspot.user.common.exception.code.FamilyErrorCode;
+import hotspot.user.family.domain.FamilySubDataLimit;
 import hotspot.user.family.domain.FamilySubscription;
 import hotspot.user.family.infrastructure.entity.FamilySubscriptionEntity;
 import hotspot.user.family.service.port.FamilySubscriptionRepository;
@@ -47,5 +50,18 @@ public class FamilySubscriptionRepositoryImpl implements FamilySubscriptionRepos
         for (FamilySubscription sub : subscriptions) {
             jpaRepository.updatePriority(sub.getSubscription().getId(), sub.getPriority());
         }
+    }
+
+    // 구성원별 데이터 한도 조회
+    @Override
+    public FamilySubDataLimit findDataLimitBySubId(Long subId) {
+        return jpaRepository.findDataLimitBySubId(subId)
+                .map(row -> FamilySubDataLimit.builder()
+                        .name(row.getName())
+                        .isLocked(row.getIsLocked())
+                        .dataLimit(row.getDataLimit())
+                        .familyDataAmount(row.getFamilyDataAmount())
+                        .build())
+                .orElseThrow(() -> new ApplicationException(FamilyErrorCode.FAMILY_SUBSCRIPTION_NOT_FOUND));
     }
 }

--- a/src/main/java/hotspot/user/family/infrastructure/FamilySubscriptionRepositoryImpl.java
+++ b/src/main/java/hotspot/user/family/infrastructure/FamilySubscriptionRepositoryImpl.java
@@ -57,6 +57,7 @@ public class FamilySubscriptionRepositoryImpl implements FamilySubscriptionRepos
     public FamilySubDataLimit findDataLimitBySubId(Long subId) {
         return jpaRepository.findDataLimitBySubId(subId)
                 .map(row -> FamilySubDataLimit.builder()
+                        .familyId(row.getFamilyId())
                         .name(row.getName())
                         .isLocked(row.getIsLocked())
                         .dataLimit(row.getDataLimit())

--- a/src/main/java/hotspot/user/family/service/FindDataLimitServiceImpl.java
+++ b/src/main/java/hotspot/user/family/service/FindDataLimitServiceImpl.java
@@ -1,0 +1,49 @@
+package hotspot.user.family.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import hotspot.user.common.exception.ApplicationException;
+import hotspot.user.common.exception.code.FamilyErrorCode;
+import hotspot.user.family.controller.port.FindDataLimitService;
+import hotspot.user.family.controller.port.FindFamilySubscriptionService;
+import hotspot.user.family.controller.response.FindDataLimitResponse;
+import hotspot.user.family.domain.FamilySubDataLimit;
+import hotspot.user.family.domain.FamilySubscription;
+import hotspot.user.family.domain.mapper.FamilySubDataLimitMapper;
+import hotspot.user.family.service.port.FamilySubscriptionRepository;
+import hotspot.user.member.domain.FamilyRole;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class FindDataLimitServiceImpl implements FindDataLimitService {
+    private final FamilySubscriptionRepository familySubscriptionRepository;
+    private final FindFamilySubscriptionService familySubscriptionService;
+
+    @Override
+    public FindDataLimitResponse findDataLimit(
+            Long targetSubId,
+            Long requesterFamilyId,
+            FamilyRole requesterRole) {
+
+        // OWNER인지 확인
+        if (requesterRole != FamilyRole.OWNER) {
+            throw new ApplicationException(FamilyErrorCode.ONLY_OWNER_CAN_MANAGE);
+        }
+
+        // 대상자 가족 정보 조회
+        FamilySubscription targetFamilySub = familySubscriptionService.findBySubId(targetSubId);
+
+        // 같은 가족 구성원인지 확인
+        if (!requesterFamilyId.equals(targetFamilySub.getFamily().getId())) {
+            throw new ApplicationException(FamilyErrorCode.NOT_FAMILY_MEMBER);
+        }
+
+        // 최적화된 쿼리로 한도 정보 조회
+        FamilySubDataLimit familySubDataLimit = familySubscriptionRepository.findDataLimitBySubId(targetSubId);
+
+        return FamilySubDataLimitMapper.toFindDataLimitResponse(familySubDataLimit);
+    }
+}

--- a/src/main/java/hotspot/user/family/service/FindDataLimitServiceImpl.java
+++ b/src/main/java/hotspot/user/family/service/FindDataLimitServiceImpl.java
@@ -34,15 +34,12 @@ public class FindDataLimitServiceImpl implements FindDataLimitService {
         }
 
         // 대상자 가족 정보 조회
-        FamilySubscription targetFamilySub = familySubscriptionService.findBySubId(targetSubId);
+        FamilySubDataLimit familySubDataLimit = familySubscriptionRepository.findDataLimitBySubId(targetSubId);
 
         // 같은 가족 구성원인지 확인
-        if (!requesterFamilyId.equals(targetFamilySub.getFamily().getId())) {
+        if (!requesterFamilyId.equals(familySubDataLimit.getFamilyId())) {
             throw new ApplicationException(FamilyErrorCode.NOT_FAMILY_MEMBER);
         }
-
-        // 최적화된 쿼리로 한도 정보 조회
-        FamilySubDataLimit familySubDataLimit = familySubscriptionRepository.findDataLimitBySubId(targetSubId);
 
         return FamilySubDataLimitMapper.toFindDataLimitResponse(familySubDataLimit);
     }

--- a/src/main/java/hotspot/user/family/service/FindDataLimitServiceImpl.java
+++ b/src/main/java/hotspot/user/family/service/FindDataLimitServiceImpl.java
@@ -6,10 +6,8 @@ import org.springframework.transaction.annotation.Transactional;
 import hotspot.user.common.exception.ApplicationException;
 import hotspot.user.common.exception.code.FamilyErrorCode;
 import hotspot.user.family.controller.port.FindDataLimitService;
-import hotspot.user.family.controller.port.FindFamilySubscriptionService;
 import hotspot.user.family.controller.response.FindDataLimitResponse;
 import hotspot.user.family.domain.FamilySubDataLimit;
-import hotspot.user.family.domain.FamilySubscription;
 import hotspot.user.family.domain.mapper.FamilySubDataLimitMapper;
 import hotspot.user.family.service.port.FamilySubscriptionRepository;
 import hotspot.user.member.domain.FamilyRole;
@@ -20,7 +18,6 @@ import lombok.RequiredArgsConstructor;
 @Transactional(readOnly = true)
 public class FindDataLimitServiceImpl implements FindDataLimitService {
     private final FamilySubscriptionRepository familySubscriptionRepository;
-    private final FindFamilySubscriptionService familySubscriptionService;
 
     @Override
     public FindDataLimitResponse findDataLimit(

--- a/src/main/java/hotspot/user/family/service/port/FamilySubscriptionRepository.java
+++ b/src/main/java/hotspot/user/family/service/port/FamilySubscriptionRepository.java
@@ -3,6 +3,7 @@ package hotspot.user.family.service.port;
 import java.util.List;
 import java.util.Optional;
 
+import hotspot.user.family.domain.FamilySubDataLimit;
 import hotspot.user.family.domain.FamilySubscription;
 
 /**
@@ -14,4 +15,5 @@ public interface FamilySubscriptionRepository {
     Optional<FamilySubscription> findByMemberId(Long memberId);
     FamilySubscription save(FamilySubscription familySubscription);
     void updatePriorities(List<FamilySubscription> subscriptions);
+    FamilySubDataLimit findDataLimitBySubId(Long subId); // subId로 데이터 한도 관련 정보 찾기
 }

--- a/src/test/java/hotspot/user/family/controller/FamilySubscriptionControllerTest.java
+++ b/src/test/java/hotspot/user/family/controller/FamilySubscriptionControllerTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -28,6 +29,7 @@ import hotspot.user.common.exception.code.AuthErrorCode;
 import hotspot.user.common.exception.code.FamilyErrorCode;
 import hotspot.user.common.security.jwt.JwtFilter;
 import hotspot.user.common.security.jwt.JwtProvider;
+import hotspot.user.family.controller.port.FindDataLimitService;
 import hotspot.user.family.controller.port.UpdateDataLimitService;
 import hotspot.user.family.controller.port.UpdateFamilyPriorityService;
 import hotspot.user.family.controller.port.UpdateFamilyRoleService;
@@ -35,6 +37,7 @@ import hotspot.user.family.controller.request.MemberPriorityRequest;
 import hotspot.user.family.controller.request.UpdateDataLimitRequest;
 import hotspot.user.family.controller.request.UpdateFamilyPriorityRequest;
 import hotspot.user.family.controller.request.UpdateFamilyRoleRequest;
+import hotspot.user.family.controller.response.FindDataLimitResponse;
 import hotspot.user.family.controller.response.MemberPriorityResponse;
 import hotspot.user.family.controller.response.UpdateDataLimitResponse;
 import hotspot.user.family.controller.response.UpdateFamilyPriorityResponse;
@@ -64,6 +67,9 @@ class FamilySubscriptionControllerTest {
 
     @MockBean
     private UpdateFamilyRoleService updateFamilyRoleService;
+
+    @MockBean
+    private FindDataLimitService findDataLimitService;
 
     @MockBean
     private FamilySubscriptionRepository familySubscriptionRepository;
@@ -274,5 +280,28 @@ class FamilySubscriptionControllerTest {
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.code").value("FAMILY_017"));
+    }
+
+    @Test
+    @DisplayName("성공: OWNER 권한으로 구성원의 데이터 한도 정보를 조회하면 200 OK를 반환한다")
+    void findDataLimitSuccess() throws Exception {
+        // given
+        setAuthentication(1L, 100L, FamilyRole.OWNER);
+        FindDataLimitResponse response = FindDataLimitResponse.builder()
+                .name("김태연")
+                .isLocked(false)
+                .dataLimit(5.0)
+                .familyDataAmount(24.0)
+                .build();
+
+        given(findDataLimitService.findDataLimit(eq(2L), eq(100L), eq(FamilyRole.OWNER)))
+                .willReturn(response);
+
+        // when & then
+        mockMvc.perform(get("/api/v1/families/data-limit/2"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("200"))
+                .andExpect(jsonPath("$.data.name").value("김태연"))
+                .andExpect(jsonPath("$.data.dataLimit").value(5.0));
     }
 }

--- a/src/test/java/hotspot/user/family/domain/FamilySubscriptionTest.java
+++ b/src/test/java/hotspot/user/family/domain/FamilySubscriptionTest.java
@@ -1,10 +1,13 @@
 package hotspot.user.family.domain;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import hotspot.user.common.exception.ApplicationException;
+import hotspot.user.common.exception.code.FamilyErrorCode;
 import hotspot.user.member.domain.FamilyRole;
 import hotspot.user.subscription.domain.Subscription;
 
@@ -27,6 +30,89 @@ class FamilySubscriptionTest {
 
         // then
         assertThat(familySubscription.getDataLimit()).isEqualTo(500);
+    }
+
+    @Test
+    @DisplayName("데이터 한도가 -1 미만인 경우 예외가 발생한다")
+    void updateDataLimitFail() {
+        // given
+        FamilySubscription familySubscription = FamilySubscription.builder()
+                .id(1L)
+                .dataLimit(100)
+                .build();
+
+        // when & then
+        assertThatThrownBy(() -> familySubscription.updateDataLimit(-2))
+                .isInstanceOf(ApplicationException.class)
+                .hasFieldOrPropertyWithValue("code", FamilyErrorCode.INVALID_DATA_LIMIT);
+    }
+
+    @Test
+    @DisplayName("우선순위를 업데이트할 수 있다")
+    void updatePriority() {
+        // given
+        FamilySubscription familySubscription = FamilySubscription.builder()
+                .id(1L)
+                .priority(1)
+                .build();
+
+        // when
+        familySubscription.updatePriority(5);
+
+        // then
+        assertThat(familySubscription.getPriority()).isEqualTo(5);
+    }
+
+    @Test
+    @DisplayName("가족 내 역할을 업데이트할 수 있다")
+    void updateFamilyRole() {
+        // given
+        FamilySubscription familySubscription = FamilySubscription.builder()
+                .id(1L)
+                .familyRole(FamilyRole.CHILD)
+                .build();
+
+        // when
+        familySubscription.updateFamilyRole(FamilyRole.PARENT);
+
+        // then
+        assertThat(familySubscription.getFamilyRole()).isEqualTo(FamilyRole.PARENT);
+    }
+
+    @Test
+    @DisplayName("같은 가족 구성원인지 검증에 성공한다")
+    void validateSameFamilySuccess() {
+        // given
+        Family family = Family.builder().id(10L).build();
+        FamilySubscription provider = FamilySubscription.builder()
+                .family(family)
+                .build();
+        FamilySubscription target = FamilySubscription.builder()
+                .family(family)
+                .build();
+
+        // when & then
+        provider.validateSameFamily(target);
+    }
+
+    @Test
+    @DisplayName("다른 가족 구성원인 경우 검증 시 예외가 발생한다")
+    void validateSameFamilyFail() {
+        // given
+        Family family1 = Family.builder().id(10L).build();
+        Family family2 = Family.builder().id(20L).build();
+
+        FamilySubscription provider = FamilySubscription.builder()
+                .family(family1)
+                .build();
+        FamilySubscription target = FamilySubscription.builder()
+                .family(family2)
+                .build();
+
+        // when & then
+        assertThatThrownBy(() -> provider.validateSameFamily(target))
+                .isInstanceOf(ApplicationException.class)
+                .hasFieldOrPropertyWithValue("code", FamilyErrorCode.NOT_FAMILY_MEMBER);
     }
 
     @Test

--- a/src/test/java/hotspot/user/family/infrastructure/FamilySubscriptionRepositoryImplTest.java
+++ b/src/test/java/hotspot/user/family/infrastructure/FamilySubscriptionRepositoryImplTest.java
@@ -1,7 +1,9 @@
 package hotspot.user.family.infrastructure;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 
 import java.util.List;
 import java.util.Optional;
@@ -13,8 +15,12 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import hotspot.user.common.exception.ApplicationException;
+import hotspot.user.common.exception.code.FamilyErrorCode;
 import hotspot.user.family.domain.Family;
+import hotspot.user.family.domain.FamilySubDataLimit;
 import hotspot.user.family.domain.FamilySubscription;
+import hotspot.user.family.infrastructure.FamilySubscriptionJpaRepository.FamilySubDataLimitRow;
 import hotspot.user.family.infrastructure.entity.FamilyEntity;
 import hotspot.user.family.infrastructure.entity.FamilySubscriptionEntity;
 import hotspot.user.member.domain.FamilyRole;
@@ -189,5 +195,41 @@ class FamilySubscriptionRepositoryImplTest {
                 .updatePriority(100L, 1);
         org.mockito.Mockito.verify(familySubscriptionJpaRepository, org.mockito.Mockito.times(1))
                 .updatePriority(101L, 2);
+    }
+
+    @Test
+    @DisplayName("회선 ID로 구성원별 데이터 한도 조회 성공")
+    void findDataLimitBySubIdSuccess() {
+        // given
+        Long subId = 100L;
+        FamilySubDataLimitRow row = mock(FamilySubDataLimitRow.class);
+        given(row.getName()).willReturn("김태연");
+        given(row.getIsLocked()).willReturn(false);
+        given(row.getDataLimit()).willReturn(5242880L);
+        given(row.getFamilyDataAmount()).willReturn(25165824L);
+
+        given(familySubscriptionJpaRepository.findDataLimitBySubId(subId)).willReturn(Optional.of(row));
+
+        // when
+        FamilySubDataLimit result = familySubscriptionRepository.findDataLimitBySubId(subId);
+
+        // then
+        assertThat(result.getName()).isEqualTo("김태연");
+        assertThat(result.getIsLocked()).isFalse();
+        assertThat(result.getDataLimit()).isEqualTo(5242880L);
+        assertThat(result.getFamilyDataAmount()).isEqualTo(25165824L);
+    }
+
+    @Test
+    @DisplayName("회선 ID로 데이터 한도 조회 시 정보가 없으면 예외 발생")
+    void findDataLimitBySubIdNotFound() {
+        // given
+        Long subId = 999L;
+        given(familySubscriptionJpaRepository.findDataLimitBySubId(subId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> familySubscriptionRepository.findDataLimitBySubId(subId))
+                .isInstanceOf(ApplicationException.class)
+                .hasFieldOrPropertyWithValue("code", FamilyErrorCode.FAMILY_SUBSCRIPTION_NOT_FOUND);
     }
 }

--- a/src/test/java/hotspot/user/family/infrastructure/FamilySubscriptionRepositoryImplTest.java
+++ b/src/test/java/hotspot/user/family/infrastructure/FamilySubscriptionRepositoryImplTest.java
@@ -203,6 +203,7 @@ class FamilySubscriptionRepositoryImplTest {
         // given
         Long subId = 100L;
         FamilySubDataLimitRow row = mock(FamilySubDataLimitRow.class);
+        given(row.getFamilyId()).willReturn(1L);
         given(row.getName()).willReturn("김태연");
         given(row.getIsLocked()).willReturn(false);
         given(row.getDataLimit()).willReturn(5242880L);
@@ -214,6 +215,7 @@ class FamilySubscriptionRepositoryImplTest {
         FamilySubDataLimit result = familySubscriptionRepository.findDataLimitBySubId(subId);
 
         // then
+        assertThat(result.getFamilyId()).isEqualTo(1L);
         assertThat(result.getName()).isEqualTo("김태연");
         assertThat(result.getIsLocked()).isFalse();
         assertThat(result.getDataLimit()).isEqualTo(5242880L);

--- a/src/test/java/hotspot/user/family/service/FindDataLimitServiceImplTest.java
+++ b/src/test/java/hotspot/user/family/service/FindDataLimitServiceImplTest.java
@@ -3,7 +3,6 @@ package hotspot.user.family.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.mock;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/hotspot/user/family/service/FindDataLimitServiceImplTest.java
+++ b/src/test/java/hotspot/user/family/service/FindDataLimitServiceImplTest.java
@@ -1,0 +1,107 @@
+package hotspot.user.family.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import hotspot.user.common.exception.ApplicationException;
+import hotspot.user.common.exception.code.FamilyErrorCode;
+import hotspot.user.family.controller.port.FindFamilySubscriptionService;
+import hotspot.user.family.controller.response.FindDataLimitResponse;
+import hotspot.user.family.domain.Family;
+import hotspot.user.family.domain.FamilySubDataLimit;
+import hotspot.user.family.domain.FamilySubscription;
+import hotspot.user.family.service.port.FamilySubscriptionRepository;
+import hotspot.user.member.domain.FamilyRole;
+
+@ExtendWith(MockitoExtension.class)
+class FindDataLimitServiceImplTest {
+
+    @Mock
+    private FamilySubscriptionRepository familySubscriptionRepository;
+
+    @Mock
+    private FindFamilySubscriptionService familySubscriptionService;
+
+    @InjectMocks
+    private FindDataLimitServiceImpl findDataLimitService;
+
+    @Test
+    @DisplayName("성공: OWNER 권한으로 동일 가족 구성원의 데이터 한도를 조회한다")
+    void findDataLimitSuccess() {
+        // given
+        Long targetSubId = 2L;
+        Long familyId = 100L;
+        FamilyRole role = FamilyRole.OWNER;
+
+        Family family = Family.builder().id(familyId).build();
+        FamilySubscription targetFs = FamilySubscription.builder()
+                .family(family)
+                .build();
+
+        FamilySubDataLimit dataLimit = FamilySubDataLimit.builder()
+                .name("김태연")
+                .isLocked(false)
+                .dataLimit(1048576L * 5) // 5GB
+                .familyDataAmount(1048576L * 24) // 24GB
+                .build();
+
+        given(familySubscriptionService.findBySubId(targetSubId)).willReturn(targetFs);
+        given(familySubscriptionRepository.findDataLimitBySubId(targetSubId)).willReturn(dataLimit);
+
+        // when
+        FindDataLimitResponse response = findDataLimitService.findDataLimit(targetSubId, familyId, role);
+
+        // then
+        assertThat(response.name()).isEqualTo("김태연");
+        assertThat(response.isLocked()).isFalse();
+        assertThat(response.dataLimit()).isEqualTo(5.0);
+        assertThat(response.familyDataAmount()).isEqualTo(24.0);
+    }
+
+    @Test
+    @DisplayName("실패: OWNER 권한이 아닌 사용자가 조회하려 하면 예외가 발생한다")
+    void findDataLimitFailByRole() {
+        // given
+        Long targetSubId = 2L;
+        Long familyId = 100L;
+
+        // when & then
+        assertThatThrownBy(() -> findDataLimitService.findDataLimit(targetSubId, familyId, FamilyRole.CHILD))
+                .isInstanceOf(ApplicationException.class)
+                .hasFieldOrPropertyWithValue("code", FamilyErrorCode.ONLY_OWNER_CAN_MANAGE);
+
+        assertThatThrownBy(() -> findDataLimitService.findDataLimit(targetSubId, familyId, FamilyRole.PARENT))
+                .isInstanceOf(ApplicationException.class)
+                .hasFieldOrPropertyWithValue("code", FamilyErrorCode.ONLY_OWNER_CAN_MANAGE);
+    }
+
+    @Test
+    @DisplayName("실패: 다른 가족 구성원의 정보를 조회하려 하면 예외가 발생한다")
+    void findDataLimitFailByDifferentFamily() {
+        // given
+        Long targetSubId = 2L;
+        Long requesterFamilyId = 100L;
+        Long targetFamilyId = 200L;
+
+        Family otherFamily = Family.builder().id(targetFamilyId).build();
+        FamilySubscription targetFs = FamilySubscription.builder()
+                .family(otherFamily)
+                .build();
+
+        given(familySubscriptionService.findBySubId(targetSubId)).willReturn(targetFs);
+
+        // when & then
+        assertThatThrownBy(() -> findDataLimitService.findDataLimit(targetSubId, requesterFamilyId, FamilyRole.OWNER))
+                .isInstanceOf(ApplicationException.class)
+                .hasFieldOrPropertyWithValue("code", FamilyErrorCode.NOT_FAMILY_MEMBER);
+    }
+}

--- a/src/test/java/hotspot/user/family/service/FindDataLimitServiceImplTest.java
+++ b/src/test/java/hotspot/user/family/service/FindDataLimitServiceImplTest.java
@@ -13,7 +13,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import hotspot.user.common.exception.ApplicationException;
 import hotspot.user.common.exception.code.FamilyErrorCode;
-import hotspot.user.family.controller.port.FindFamilySubscriptionService;
 import hotspot.user.family.controller.response.FindDataLimitResponse;
 import hotspot.user.family.domain.Family;
 import hotspot.user.family.domain.FamilySubDataLimit;
@@ -26,9 +25,6 @@ class FindDataLimitServiceImplTest {
 
     @Mock
     private FamilySubscriptionRepository familySubscriptionRepository;
-
-    @Mock
-    private FindFamilySubscriptionService familySubscriptionService;
 
     @InjectMocks
     private FindDataLimitServiceImpl findDataLimitService;
@@ -47,13 +43,13 @@ class FindDataLimitServiceImplTest {
                 .build();
 
         FamilySubDataLimit dataLimit = FamilySubDataLimit.builder()
+                .familyId(familyId)
                 .name("김태연")
                 .isLocked(false)
                 .dataLimit(1048576L * 5) // 5GB
                 .familyDataAmount(1048576L * 24) // 24GB
                 .build();
 
-        given(familySubscriptionService.findBySubId(targetSubId)).willReturn(targetFs);
         given(familySubscriptionRepository.findDataLimitBySubId(targetSubId)).willReturn(dataLimit);
 
         // when
@@ -91,12 +87,15 @@ class FindDataLimitServiceImplTest {
         Long requesterFamilyId = 100L;
         Long targetFamilyId = 200L;
 
-        Family otherFamily = Family.builder().id(targetFamilyId).build();
-        FamilySubscription targetFs = FamilySubscription.builder()
-                .family(otherFamily)
+        FamilySubDataLimit dataLimit = FamilySubDataLimit.builder()
+                .familyId(targetFamilyId)
+                .name("김태연")
+                .isLocked(false)
+                .dataLimit(1048576L * 5)
+                .familyDataAmount(1048576L * 24)
                 .build();
 
-        given(familySubscriptionService.findBySubId(targetSubId)).willReturn(targetFs);
+        given(familySubscriptionRepository.findDataLimitBySubId(targetSubId)).willReturn(dataLimit);
 
         // when & then
         assertThatThrownBy(() -> findDataLimitService.findDataLimit(targetSubId, requesterFamilyId, FamilyRole.OWNER))


### PR DESCRIPTION
## 🎫 지라 티켓

<!-- 지라 티켓을 작성해주세요 ex) HOTSPOT-123 -->
HOTSPOT-180

---

## 🔗 GitHub 이슈
<!-- 자동 close를 원하면 아래 형식으로 작성
예) Closes #12
-->
Closes #89 

---


## ✅ 작업 사항

<!-- 작업한 부분을 설명해주세요. -->

가족 구성원의 데이터 공유 한도 및 차단 상태를 조회하는 기능 구현

---

  1. Controller & API 명세 (FamilySubscriptionApi)
   - 구성원 데이터 한도 정보 조회 API `GET /api/v1/families/data-limit/{subId}` 추가

<br/>


  2. Service Layer `FindDataLimitServiceImpl`
   - 인가 로직 강화: 가족 관리자(OWNER) 권한 여부를 서비스 진입점에서 최우선 검증
   - 비즈니스 검증: 조회 대상자가 요청자와 동일한 가족 그룹에 속해 있는지 확인하는 로직 구현

<br/>


  3. Repository Layer `FamilySubscriptionJpaRepository`
   - 3개 테이블(Member, Subscription, FamilySubscription) 조인이 필요한 조회를 단일 쿼리로 처리
   - JPA Projection 적용: 인프라 전용 인터페이스(FamilySubDataLimitRow)를 사용해 필요한 컬럼만 조회하여 N+1 문제 원천 차단
   - 매핑 책임 분리: DB 조회 결과(Row)를 도메인 모델(FamilySubDataLimit)로 변환하여 상위 계층에 전달

<br/>


  4. Domain & Entity Layer
   - 도메인 모델 신설: 조회 전용 모델인 FamilySubDataLimit (Read Model) 정의
   - 검증 로직 응집: FamilySubscription 도메인에 validateSameFamily 메서드를 추가하여 비즈니스 규칙을 도메인 내부로 캡슐화
   - 단위 변환: Mapper 계층에서 kbToGb 변환을 수행하여 도메인의 순수성과 API의 편의성 동시 확보

---

## 📋 체크리스트

<!-- PR 제출 전 확인해주세요. 해당 항목에 [x]로 체크해주세요. -->

- [x] 코드가 정상적으로 빌드됩니다.
- [x] 관련 테스트 코드를 작성했습니다.
- [x] 기존 테스트가 모두 통과합니다.
- [x] 코드 스타일(Spotless, Checkstyle)을 준수합니다.
- [x] Jira 티켓 상태를 In Review / Done으로 변경했습니다.

---

## ⌨ 기타
