### PR TITLE
[HOTSPOT-181] 구성원별 데이터 한도 및 즉시 차단 여부 업데이트 API 수정

### DIFF
--- a/src/main/java/hotspot/user/common/exception/code/FamilyErrorCode.java
+++ b/src/main/java/hotspot/user/common/exception/code/FamilyErrorCode.java
@@ -28,6 +28,7 @@ public enum FamilyErrorCode implements BaseErrorCode {
     DUPLICATE_FAMILY_APPLY(HttpStatus.CONFLICT, "FAMILY_015", "이미 처리 대기 중인 신청이 존재합니다."),
     CANNOT_CHANGE_OWNER_ROLE(HttpStatus.BAD_REQUEST, "FAMILY_016", "가족 관리자(OWNER) 본인의 역할은 변경할 수 없습니다."),
     CANNOT_ASSIGN_OWNER_ROLE(HttpStatus.BAD_REQUEST, "FAMILY_017", "타인에게 OWNER 역할을 부여할 수 없습니다."),
+    DATA_LIMIT_EXCEEDS_FAMILY_AMOUNT(HttpStatus.BAD_REQUEST, "FAMILY_018", "설정하려는 한도가 가족 전체 데이터 양을 초과합니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/hotspot/user/common/util/redis/RedisUsageCalculator.java
+++ b/src/main/java/hotspot/user/common/util/redis/RedisUsageCalculator.java
@@ -23,6 +23,14 @@ public final class RedisUsageCalculator {
                 .doubleValue();
     }
 
+    // GB -> KB 로직 추가
+    public static long gbToKb(double gb) {
+        if (gb < 0) {
+            return -1L;
+        }
+        return Math.round(gb * KB_TO_GB);
+    }
+
     public static double calculateRemain(double limitKb, double usedKb) {
         return Math.max(limitKb - usedKb, 0);
     }

--- a/src/main/java/hotspot/user/family/controller/request/UpdateDataLimitRequest.java
+++ b/src/main/java/hotspot/user/family/controller/request/UpdateDataLimitRequest.java
@@ -15,7 +15,7 @@ public record UpdateDataLimitRequest(
         Long familyId,
         Long subId,
         @Min(value = FamilyConstant.UNLIMITED_DATA_LIMIT, message = "데이터 한도는 -1(무한대) 이상이어야 합니다.")
-        double dataLimit,
+        long dataLimit,
         boolean isLocked // 데이터 차단 여부
 ) {
 }

--- a/src/main/java/hotspot/user/family/controller/request/UpdateDataLimitRequest.java
+++ b/src/main/java/hotspot/user/family/controller/request/UpdateDataLimitRequest.java
@@ -9,11 +9,13 @@ import hotspot.user.common.constant.FamilyConstant;
  * @param familyId
  * @param subId
  * @param dataLimit
+ * @param isLocked
  */
 public record UpdateDataLimitRequest(
         Long familyId,
         Long subId,
         @Min(value = FamilyConstant.UNLIMITED_DATA_LIMIT, message = "데이터 한도는 -1(무한대) 이상이어야 합니다.")
-        int dataLimit
+        double dataLimit,
+        boolean isLocked // 데이터 차단 여부
 ) {
 }

--- a/src/main/java/hotspot/user/family/controller/request/UpdateDataLimitRequest.java
+++ b/src/main/java/hotspot/user/family/controller/request/UpdateDataLimitRequest.java
@@ -15,7 +15,7 @@ public record UpdateDataLimitRequest(
         Long familyId,
         Long subId,
         @Min(value = FamilyConstant.UNLIMITED_DATA_LIMIT, message = "데이터 한도는 -1(무한대) 이상이어야 합니다.")
-        int dataLimit,
+        long dataLimit,
         boolean isLocked // 데이터 차단 여부
 ) {
 }

--- a/src/main/java/hotspot/user/family/controller/request/UpdateDataLimitRequest.java
+++ b/src/main/java/hotspot/user/family/controller/request/UpdateDataLimitRequest.java
@@ -15,7 +15,7 @@ public record UpdateDataLimitRequest(
         Long familyId,
         Long subId,
         @Min(value = FamilyConstant.UNLIMITED_DATA_LIMIT, message = "데이터 한도는 -1(무한대) 이상이어야 합니다.")
-        long dataLimit,
+        int dataLimit,
         boolean isLocked // 데이터 차단 여부
 ) {
 }

--- a/src/main/java/hotspot/user/family/controller/response/FamilyResponse.java
+++ b/src/main/java/hotspot/user/family/controller/response/FamilyResponse.java
@@ -1,5 +1,6 @@
 package hotspot.user.family.controller.response;
 
+import hotspot.user.common.util.redis.RedisUsageCalculator;
 import hotspot.user.family.domain.Family;
 import hotspot.user.family.domain.PriorityType;
 
@@ -9,14 +10,14 @@ import hotspot.user.family.domain.PriorityType;
 public record FamilyResponse(
         Long id,
         int familyNum,
-        int familyDataAmount,
+        double familyDataAmount,
         PriorityType priorityType
 ) {
     public static FamilyResponse from(Family family) {
         return new FamilyResponse(
                 family.getId(),
                 family.getFamilyNum(),
-                family.getFamilyDataAmount(),
+                RedisUsageCalculator.kbToGb(family.getFamilyDataAmount()),
                 family.getPriorityType()
         );
     }

--- a/src/main/java/hotspot/user/family/controller/response/FamilySubscriptionResponse.java
+++ b/src/main/java/hotspot/user/family/controller/response/FamilySubscriptionResponse.java
@@ -1,5 +1,6 @@
 package hotspot.user.family.controller.response;
 
+import hotspot.user.common.util.redis.RedisUsageCalculator;
 import hotspot.user.family.domain.FamilySubscription;
 import hotspot.user.member.domain.FamilyRole;
 
@@ -21,7 +22,7 @@ public record FamilySubscriptionResponse(
                 familySubscription.getFamily().getId(),
                 familySubscription.getFamilyRole(),
                 familySubscription.getPriority(),
-                familySubscription.getDataLimit()
+                RedisUsageCalculator.kbToGb(familySubscription.getDataLimit())
         );
     }
 }

--- a/src/main/java/hotspot/user/family/controller/response/FamilySubscriptionResponse.java
+++ b/src/main/java/hotspot/user/family/controller/response/FamilySubscriptionResponse.java
@@ -12,7 +12,7 @@ public record FamilySubscriptionResponse(
         Long familyId,
         FamilyRole role,
         int priority,
-        int dataLimit
+        double dataLimit
 ) {
     public static FamilySubscriptionResponse from(FamilySubscription familySubscription) {
         return new FamilySubscriptionResponse(

--- a/src/main/java/hotspot/user/family/controller/response/UpdateDataLimitResponse.java
+++ b/src/main/java/hotspot/user/family/controller/response/UpdateDataLimitResponse.java
@@ -13,7 +13,7 @@ import lombok.Builder;
 public record UpdateDataLimitResponse(
         Long familyId,
         Long subId,
-        long dataLimit,
+        double dataLimit,
         boolean isLocked
 ) {
 }

--- a/src/main/java/hotspot/user/family/controller/response/UpdateDataLimitResponse.java
+++ b/src/main/java/hotspot/user/family/controller/response/UpdateDataLimitResponse.java
@@ -13,7 +13,7 @@ import lombok.Builder;
 public record UpdateDataLimitResponse(
         Long familyId,
         Long subId,
-        int dataLimit,
+        long dataLimit,
         boolean isLocked
 ) {
 }

--- a/src/main/java/hotspot/user/family/controller/response/UpdateDataLimitResponse.java
+++ b/src/main/java/hotspot/user/family/controller/response/UpdateDataLimitResponse.java
@@ -13,7 +13,7 @@ import lombok.Builder;
 public record UpdateDataLimitResponse(
         Long familyId,
         Long subId,
-        long dataLimit,
+        int dataLimit,
         boolean isLocked
 ) {
 }

--- a/src/main/java/hotspot/user/family/controller/response/UpdateDataLimitResponse.java
+++ b/src/main/java/hotspot/user/family/controller/response/UpdateDataLimitResponse.java
@@ -7,11 +7,13 @@ import lombok.Builder;
  * @param familyId
  * @param subId
  * @param dataLimit
+ * @param isLocked
  */
 @Builder
 public record UpdateDataLimitResponse(
         Long familyId,
         Long subId,
-        int dataLimit
+        double dataLimit,
+        boolean isLocked
 ) {
 }

--- a/src/main/java/hotspot/user/family/controller/response/UpdateDataLimitResponse.java
+++ b/src/main/java/hotspot/user/family/controller/response/UpdateDataLimitResponse.java
@@ -13,7 +13,7 @@ import lombok.Builder;
 public record UpdateDataLimitResponse(
         Long familyId,
         Long subId,
-        double dataLimit,
+        long dataLimit,
         boolean isLocked
 ) {
 }

--- a/src/main/java/hotspot/user/family/controller/swagger/FamilySubscriptionApi.java
+++ b/src/main/java/hotspot/user/family/controller/swagger/FamilySubscriptionApi.java
@@ -34,14 +34,18 @@ public interface FamilySubscriptionApi {
         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "수정 성공"),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청\n"
                                          + "- COMMON_002: 입력값 유효성 검증 실패\n"
-                                         + "- FAMILY_004: 데이터 한도 범위 오류 (-1 미만)",
+                                         + "- FAMILY_004: 데이터 한도는 -1(무한대) 이상이어야 합니다.",
+                     content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 실패\n"
+                                         + "- AUTH_002: 유효하지 않은 토큰\n"
+                                         + "- AUTH_006: 토큰 만료",
                      content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "권한 없음\n"
-                                         + "- AUTH_004: OWNER 권한이 아님\n"
-                                         + "- FAMILY_003: 동일 가족 구성원이 아님",
+                                         + "- AUTH_004: 해당 요청에 대한 접근 권한이 없습니다. (OWNER 권한이 아님)\n"
+                                         + "- FAMILY_003: 해당 구성원은 동일한 가족 그룹에 속해 있지 않습니다.",
                      content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "찾을 수 없음\n"
-                                         + "- FAMILY_002: 해당 회선(Subscription)이 가족에 등록되어 있지 않음",
+                                         + "- FAMILY_002: 가족에 가입된 회선 정보를 찾을 수 없습니다.",
                      content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     ResponseEntity<ApiResponse<UpdateDataLimitResponse>> updateDataLimit(

--- a/src/main/java/hotspot/user/family/domain/Family.java
+++ b/src/main/java/hotspot/user/family/domain/Family.java
@@ -13,7 +13,7 @@ import lombok.Getter;
 public class Family {
     private Long id;
     private int familyNum;
-    private int familyDataAmount;
+    private long familyDataAmount;
     private PriorityType priorityType;
 
     // 우선순위 정책 타입 업데이트

--- a/src/main/java/hotspot/user/family/domain/FamilySubscription.java
+++ b/src/main/java/hotspot/user/family/domain/FamilySubscription.java
@@ -21,7 +21,7 @@ public class FamilySubscription {
     private Family family;
     private FamilyRole familyRole;
     private int priority;
-    private int dataLimit;
+    private long dataLimit;
 
     /**
      * 같은 가족 구성원인지 검증
@@ -33,7 +33,7 @@ public class FamilySubscription {
     }
 
     // 데이터 한도 업데이트
-    public void updateDataLimit(int dataLimit) {
+    public void updateDataLimit(long dataLimit) {
         if (dataLimit < FamilyConstant.UNLIMITED_DATA_LIMIT) {
             throw new ApplicationException(
                 FamilyErrorCode.INVALID_DATA_LIMIT

--- a/src/main/java/hotspot/user/family/domain/mapper/FamilySubscriptionMapper.java
+++ b/src/main/java/hotspot/user/family/domain/mapper/FamilySubscriptionMapper.java
@@ -1,7 +1,9 @@
 package hotspot.user.family.domain.mapper;
 
+import hotspot.user.common.util.redis.RedisUsageCalculator;
 import hotspot.user.family.controller.response.UpdateDataLimitResponse;
 import hotspot.user.family.controller.response.UpdateFamilyRoleResponse;
+import hotspot.user.family.domain.FamilySubDataLimit;
 import hotspot.user.family.domain.FamilySubscription;
 
 /**
@@ -14,11 +16,12 @@ public class FamilySubscriptionMapper {
 
 
     // domain -> response
-    public static UpdateDataLimitResponse toUpdateDataLimitResponse(FamilySubscription familySub) {
+    public static UpdateDataLimitResponse toUpdateDataLimitResponse(Long subId, FamilySubDataLimit dataLimit) {
         return UpdateDataLimitResponse.builder()
-                .familyId(familySub.getFamily().getId())
-                .subId(familySub.getSubscription().getId())
-                .dataLimit(familySub.getDataLimit())
+                .familyId(dataLimit.getFamilyId())
+                .subId(subId)
+                .dataLimit(dataLimit.getDataLimit())
+                .isLocked(dataLimit.getIsLocked())
                 .build();
     }
 

--- a/src/main/java/hotspot/user/family/domain/mapper/FamilySubscriptionMapper.java
+++ b/src/main/java/hotspot/user/family/domain/mapper/FamilySubscriptionMapper.java
@@ -1,6 +1,5 @@
 package hotspot.user.family.domain.mapper;
 
-import hotspot.user.common.util.redis.RedisUsageCalculator;
 import hotspot.user.family.controller.response.UpdateDataLimitResponse;
 import hotspot.user.family.controller.response.UpdateFamilyRoleResponse;
 import hotspot.user.family.domain.FamilySubDataLimit;

--- a/src/main/java/hotspot/user/family/domain/mapper/FamilySubscriptionMapper.java
+++ b/src/main/java/hotspot/user/family/domain/mapper/FamilySubscriptionMapper.java
@@ -1,5 +1,6 @@
 package hotspot.user.family.domain.mapper;
 
+import hotspot.user.common.util.redis.RedisUsageCalculator;
 import hotspot.user.family.controller.response.UpdateDataLimitResponse;
 import hotspot.user.family.controller.response.UpdateFamilyRoleResponse;
 import hotspot.user.family.domain.FamilySubDataLimit;
@@ -19,7 +20,7 @@ public class FamilySubscriptionMapper {
         return UpdateDataLimitResponse.builder()
                 .familyId(dataLimit.getFamilyId())
                 .subId(subId)
-                .dataLimit(dataLimit.getDataLimit())
+                .dataLimit(RedisUsageCalculator.kbToGb(dataLimit.getDataLimit()))
                 .isLocked(dataLimit.getIsLocked())
                 .build();
     }

--- a/src/main/java/hotspot/user/family/infrastructure/FamilySubscriptionJpaRepository.java
+++ b/src/main/java/hotspot/user/family/infrastructure/FamilySubscriptionJpaRepository.java
@@ -30,6 +30,10 @@ public interface FamilySubscriptionJpaRepository extends JpaRepository<FamilySub
     @Query("UPDATE FamilySubscriptionEntity fs SET fs.priority = :priority WHERE fs.subscription.subId = :subId")
     void updatePriority(@Param("subId") Long subId, @Param("priority") int priority);
 
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE FamilySubscriptionEntity fs SET fs.dataLimit = :dataLimit WHERE fs.subscription.subId = :subId")
+    void updateDataLimit(@Param("subId") Long subId, @Param("dataLimit") long dataLimit);
+
     @Query("""
              SELECT
                  f.familyId as familyId,

--- a/src/main/java/hotspot/user/family/infrastructure/FamilySubscriptionRepositoryImpl.java
+++ b/src/main/java/hotspot/user/family/infrastructure/FamilySubscriptionRepositoryImpl.java
@@ -52,6 +52,11 @@ public class FamilySubscriptionRepositoryImpl implements FamilySubscriptionRepos
         }
     }
 
+    @Override
+    public void updateDataLimit(Long subId, long dataLimit) {
+        jpaRepository.updateDataLimit(subId, dataLimit);
+    }
+
     // 구성원별 데이터 한도 조회
     @Override
     public FamilySubDataLimit findDataLimitBySubId(Long subId) {

--- a/src/main/java/hotspot/user/family/infrastructure/entity/FamilyEntity.java
+++ b/src/main/java/hotspot/user/family/infrastructure/entity/FamilyEntity.java
@@ -44,7 +44,7 @@ public class FamilyEntity extends BaseEntity {
 
     @Column(nullable = false)
     @Builder.Default
-    private int familyDataAmount = 0;
+    private long familyDataAmount = 0;
 
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)

--- a/src/main/java/hotspot/user/family/infrastructure/entity/FamilySubscriptionEntity.java
+++ b/src/main/java/hotspot/user/family/infrastructure/entity/FamilySubscriptionEntity.java
@@ -57,7 +57,7 @@ public class FamilySubscriptionEntity {
 
     @Column(nullable = false)
     @Builder.Default
-    private int dataLimit = FamilyConstant.UNLIMITED_DATA_LIMIT;
+    private long dataLimit = FamilyConstant.UNLIMITED_DATA_LIMIT;
 
     public static FamilySubscriptionEntity domainToEntity(FamilySubscription familySubscription) {
         return FamilySubscriptionEntity.builder()

--- a/src/main/java/hotspot/user/family/service/UpdateDataLimitServiceImpl.java
+++ b/src/main/java/hotspot/user/family/service/UpdateDataLimitServiceImpl.java
@@ -45,11 +45,20 @@ public class UpdateDataLimitServiceImpl implements UpdateDataLimitService {
             throw new ApplicationException(FamilyErrorCode.NOT_FAMILY_MEMBER);
         }
 
+        // 3. 데이터 한도 유효성 검증
+        if (request.dataLimit() < FamilyConstant.UNLIMITED_DATA_LIMIT) {
+            throw new ApplicationException(FamilyErrorCode.INVALID_DATA_LIMIT);
+        }
+
         // 4. 데이터 한도 업데이트
-        long dataLimitKb = request.dataLimit() * 1024L * 1024L;
+        // GB -> KB 변환 (-1은 무제한이므로 그대로 유지)
+        long dataLimitKb = (request.dataLimit() == FamilyConstant.UNLIMITED_DATA_LIMIT)
+                ? FamilyConstant.UNLIMITED_DATA_LIMIT
+                : request.dataLimit() * 1024L * 1024L;
+
         familySubscriptionRepository.updateDataLimit(request.subId(), dataLimitKb);
 
-        // 5. 차단 여부 업데이트 (Selective Update)
+        // 5. 차단 여부 업데이트
         subscriptionRepository.updateLockedStatus(request.subId(), request.isLocked());
 
         // 6. 실제 DB에서 최종 상태를 다시 읽어와서 응답 (데이터 정합성 보장)

--- a/src/main/java/hotspot/user/family/service/UpdateDataLimitServiceImpl.java
+++ b/src/main/java/hotspot/user/family/service/UpdateDataLimitServiceImpl.java
@@ -3,23 +3,30 @@ package hotspot.user.family.service;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import hotspot.user.common.constant.FamilyConstant;
 import hotspot.user.common.exception.ApplicationException;
 import hotspot.user.common.exception.code.AuthErrorCode;
 import hotspot.user.common.exception.code.FamilyErrorCode;
 import hotspot.user.family.controller.port.UpdateDataLimitService;
 import hotspot.user.family.controller.request.UpdateDataLimitRequest;
 import hotspot.user.family.controller.response.UpdateDataLimitResponse;
+import hotspot.user.family.domain.FamilySubDataLimit;
 import hotspot.user.family.domain.FamilySubscription;
 import hotspot.user.family.domain.mapper.FamilySubscriptionMapper;
 import hotspot.user.family.service.port.FamilySubscriptionRepository;
 import hotspot.user.member.domain.FamilyRole;
+import hotspot.user.subscription.service.port.SubscriptionRepository;
 import lombok.RequiredArgsConstructor;
 
+/**
+ * 구성원 데이터 한도 및 즉시 차단 여부 업데이트 서비스 구현체
+ */
 @Service
 @RequiredArgsConstructor
 @Transactional
 public class UpdateDataLimitServiceImpl implements UpdateDataLimitService {
     private final FamilySubscriptionRepository familySubscriptionRepository;
+    private final SubscriptionRepository subscriptionRepository;
 
     @Override
     public UpdateDataLimitResponse updateDataLimit(UpdateDataLimitRequest request,
@@ -38,11 +45,15 @@ public class UpdateDataLimitServiceImpl implements UpdateDataLimitService {
             throw new ApplicationException(FamilyErrorCode.NOT_FAMILY_MEMBER);
         }
 
-        // 3. 데이터 한도 업데이트
-        familySub.updateDataLimit(request.dataLimit());
+        // 4. 데이터 한도 업데이트
+        long dataLimitKb = request.dataLimit() * 1024L * 1024L;
+        familySubscriptionRepository.updateDataLimit(request.subId(), dataLimitKb);
 
-        FamilySubscription savedFamilySub = familySubscriptionRepository.save(familySub);
+        // 5. 차단 여부 업데이트 (Selective Update)
+        subscriptionRepository.updateLockedStatus(request.subId(), request.isLocked());
 
-        return FamilySubscriptionMapper.toUpdateDataLimitResponse(savedFamilySub);
+        // 6. 실제 DB에서 최종 상태를 다시 읽어와서 응답 (데이터 정합성 보장)
+        FamilySubDataLimit savedDataLimit = familySubscriptionRepository.findDataLimitBySubId(request.subId());
+        return FamilySubscriptionMapper.toUpdateDataLimitResponse(request.subId(), savedDataLimit);
     }
 }

--- a/src/main/java/hotspot/user/family/service/UpdateDataLimitServiceImpl.java
+++ b/src/main/java/hotspot/user/family/service/UpdateDataLimitServiceImpl.java
@@ -56,6 +56,12 @@ public class UpdateDataLimitServiceImpl implements UpdateDataLimitService {
                 ? FamilyConstant.UNLIMITED_DATA_LIMIT
                 : request.dataLimit() * 1024L * 1024L;
 
+        // 가족 전체 데이터 양 초과 여부 검증 (무제한 설정은 제외)
+        if (dataLimitKb != FamilyConstant.UNLIMITED_DATA_LIMIT &&
+            dataLimitKb > familySub.getFamily().getFamilyDataAmount()) {
+            throw new ApplicationException(FamilyErrorCode.DATA_LIMIT_EXCEEDS_FAMILY_AMOUNT);
+        }
+
         familySubscriptionRepository.updateDataLimit(request.subId(), dataLimitKb);
 
         // 5. 차단 여부 업데이트

--- a/src/main/java/hotspot/user/family/service/UpdateDataLimitServiceImpl.java
+++ b/src/main/java/hotspot/user/family/service/UpdateDataLimitServiceImpl.java
@@ -7,6 +7,7 @@ import hotspot.user.common.constant.FamilyConstant;
 import hotspot.user.common.exception.ApplicationException;
 import hotspot.user.common.exception.code.AuthErrorCode;
 import hotspot.user.common.exception.code.FamilyErrorCode;
+import hotspot.user.common.util.redis.RedisUsageCalculator;
 import hotspot.user.family.controller.port.UpdateDataLimitService;
 import hotspot.user.family.controller.request.UpdateDataLimitRequest;
 import hotspot.user.family.controller.response.UpdateDataLimitResponse;
@@ -52,9 +53,7 @@ public class UpdateDataLimitServiceImpl implements UpdateDataLimitService {
 
         // 4. 데이터 한도 업데이트
         // GB -> KB 변환 (-1은 무제한이므로 그대로 유지)
-        long dataLimitKb = (request.dataLimit() == FamilyConstant.UNLIMITED_DATA_LIMIT)
-                ? FamilyConstant.UNLIMITED_DATA_LIMIT
-                : request.dataLimit() * 1024L * 1024L;
+        long dataLimitKb = RedisUsageCalculator.gbToKb(request.dataLimit());
 
         // 가족 전체 데이터 양 초과 여부 검증 (무제한 설정은 제외)
         if (dataLimitKb != FamilyConstant.UNLIMITED_DATA_LIMIT &&

--- a/src/main/java/hotspot/user/family/service/port/FamilySubscriptionRepository.java
+++ b/src/main/java/hotspot/user/family/service/port/FamilySubscriptionRepository.java
@@ -15,5 +15,6 @@ public interface FamilySubscriptionRepository {
     Optional<FamilySubscription> findByMemberId(Long memberId);
     FamilySubscription save(FamilySubscription familySubscription);
     void updatePriorities(List<FamilySubscription> subscriptions);
+    void updateDataLimit(Long subId, long dataLimit);
     FamilySubDataLimit findDataLimitBySubId(Long subId); // subId로 데이터 한도 관련 정보 찾기
 }

--- a/src/main/java/hotspot/user/policy/controller/response/AppliedPolicyResponse.java
+++ b/src/main/java/hotspot/user/policy/controller/response/AppliedPolicyResponse.java
@@ -12,7 +12,7 @@ public record AppliedPolicyResponse(
         Long memberId,
         String memberName,
         Long subId,
-        int dataLimit, // 개인별 한도
+        double dataLimit, // 개인별 한도
         int priority, // 구성원 내 우선 순위
         List<BlockPolicyResponse> blockPolicyResponseList,
         List<AppBlockedServiceResponse> appBlockedServiceResponseList

--- a/src/main/java/hotspot/user/policy/controller/response/FamilyAppliedPolicyResponse.java
+++ b/src/main/java/hotspot/user/policy/controller/response/FamilyAppliedPolicyResponse.java
@@ -12,7 +12,7 @@ import lombok.Builder;
 public record FamilyAppliedPolicyResponse(
         Long familyId,
         int familyNum,
-        int familyDataAmount,
+        double familyDataAmount,
         PriorityType priorityType,
         List<AppliedPolicyResponse> memberPolicies
 ) {

--- a/src/main/java/hotspot/user/policy/domain/mapper/AppliedPolicyMapper.java
+++ b/src/main/java/hotspot/user/policy/domain/mapper/AppliedPolicyMapper.java
@@ -2,6 +2,7 @@ package hotspot.user.policy.domain.mapper;
 
 import java.util.List;
 
+import hotspot.user.common.util.redis.RedisUsageCalculator;
 import hotspot.user.family.domain.Family;
 import hotspot.user.family.domain.FamilySubscription;
 import hotspot.user.policy.controller.response.AppliedPolicyResponse;
@@ -24,7 +25,7 @@ public class AppliedPolicyMapper {
                 .memberId(familySub.getSubscription().getMember().getId())
                 .memberName(familySub.getSubscription().getMember().getName())
                 .subId(familySub.getSubscription().getId())
-                .dataLimit(familySub.getDataLimit())
+                .dataLimit(RedisUsageCalculator.kbToGb(familySub.getDataLimit()))
                 .priority(familySub.getPriority())
                 .blockPolicyResponseList(policySubs.stream()
                         .map(BlockPolicyMapper::toBlockPolicyResponse)

--- a/src/main/java/hotspot/user/policy/domain/mapper/AppliedPolicyMapper.java
+++ b/src/main/java/hotspot/user/policy/domain/mapper/AppliedPolicyMapper.java
@@ -44,7 +44,7 @@ public class AppliedPolicyMapper {
         return FamilyAppliedPolicyResponse.builder()
                 .familyId(family.getId())
                 .familyNum(family.getFamilyNum())
-                .familyDataAmount(family.getFamilyDataAmount())
+                .familyDataAmount(RedisUsageCalculator.kbToGb(family.getFamilyDataAmount()))
                 .priorityType(family.getPriorityType())
                 .memberPolicies(memberPolicies)
                 .build();

--- a/src/main/java/hotspot/user/subscription/infrastructure/SubscriptionJpaRepository.java
+++ b/src/main/java/hotspot/user/subscription/infrastructure/SubscriptionJpaRepository.java
@@ -5,7 +5,9 @@ import java.util.Optional;
 
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import hotspot.user.subscription.infrastructure.entity.SubscriptionEntity;
 
@@ -26,4 +28,8 @@ public interface SubscriptionJpaRepository extends JpaRepository<SubscriptionEnt
         where s.subId in :subIds
     """)
     List<SubscriptionEntity> findAllByIdIn(List<Long> subIds);
+
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE SubscriptionEntity s SET s.isLocked = :isLocked WHERE s.subId = :subId")
+    void updateLockedStatus(@Param("subId") Long subId, @Param("isLocked") boolean isLocked);
 }

--- a/src/main/java/hotspot/user/subscription/infrastructure/SubscriptionRepositoryImpl.java
+++ b/src/main/java/hotspot/user/subscription/infrastructure/SubscriptionRepositoryImpl.java
@@ -43,6 +43,11 @@ public class SubscriptionRepositoryImpl implements SubscriptionRepository {
     }
 
     @Override
+    public void updateLockedStatus(Long subId, boolean isLocked) {
+        subscriptionJpaRepository.updateLockedStatus(subId, isLocked);
+    }
+
+    @Override
     public Map<Long, DataPeriod> findDataPeriodsBySubIds(List<Long> subIds) {
 
         if (subIds == null || subIds.isEmpty()) {

--- a/src/main/java/hotspot/user/subscription/service/port/SubscriptionRepository.java
+++ b/src/main/java/hotspot/user/subscription/service/port/SubscriptionRepository.java
@@ -15,5 +15,6 @@ public interface SubscriptionRepository {
     Optional<Subscription> findByMemberId(Long memberId);
     Optional<Subscription> findByPhoneHash(String phoneHash);
     Subscription save(Subscription subscription);
+    void updateLockedStatus(Long subId, boolean isLocked);
     Map<Long, DataPeriod> findDataPeriodsBySubIds(List<Long> subIds);
 }

--- a/src/test/java/hotspot/user/family/controller/FamilySubscriptionControllerTest.java
+++ b/src/test/java/hotspot/user/family/controller/FamilySubscriptionControllerTest.java
@@ -88,11 +88,11 @@ class FamilySubscriptionControllerTest {
     void updateDataLimitSuccess() throws Exception {
         // given
         setAuthentication(1L, 100L, FamilyRole.OWNER);
-        UpdateDataLimitRequest request = new UpdateDataLimitRequest(100L, 1L, 5000);
+        UpdateDataLimitRequest request = new UpdateDataLimitRequest(100L, 1L, 5L, false);
         UpdateDataLimitResponse response = UpdateDataLimitResponse.builder()
                 .familyId(100L)
                 .subId(1L)
-                .dataLimit(5000)
+                .dataLimit(5L)
                 .build();
 
         given(updateDataLimitService.updateDataLimit(any(UpdateDataLimitRequest.class), eq(100L), eq(FamilyRole.OWNER)))
@@ -104,7 +104,7 @@ class FamilySubscriptionControllerTest {
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value("200"))
-                .andExpect(jsonPath("$.data.dataLimit").value(5000));
+                .andExpect(jsonPath("$.data.dataLimit").value(5));
     }
 
     @Test
@@ -112,7 +112,7 @@ class FamilySubscriptionControllerTest {
     void updateDataLimitFailByChild() throws Exception {
         // given
         setAuthentication(1L, 100L, FamilyRole.CHILD);
-        UpdateDataLimitRequest request = new UpdateDataLimitRequest(100L, 1L, 5000);
+        UpdateDataLimitRequest request = new UpdateDataLimitRequest(100L, 1L, 5L, false);
 
         // 서비스가 호출되기 전 컨트롤러의 권한 체크 로직에서 예외가 발생함
         given(updateDataLimitService.updateDataLimit(any(UpdateDataLimitRequest.class), eq(100L), eq(FamilyRole.CHILD)))

--- a/src/test/java/hotspot/user/family/domain/FamilySubscriptionTest.java
+++ b/src/test/java/hotspot/user/family/domain/FamilySubscriptionTest.java
@@ -22,14 +22,14 @@ class FamilySubscriptionTest {
         // given
         FamilySubscription familySubscription = FamilySubscription.builder()
                 .id(1L)
-                .dataLimit(100)
+                .dataLimit(100L)
                 .build();
 
         // when
-        familySubscription.updateDataLimit(500);
+        familySubscription.updateDataLimit(500L);
 
         // then
-        assertThat(familySubscription.getDataLimit()).isEqualTo(500);
+        assertThat(familySubscription.getDataLimit()).isEqualTo(500L);
     }
 
     @Test
@@ -38,11 +38,11 @@ class FamilySubscriptionTest {
         // given
         FamilySubscription familySubscription = FamilySubscription.builder()
                 .id(1L)
-                .dataLimit(100)
+                .dataLimit(100L)
                 .build();
 
         // when & then
-        assertThatThrownBy(() -> familySubscription.updateDataLimit(-2))
+        assertThatThrownBy(() -> familySubscription.updateDataLimit(-2L))
                 .isInstanceOf(ApplicationException.class)
                 .hasFieldOrPropertyWithValue("code", FamilyErrorCode.INVALID_DATA_LIMIT);
     }
@@ -129,12 +129,12 @@ class FamilySubscriptionTest {
                 .family(family)
                 .familyRole(FamilyRole.OWNER)
                 .priority(1)
-                .dataLimit(1000)
+                .dataLimit(1000L)
                 .build();
 
         // then
         assertThat(familySubscription.getId()).isEqualTo(1L);
         assertThat(familySubscription.getFamilyRole()).isEqualTo(FamilyRole.OWNER);
-        assertThat(familySubscription.getDataLimit()).isEqualTo(1000);
+        assertThat(familySubscription.getDataLimit()).isEqualTo(1000L);
     }
 }

--- a/src/test/java/hotspot/user/family/infrastructure/FamilySubscriptionRepositoryImplTest.java
+++ b/src/test/java/hotspot/user/family/infrastructure/FamilySubscriptionRepositoryImplTest.java
@@ -137,7 +137,7 @@ class FamilySubscriptionRepositoryImplTest {
                 .family(family)
                 .familyRole(FamilyRole.CHILD)
                 .priority(-1)
-                .dataLimit(500)
+                .dataLimit(500L)
                 .build();
 
         // entityToDomain 변환 시 필요한 연관 엔티티들 모킹
@@ -158,7 +158,7 @@ class FamilySubscriptionRepositoryImplTest {
                 .subscription(subEntity)
                 .family(familyEntity)
                 .familyRole(FamilyRole.CHILD)
-                .dataLimit(500)
+                .dataLimit(500L)
                 .build();
 
         org.mockito.BDDMockito.given(familySubscriptionJpaRepository.save(

--- a/src/test/java/hotspot/user/family/service/UpdateDataLimitServiceImplTest.java
+++ b/src/test/java/hotspot/user/family/service/UpdateDataLimitServiceImplTest.java
@@ -184,12 +184,38 @@ class UpdateDataLimitServiceImplTest {
                 .hasFieldOrPropertyWithValue("code", FamilyErrorCode.INVALID_DATA_LIMIT);
     }
 
-    private FamilySubscription createFamilySubscription(Long familyId, Long subId, int currentLimit) {
+    @Test
+    @DisplayName("실패: 설정하려는 한도가 가족 전체 데이터 양을 초과하면 예외가 발생한다")
+    void updateDataLimitFailExceedsFamilyAmount() {
+        // given
+        Long familyId = 1L;
+        Long subId = 100L;
+        long newDataLimitGb = 10L; // 10GB 요청
+        int familyDataAmountKb = 5 * 1024 * 1024; // 가족 총량은 5GB
+        UpdateDataLimitRequest request = new UpdateDataLimitRequest(familyId, subId, newDataLimitGb, false);
+
+        FamilySubscription familySub = createFamilySubscription(familyId, subId, 1000, familyDataAmountKb);
+        given(familySubscriptionRepository.findBySubId(subId)).willReturn(Optional.of(familySub));
+
+        // when & then
+        assertThatThrownBy(() -> updateDataLimitService.updateDataLimit(request, familyId, FamilyRole.OWNER))
+                .isInstanceOf(ApplicationException.class)
+                .hasFieldOrPropertyWithValue("code", FamilyErrorCode.DATA_LIMIT_EXCEEDS_FAMILY_AMOUNT);
+    }
+
+    private FamilySubscription createFamilySubscription(Long familyId, Long subId, int currentLimit, int familyDataAmount) {
         return FamilySubscription.builder()
                 .id(1L)
-                .family(Family.builder().id(familyId).build())
+                .family(Family.builder()
+                        .id(familyId)
+                        .familyDataAmount(familyDataAmount)
+                        .build())
                 .subscription(Subscription.builder().id(subId).build())
                 .dataLimit(currentLimit)
                 .build();
+    }
+
+    private FamilySubscription createFamilySubscription(Long familyId, Long subId, int currentLimit) {
+        return createFamilySubscription(familyId, subId, currentLimit, 100 * 1024 * 1024); // 기본 100GB
     }
 }

--- a/src/test/java/hotspot/user/family/service/UpdateDataLimitServiceImplTest.java
+++ b/src/test/java/hotspot/user/family/service/UpdateDataLimitServiceImplTest.java
@@ -2,7 +2,7 @@ package hotspot.user.family.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -23,10 +23,12 @@ import hotspot.user.common.exception.code.FamilyErrorCode;
 import hotspot.user.family.controller.request.UpdateDataLimitRequest;
 import hotspot.user.family.controller.response.UpdateDataLimitResponse;
 import hotspot.user.family.domain.Family;
+import hotspot.user.family.domain.FamilySubDataLimit;
 import hotspot.user.family.domain.FamilySubscription;
 import hotspot.user.family.service.port.FamilySubscriptionRepository;
 import hotspot.user.member.domain.FamilyRole;
 import hotspot.user.subscription.domain.Subscription;
+import hotspot.user.subscription.service.port.SubscriptionRepository;
 
 /**
  * 구성원의 데이터 한도 조정하는 서비스 단위 테스트
@@ -37,41 +39,79 @@ class UpdateDataLimitServiceImplTest {
     @Mock
     private FamilySubscriptionRepository familySubscriptionRepository;
 
+    @Mock
+    private SubscriptionRepository subscriptionRepository;
+
     @InjectMocks
     private UpdateDataLimitServiceImpl updateDataLimitService;
 
     @Test
-    @DisplayName("성공: OWNER가 동일 가족 구성원의 데이터 한도를 업데이트한다")
+    @DisplayName("성공: OWNER가 동일 가족 구성원의 데이터 한도를 업데이트한다 (GB -> KB 변환 확인)")
     void updateDataLimitSuccess() {
         // given
         Long familyId = 1L;
         Long subId = 100L;
-        int newDataLimit = 5000;
-        UpdateDataLimitRequest request = new UpdateDataLimitRequest(familyId, subId, newDataLimit);
+        long newDataLimitGb = 5L;
+        long expectedKb = 5L * 1024L * 1024L;
+        UpdateDataLimitRequest request = new UpdateDataLimitRequest(familyId, subId, newDataLimitGb, false);
 
         FamilySubscription familySub = createFamilySubscription(familyId, subId, 1000);
+        FamilySubDataLimit finalState = FamilySubDataLimit.builder()
+                .familyId(familyId)
+                .name("김태연")
+                .isLocked(false)
+                .dataLimit(expectedKb)
+                .build();
+
         given(familySubscriptionRepository.findBySubId(subId)).willReturn(Optional.of(familySub));
-        given(familySubscriptionRepository.save(any(FamilySubscription.class))).willReturn(familySub);
+        given(familySubscriptionRepository.findDataLimitBySubId(subId)).willReturn(finalState);
 
         // when
         UpdateDataLimitResponse response = updateDataLimitService.updateDataLimit(request, familyId, FamilyRole.OWNER);
 
         // then
         assertThat(response.subId()).isEqualTo(subId);
-        assertThat(response.dataLimit()).isEqualTo(newDataLimit);
-        verify(familySubscriptionRepository, times(1)).save(any(FamilySubscription.class));
+        verify(familySubscriptionRepository, times(1)).updateDataLimit(eq(subId), eq(expectedKb));
+        verify(subscriptionRepository, times(1)).updateLockedStatus(eq(subId), eq(false));
+    }
+
+    @Test
+    @DisplayName("성공: 데이터 한도를 0으로 설정하면 즉시 차단(isLocked=true)된다")
+    void updateDataLimitToZeroAndLock() {
+        // given
+        Long familyId = 1L;
+        Long subId = 100L;
+        long newDataLimitGb = 0L;
+        UpdateDataLimitRequest request = new UpdateDataLimitRequest(familyId, subId, newDataLimitGb, true);
+
+        FamilySubscription familySub = createFamilySubscription(familyId, subId, 1000);
+        FamilySubDataLimit finalState = FamilySubDataLimit.builder()
+                .familyId(familyId)
+                .isLocked(true)
+                .dataLimit(0L)
+                .build();
+
+        given(familySubscriptionRepository.findBySubId(subId)).willReturn(Optional.of(familySub));
+        given(familySubscriptionRepository.findDataLimitBySubId(subId)).willReturn(finalState);
+
+        // when
+        updateDataLimitService.updateDataLimit(request, familyId, FamilyRole.OWNER);
+
+        // then
+        verify(familySubscriptionRepository, times(1)).updateDataLimit(eq(subId), eq(0L));
+        verify(subscriptionRepository, times(1)).updateLockedStatus(eq(subId), eq(true));
     }
 
     @Test
     @DisplayName("실패: 요청자가 OWNER가 아니면 예외가 발생한다")
     void updateDataLimitFailNotOwner() {
         // given
-        UpdateDataLimitRequest request = new UpdateDataLimitRequest(1L, 100L, 5000);
+        UpdateDataLimitRequest request = new UpdateDataLimitRequest(1L, 100L, 5L, false);
 
         // when & then
         assertThatThrownBy(() -> updateDataLimitService.updateDataLimit(request, 1L, FamilyRole.CHILD))
                 .isInstanceOf(ApplicationException.class)
-                .hasMessage(AuthErrorCode.ACCESS_DENIED.getMessage());
+                .hasFieldOrPropertyWithValue("code", AuthErrorCode.ACCESS_DENIED);
     }
 
     @Test
@@ -81,7 +121,7 @@ class UpdateDataLimitServiceImplTest {
         Long requesterFamilyId = 1L;
         Long targetFamilyId = 2L;
         Long subId = 100L;
-        UpdateDataLimitRequest request = new UpdateDataLimitRequest(requesterFamilyId, subId, 5000);
+        UpdateDataLimitRequest request = new UpdateDataLimitRequest(requesterFamilyId, subId, 5L, false);
 
         FamilySubscription familySub = createFamilySubscription(targetFamilyId, subId, 1000);
         given(familySubscriptionRepository.findBySubId(subId)).willReturn(Optional.of(familySub));
@@ -89,50 +129,59 @@ class UpdateDataLimitServiceImplTest {
         // when & then
         assertThatThrownBy(() -> updateDataLimitService.updateDataLimit(request, requesterFamilyId, FamilyRole.OWNER))
                 .isInstanceOf(ApplicationException.class)
-                .hasMessage(FamilyErrorCode.NOT_FAMILY_MEMBER.getMessage());
+                .hasFieldOrPropertyWithValue("code", FamilyErrorCode.NOT_FAMILY_MEMBER);
     }
 
     @Test
     @DisplayName("실패: 존재하지 않는 subId로 요청하면 예외가 발생한다")
     void updateDataLimitFailNotFound() {
         // given
-        UpdateDataLimitRequest request = new UpdateDataLimitRequest(1L, 999L, 5000);
+        UpdateDataLimitRequest request = new UpdateDataLimitRequest(1L, 999L, 5L, false);
         given(familySubscriptionRepository.findBySubId(999L)).willReturn(Optional.empty());
 
         // when & then
         assertThatThrownBy(() -> updateDataLimitService.updateDataLimit(request, 1L, FamilyRole.OWNER))
                 .isInstanceOf(ApplicationException.class)
-                .hasMessage(FamilyErrorCode.FAMILY_SUBSCRIPTION_NOT_FOUND.getMessage());
+                .hasFieldOrPropertyWithValue("code", FamilyErrorCode.FAMILY_SUBSCRIPTION_NOT_FOUND);
     }
 
     @Test
-    @DisplayName("성공: 데이터 한도를 무제한(UNLIMITED_DATA_LIMIT)으로 업데이트할 수 있다")
+    @DisplayName("성공: 데이터 한도를 무제한(-1)으로 업데이트할 수 있다")
     void updateDataLimitToUnlimited() {
         // given
-        UpdateDataLimitRequest request = new UpdateDataLimitRequest(1L, 100L, FamilyConstant.UNLIMITED_DATA_LIMIT);
+        long unlimitedGb = (long) FamilyConstant.UNLIMITED_DATA_LIMIT;
+        UpdateDataLimitRequest request = new UpdateDataLimitRequest(1L, 100L, unlimitedGb, false);
         FamilySubscription familySub = createFamilySubscription(1L, 100L, 1000);
+        FamilySubDataLimit finalState = FamilySubDataLimit.builder()
+                .familyId(1L)
+                .isLocked(false)
+                .dataLimit(unlimitedGb)
+                .build();
+
         given(familySubscriptionRepository.findBySubId(100L)).willReturn(Optional.of(familySub));
-        given(familySubscriptionRepository.save(any(FamilySubscription.class))).willReturn(familySub);
+        given(familySubscriptionRepository.findDataLimitBySubId(100L)).willReturn(finalState);
 
         // when
         UpdateDataLimitResponse response = updateDataLimitService.updateDataLimit(request, 1L, FamilyRole.OWNER);
 
         // then
-        assertThat(response.dataLimit()).isEqualTo(FamilyConstant.UNLIMITED_DATA_LIMIT);
+        assertThat(response.dataLimit()).isEqualTo(unlimitedGb);
+        verify(familySubscriptionRepository, times(1)).updateDataLimit(eq(100L), eq(unlimitedGb));
     }
 
     @Test
     @DisplayName("실패: 데이터 한도를 무제한보다 작은 값으로 수정하려 하면 예외가 발생한다")
     void updateDataLimitFailInvalidValue() {
         // given
-        UpdateDataLimitRequest request = new UpdateDataLimitRequest(1L, 100L, FamilyConstant.UNLIMITED_DATA_LIMIT - 1);
+        long invalidLimit = (long) FamilyConstant.UNLIMITED_DATA_LIMIT - 1L;
+        UpdateDataLimitRequest request = new UpdateDataLimitRequest(1L, 100L, invalidLimit, false);
         FamilySubscription familySub = createFamilySubscription(1L, 100L, 1000);
         given(familySubscriptionRepository.findBySubId(100L)).willReturn(Optional.of(familySub));
 
         // when & then
         assertThatThrownBy(() -> updateDataLimitService.updateDataLimit(request, 1L, FamilyRole.OWNER))
                 .isInstanceOf(ApplicationException.class)
-                .hasMessage(FamilyErrorCode.INVALID_DATA_LIMIT.getMessage());
+                .hasFieldOrPropertyWithValue("code", FamilyErrorCode.INVALID_DATA_LIMIT);
     }
 
     private FamilySubscription createFamilySubscription(Long familyId, Long subId, int currentLimit) {

--- a/src/test/java/hotspot/user/family/service/UpdateDataLimitServiceImplTest.java
+++ b/src/test/java/hotspot/user/family/service/UpdateDataLimitServiceImplTest.java
@@ -184,38 +184,39 @@ class UpdateDataLimitServiceImplTest {
                 .hasFieldOrPropertyWithValue("code", FamilyErrorCode.INVALID_DATA_LIMIT);
     }
 
-    @Test
-    @DisplayName("실패: 설정하려는 한도가 가족 전체 데이터 양을 초과하면 예외가 발생한다")
-    void updateDataLimitFailExceedsFamilyAmount() {
-        // given
-        Long familyId = 1L;
-        Long subId = 100L;
-        long newDataLimitGb = 10L; // 10GB 요청
-        int familyDataAmountKb = 5 * 1024 * 1024; // 가족 총량은 5GB
-        UpdateDataLimitRequest request = new UpdateDataLimitRequest(familyId, subId, newDataLimitGb, false);
+        @Test
+        @DisplayName("실패: 설정하려는 한도가 가족 전체 데이터 양을 초과하면 예외가 발생한다")
+        void updateDataLimitFailExceedsFamilyAmount() {
+            // given
+            Long familyId = 1L;
+            Long subId = 100L;
+            long newDataLimitGb = 10L; // 10GB 요청
+            long familyDataAmountKb = 5L * 1024L * 1024L; // 가족 총량은 5GB
+            UpdateDataLimitRequest request = new UpdateDataLimitRequest(familyId, subId, newDataLimitGb, false);
 
-        FamilySubscription familySub = createFamilySubscription(familyId, subId, 1000, familyDataAmountKb);
-        given(familySubscriptionRepository.findBySubId(subId)).willReturn(Optional.of(familySub));
+            FamilySubscription familySub = createFamilySubscription(familyId, subId, 1000L, familyDataAmountKb);
+            given(familySubscriptionRepository.findBySubId(subId)).willReturn(Optional.of(familySub));
 
-        // when & then
-        assertThatThrownBy(() -> updateDataLimitService.updateDataLimit(request, familyId, FamilyRole.OWNER))
-                .isInstanceOf(ApplicationException.class)
-                .hasFieldOrPropertyWithValue("code", FamilyErrorCode.DATA_LIMIT_EXCEEDS_FAMILY_AMOUNT);
+            // when & then
+            assertThatThrownBy(() -> updateDataLimitService.updateDataLimit(request, familyId, FamilyRole.OWNER))
+                    .isInstanceOf(ApplicationException.class)
+                    .hasFieldOrPropertyWithValue("code", FamilyErrorCode.DATA_LIMIT_EXCEEDS_FAMILY_AMOUNT);
+        }
+
+        private FamilySubscription createFamilySubscription(Long familyId, Long subId,
+                                                        long currentLimit, long familyDataAmount) {
+            return FamilySubscription.builder()
+                    .id(1L)
+                    .family(Family.builder()
+                            .id(familyId)
+                            .familyDataAmount(familyDataAmount)
+                            .build())
+                    .subscription(Subscription.builder().id(subId).build())
+                    .dataLimit(currentLimit)
+                    .build();
+        }
+
+        private FamilySubscription createFamilySubscription(Long familyId, Long subId, long currentLimit) {
+            return createFamilySubscription(familyId, subId, currentLimit, 100L * 1024L * 1024L); // 기본 100GB
+        }
     }
-
-    private FamilySubscription createFamilySubscription(Long familyId, Long subId, int currentLimit, int familyDataAmount) {
-        return FamilySubscription.builder()
-                .id(1L)
-                .family(Family.builder()
-                        .id(familyId)
-                        .familyDataAmount(familyDataAmount)
-                        .build())
-                .subscription(Subscription.builder().id(subId).build())
-                .dataLimit(currentLimit)
-                .build();
-    }
-
-    private FamilySubscription createFamilySubscription(Long familyId, Long subId, int currentLimit) {
-        return createFamilySubscription(familyId, subId, currentLimit, 100 * 1024 * 1024); // 기본 100GB
-    }
-}


### PR DESCRIPTION
## 🎫 지라 티켓

<!-- 지라 티켓을 작성해주세요 ex) HOTSPOT-123 -->
HOTSPOT-181

---

## 🔗 GitHub 이슈
<!-- 자동 close를 원하면 아래 형식으로 작성
예) Closes #12
-->
Closes #93 

---


## ✅ 작업 사항

<!-- 작업한 부분을 설명해주세요. -->

구성원 데이터 한도양 업데이트 => 즉시 차단 여부도 추가함

`dataLimit` & `familyDataAmount` 같은 데이터 사용량과 관련된 필드의 데이터 타입 일치시킴
- request, db 저장 : `long`
- response, Gb <-> Kb 연산 : `double`


---

## 📋 체크리스트

<!-- PR 제출 전 확인해주세요. 해당 항목에 [x]로 체크해주세요. -->

- [x] 코드가 정상적으로 빌드됩니다.
- [x] 관련 테스트 코드를 작성했습니다.
- [x] 기존 테스트가 모두 통과합니다.
- [x] 코드 스타일(Spotless, Checkstyle)을 준수합니다.
- [x] Jira 티켓 상태를 In Review / Done으로 변경했습니다.

---

## ⌨ 기타
