### PR TITLE
[HOTSPOT-194] SSE 구독 API 스웨거 테스트 및 로그아웃 시 세션 제거

### DIFF
--- a/src/main/java/hotspot/user/auth/service/LogoutServiceImpl.java
+++ b/src/main/java/hotspot/user/auth/service/LogoutServiceImpl.java
@@ -10,6 +10,8 @@ import hotspot.user.common.exception.ApplicationException;
 import hotspot.user.common.exception.code.AuthErrorCode;
 import hotspot.user.common.security.PrincipalDetails;
 import hotspot.user.common.security.jwt.JwtProvider;
+import hotspot.user.dispatch.registry.SseEmitterRegistry;
+import hotspot.user.subscription.service.port.SubscriptionRepository;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -19,6 +21,8 @@ public class LogoutServiceImpl implements LogoutService {
 
     private final TokenRepository tokenRepository;
     private final JwtProvider jwtProvider;
+    private final SubscriptionRepository subscriptionRepository;
+    private final SseEmitterRegistry sseEmitterRegistry;
 
     @Override
     public void logout(Long memberId, TokenRequest request) {
@@ -39,5 +43,7 @@ public class LogoutServiceImpl implements LogoutService {
 
         // 3. 토큰 삭제 (무효화)
         tokenRepository.deleteByMemberId(memberId);
+        subscriptionRepository.findByMemberId(memberId)
+                .ifPresent(subscription -> sseEmitterRegistry.closeAllBySubId(subscription.getId()));
     }
 }

--- a/src/main/java/hotspot/user/dispatch/registry/SseEmitterRegistry.java
+++ b/src/main/java/hotspot/user/dispatch/registry/SseEmitterRegistry.java
@@ -41,7 +41,11 @@ public class SseEmitterRegistry {
     public void closeAllBySubId(Long subId) {
         findBySubId(subId).forEach(registeredEmitter -> {
             remove(registeredEmitter.emitterId());
-            registeredEmitter.emitter().complete();
+            try {
+                registeredEmitter.emitter().complete();
+            } catch (RuntimeException ignored) {
+                // 연결 종료 중 예외가 발생해도 다른 emitter 정리는 계속 진행한다.
+            }
         });
     }
 

--- a/src/main/java/hotspot/user/dispatch/registry/SseEmitterRegistry.java
+++ b/src/main/java/hotspot/user/dispatch/registry/SseEmitterRegistry.java
@@ -37,6 +37,14 @@ public class SseEmitterRegistry {
         removeFromBucket(emittersBySubId, subId, emitterId);
     }
 
+    // 특정 subId에 연결된 모든 SSE 연결을 강제로 종료하고 레지스트리에서 제거한다.
+    public void closeAllBySubId(Long subId) {
+        findBySubId(subId).forEach(registeredEmitter -> {
+            remove(registeredEmitter.emitterId());
+            registeredEmitter.emitter().complete();
+        });
+    }
+
     // 특정 subId에 연결된 모든 SSE 연결을 조회한다.
     public List<RegisteredEmitter> findBySubId(Long subId) {
         Map<String, SseEmitter> bucket = emittersBySubId.get(subId);

--- a/src/main/java/hotspot/user/subscription/infrastructure/SubscriptionJpaRepository.java
+++ b/src/main/java/hotspot/user/subscription/infrastructure/SubscriptionJpaRepository.java
@@ -14,15 +14,21 @@ import hotspot.user.subscription.infrastructure.entity.SubscriptionEntity;
  */
 public interface SubscriptionJpaRepository extends JpaRepository<SubscriptionEntity, Long> {
 
-    @EntityGraph(attributePaths = {"plan"})
+    @EntityGraph(attributePaths = {"plan", "member"})
+    @Override
+    Optional<SubscriptionEntity> findById(Long id);
+
+    @EntityGraph(attributePaths = {"plan", "member"})
     Optional<SubscriptionEntity> findByMemberId(Long memberId);
 
+    @EntityGraph(attributePaths = {"plan", "member"})
     Optional<SubscriptionEntity> findByPhoneHash(String phoneHash);
 
     @Query("""
         select s
         from SubscriptionEntity s
         join fetch s.plan
+        join fetch s.member
         where s.subId in :subIds
     """)
     List<SubscriptionEntity> findAllByIdIn(List<Long> subIds);

--- a/src/test/java/hotspot/user/auth/service/LogoutServiceImplTest.java
+++ b/src/test/java/hotspot/user/auth/service/LogoutServiceImplTest.java
@@ -4,6 +4,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
+import java.util.Optional;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -18,8 +20,11 @@ import hotspot.user.auth.service.port.TokenRepository;
 import hotspot.user.common.exception.ApplicationException;
 import hotspot.user.common.security.PrincipalDetails;
 import hotspot.user.common.security.jwt.JwtProvider;
+import hotspot.user.dispatch.registry.SseEmitterRegistry;
 import hotspot.user.member.domain.FamilyRole;
 import hotspot.user.member.domain.Status;
+import hotspot.user.subscription.domain.Subscription;
+import hotspot.user.subscription.service.port.SubscriptionRepository;
 
 /**
  * 로그아웃 서비스 단위 테스트
@@ -31,6 +36,10 @@ class LogoutServiceImplTest {
     private JwtProvider jwtProvider;
     @Mock
     private TokenRepository tokenRepository;
+    @Mock
+    private SubscriptionRepository subscriptionRepository;
+    @Mock
+    private SseEmitterRegistry sseEmitterRegistry;
 
     @InjectMocks
     private LogoutServiceImpl logoutService;
@@ -51,12 +60,15 @@ class LogoutServiceImplTest {
 
         given(jwtProvider.validateToken(refreshToken)).willReturn(true);
         given(jwtProvider.getAuthenticationFromRefreshToken(refreshToken)).willReturn(authentication);
+        given(subscriptionRepository.findByMemberId(memberId))
+                .willReturn(Optional.of(Subscription.builder().id(1000003L).build()));
 
         // when
         logoutService.logout(memberId, request);
 
         // then
         verify(tokenRepository).deleteByMemberId(memberId);
+        verify(sseEmitterRegistry).closeAllBySubId(1000003L);
     }
 
     @Test

--- a/src/test/java/hotspot/user/dispatch/registry/SseEmitterRegistryTest.java
+++ b/src/test/java/hotspot/user/dispatch/registry/SseEmitterRegistryTest.java
@@ -25,4 +25,18 @@ class SseEmitterRegistryTest {
         assertThat(sseEmitterRegistry.findBySubId(11L)).isEmpty();
         assertThat(sseEmitterRegistry.findAll()).isEmpty();
     }
+
+    @Test
+    @DisplayName("closeAllBySubId removes all emitters for target subscription")
+    void closeAllBySubIdRemovesEmitters() {
+        sseEmitterRegistry.register(11L, new SseEmitter());
+        sseEmitterRegistry.register(11L, new SseEmitter());
+        sseEmitterRegistry.register(12L, new SseEmitter());
+
+        sseEmitterRegistry.closeAllBySubId(11L);
+
+        assertThat(sseEmitterRegistry.findBySubId(11L)).isEmpty();
+        assertThat(sseEmitterRegistry.findBySubId(12L)).hasSize(1);
+        assertThat(sseEmitterRegistry.findAll()).hasSize(1);
+    }
 }


### PR DESCRIPTION
## 🎫 지라 티켓

<!-- 지라 티켓을 작성해주세요 ex) HOTSPOT-123 -->
HOTSPOT-194

---

## 🔗 GitHub 이슈
<!-- 자동 close를 원하면 아래 형식으로 작성
예) Closes #12
-->
Closes #94 

---


## ✅ 작업 사항

<!-- 작업한 부분을 설명해주세요. -->
- SSE subscribe에 대한 스웨거 테스트 진행
- 로그아웃 핸들러에서 현재 사용자 식별
- 해당 사용자 emitter 제거 API 호출 추가
- 로그아웃 후 알림 push가 더 이상 전달되지 않는지 검증

---

## 📋 체크리스트

<!-- PR 제출 전 확인해주세요. 해당 항목에 [x]로 체크해주세요. -->

- [x] 코드가 정상적으로 빌드됩니다.
- [x] 관련 테스트 코드를 작성했습니다.
- [x] 기존 테스트가 모두 통과합니다.
- [x] 코드 스타일(Spotless, Checkstyle)을 준수합니다.
- [x] Jira 티켓 상태를 In Review / Done으로 변경했습니다.

---

## ⌨ 기타
