### PR TITLE
[HOTSPOT-201] 우리 가족이 생성한 정책 조회 API 구현

### DIFF
--- a/src/main/java/hotspot/user/common/util/cookie/CookieUtil.java
+++ b/src/main/java/hotspot/user/common/util/cookie/CookieUtil.java
@@ -12,7 +12,7 @@ public class CookieUtil {
     public static ResponseCookie createCookie(String name, String value, long maxAge) {
     return ResponseCookie.from(name, value)
             // 로컬에서는 주석처리
-            .domain(".hotspot.pics")
+            //.domain(".hotspot.pics")
             .path("/")
             .sameSite("None")
             .httpOnly(true)
@@ -24,7 +24,7 @@ public class CookieUtil {
     public static ResponseCookie deleteCookie(String name) {
         return ResponseCookie.from(name, "")
                 // 로컬에서는 주석처리
-                .domain(".hotspot.pics")
+                //.domain(".hotspot.pics")
                 .path("/")
                 .sameSite("None")
                 .httpOnly(true)

--- a/src/main/java/hotspot/user/common/util/cookie/CookieUtil.java
+++ b/src/main/java/hotspot/user/common/util/cookie/CookieUtil.java
@@ -12,7 +12,7 @@ public class CookieUtil {
     public static ResponseCookie createCookie(String name, String value, long maxAge) {
     return ResponseCookie.from(name, value)
             // 로컬에서는 주석처리
-            //.domain(".hotspot.pics")
+            .domain(".hotspot.pics")
             .path("/")
             .sameSite("None")
             .httpOnly(true)
@@ -24,7 +24,7 @@ public class CookieUtil {
     public static ResponseCookie deleteCookie(String name) {
         return ResponseCookie.from(name, "")
                 // 로컬에서는 주석처리
-                //.domain(".hotspot.pics")
+                .domain(".hotspot.pics")
                 .path("/")
                 .sameSite("None")
                 .httpOnly(true)

--- a/src/main/java/hotspot/user/policy/controller/BlockPolicyController.java
+++ b/src/main/java/hotspot/user/policy/controller/BlockPolicyController.java
@@ -37,6 +37,7 @@ public class BlockPolicyController implements BlockPolicyApi {
     }
 
     // 우리가족 정책 조회
+    @Override
     @GetMapping("/families")
     public ResponseEntity<ApiResponse<List<BlockPolicyResponse>>> getFamilyPolicies(
             @AuthenticationPrincipal PrincipalDetails principal) {

--- a/src/main/java/hotspot/user/policy/controller/BlockPolicyController.java
+++ b/src/main/java/hotspot/user/policy/controller/BlockPolicyController.java
@@ -2,7 +2,10 @@ package hotspot.user.policy.controller;
 
 import java.util.List;
 
+import hotspot.user.common.security.PrincipalDetails;
+import hotspot.user.policy.controller.port.FindFamilyBlockPolicyService;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -22,6 +25,7 @@ import lombok.RequiredArgsConstructor;
 public class BlockPolicyController implements BlockPolicyApi {
 
     private final FindBlockPolicyService findBlockPolicyService;
+    private final FindFamilyBlockPolicyService findFamilyBlockPolicyService; // 우리 가족이 생성한 정책 조회
 
     @Override
     @GetMapping
@@ -31,4 +35,18 @@ public class BlockPolicyController implements BlockPolicyApi {
         return ResponseEntity.ok()
                 .body(ApiResponse.success(policiesList));
     }
+
+    // 우리가족 정책 조회
+    @GetMapping("/families")
+    public ResponseEntity<ApiResponse<List<BlockPolicyResponse>>> getFamilyPolicies(
+            @AuthenticationPrincipal PrincipalDetails principal) {
+        Long memberId = principal.getId();
+        Long familyId = principal.getFamilyId();
+
+        List<BlockPolicyResponse> policiesList = findFamilyBlockPolicyService.findAllByFamilyId(memberId, familyId);
+
+        return ResponseEntity.ok()
+                .body(ApiResponse.success(policiesList));
+    }
+
 }

--- a/src/main/java/hotspot/user/policy/controller/BlockPolicyController.java
+++ b/src/main/java/hotspot/user/policy/controller/BlockPolicyController.java
@@ -2,8 +2,6 @@ package hotspot.user.policy.controller;
 
 import java.util.List;
 
-import hotspot.user.common.security.PrincipalDetails;
-import hotspot.user.policy.controller.port.FindFamilyBlockPolicyService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -11,7 +9,9 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import hotspot.user.common.ApiResponse;
+import hotspot.user.common.security.PrincipalDetails;
 import hotspot.user.policy.controller.port.FindBlockPolicyService;
+import hotspot.user.policy.controller.port.FindFamilyBlockPolicyService;
 import hotspot.user.policy.controller.response.BlockPolicyResponse;
 import hotspot.user.policy.controller.swagger.BlockPolicyApi;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/hotspot/user/policy/controller/port/FindFamilyBlockPolicyService.java
+++ b/src/main/java/hotspot/user/policy/controller/port/FindFamilyBlockPolicyService.java
@@ -1,8 +1,8 @@
 package hotspot.user.policy.controller.port;
 
-import hotspot.user.policy.controller.response.BlockPolicyResponse;
-
 import java.util.List;
+
+import hotspot.user.policy.controller.response.BlockPolicyResponse;
 
 /**
  * 우리 가족이 생성한 정책 조회

--- a/src/main/java/hotspot/user/policy/controller/port/FindFamilyBlockPolicyService.java
+++ b/src/main/java/hotspot/user/policy/controller/port/FindFamilyBlockPolicyService.java
@@ -1,0 +1,12 @@
+package hotspot.user.policy.controller.port;
+
+import hotspot.user.policy.controller.response.BlockPolicyResponse;
+
+import java.util.List;
+
+/**
+ * 우리 가족이 생성한 정책 조회
+ */
+public interface FindFamilyBlockPolicyService {
+    List<BlockPolicyResponse> findAllByFamilyId(Long memberId, Long familyId);
+}

--- a/src/main/java/hotspot/user/policy/controller/swagger/BlockPolicyApi.java
+++ b/src/main/java/hotspot/user/policy/controller/swagger/BlockPolicyApi.java
@@ -3,33 +3,52 @@ package hotspot.user.policy.controller.swagger;
 import java.util.List;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 
+import hotspot.user.common.ApiResponse;
 import hotspot.user.common.exception.ErrorResponse;
+import hotspot.user.common.security.PrincipalDetails;
 import hotspot.user.policy.controller.response.BlockPolicyResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
 @Tag(name = "Policy", description = "차단 정책 관련 API")
 public interface BlockPolicyApi {
 
-    @Operation(summary = "전체 정책 목록 조회", description = "시스템에 정의된 모든 차단 정책(앱 차단, 시간 제한 등) 목록을 조회합니다.")
+    @Operation(summary = "전체 관리자 정책 목록 조회", description = "시스템 관리자가 생성한 공용 차단 정책(isActive=true) 목록을 조회합니다.")
     @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "조회 성공"),
-        @ApiResponse(responseCode = "401", description = """
-                인증 실패
-                - AUTH_001: 유효하지 않은 토큰
-                - AUTH_002: 만료된 토큰
-                """,
-                 content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-        @ApiResponse(responseCode = "403", description = """
-                권한 없음
-                - AUTH_004: 온보딩 미완료 유저(PENDING)
-                """,
-                 content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 실패\n"
+                                         + "- AUTH_002: 유효하지 않은 토큰입니다.\n"
+                                         + "- AUTH_006: 토큰이 만료되었습니다.",
+                     content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
-    ResponseEntity<hotspot.user.common.ApiResponse<List<BlockPolicyResponse>>> getAllPolicies();
+    @GetMapping
+    ResponseEntity<ApiResponse<List<BlockPolicyResponse>>> getAllPolicies();
+
+    @Operation(summary = "우리 가족 정책 목록 조회", description = "우리 가족 구성원이 생성한 정책 목록을 조회합니다. OWNER 또는 PARENT 권한이 필요합니다.")
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "권한 없음\n"
+                                         + "- FAMILY_003: 해당 구성원은 동일한 가족 그룹에 속해 있지 않습니다.\n"
+                                         + "- AUTH_004: 해당 요청에 대한 접근 권한이 없습니다.",
+                     content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "찾을 수 없음\n"
+                                         + "- FAMILY_002: 가족에 가입된 회선 정보를 찾을 수 없습니다.",
+                     content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 실패\n"
+                                         + "- AUTH_002: 유효하지 않은 토큰입니다.\n"
+                                         + "- AUTH_006: 토큰이 만료되었습니다.",
+                     content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @GetMapping("/families")
+    ResponseEntity<ApiResponse<List<BlockPolicyResponse>>> getFamilyPolicies(
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal PrincipalDetails principal
+    );
 }

--- a/src/main/java/hotspot/user/policy/infrastructure/BlockPolicyJpaRepository.java
+++ b/src/main/java/hotspot/user/policy/infrastructure/BlockPolicyJpaRepository.java
@@ -8,4 +8,6 @@ import hotspot.user.policy.infrastructure.entity.BlockPolicyEntity;
 
 public interface BlockPolicyJpaRepository extends JpaRepository<BlockPolicyEntity, Long> {
     List<BlockPolicyEntity> findAllByIsActiveTrueAndFamilyIdIsNull();
+    List<BlockPolicyEntity> findAllByFamilyId(Long familyId); // 우리 가족이 생성한 정책 조회
+
 }

--- a/src/main/java/hotspot/user/policy/infrastructure/BlockPolicyRepositoryImpl.java
+++ b/src/main/java/hotspot/user/policy/infrastructure/BlockPolicyRepositoryImpl.java
@@ -28,4 +28,12 @@ public class BlockPolicyRepositoryImpl implements BlockPolicyRepository {
                 .map(BlockPolicyEntity::entityToDomain)
                 .toList();
     }
+
+    // familyId에 해당하는 모든 정책 리턴
+    @Override
+    public List<BlockPolicy> findAllByFamilyId(Long familyId) {
+        return blockPolicyJpaRepository.findAllByFamilyId(familyId).stream()
+                .map(BlockPolicyEntity::entityToDomain)
+                .toList();
+    }
 }

--- a/src/main/java/hotspot/user/policy/service/FindFamilyBlockPolicyServiceImpl.java
+++ b/src/main/java/hotspot/user/policy/service/FindFamilyBlockPolicyServiceImpl.java
@@ -1,5 +1,10 @@
 package hotspot.user.policy.service;
 
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import hotspot.user.common.exception.ApplicationException;
 import hotspot.user.common.exception.code.AuthErrorCode;
 import hotspot.user.common.exception.code.FamilyErrorCode;
@@ -11,10 +16,6 @@ import hotspot.user.policy.controller.response.BlockPolicyResponse;
 import hotspot.user.policy.domain.mapper.BlockPolicyMapper;
 import hotspot.user.policy.service.port.BlockPolicyRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
 
 /**
  * 우리 가족이 생성한 정책 조회 서비스 구현체
@@ -37,7 +38,7 @@ public class FindFamilyBlockPolicyServiceImpl implements FindFamilyBlockPolicySe
                 .orElseThrow(() -> new ApplicationException(FamilyErrorCode.FAMILY_SUBSCRIPTION_NOT_FOUND));
 
         // 실제 구성된 familyId 일치 여부 확인
-        if(!familySub.getFamily().getId().equals(familyId)) {
+        if (!familySub.getFamily().getId().equals(familyId)) {
             throw new ApplicationException(FamilyErrorCode.NOT_FAMILY_MEMBER);
         }
 

--- a/src/main/java/hotspot/user/policy/service/FindFamilyBlockPolicyServiceImpl.java
+++ b/src/main/java/hotspot/user/policy/service/FindFamilyBlockPolicyServiceImpl.java
@@ -1,0 +1,53 @@
+package hotspot.user.policy.service;
+
+import hotspot.user.common.exception.ApplicationException;
+import hotspot.user.common.exception.code.AuthErrorCode;
+import hotspot.user.common.exception.code.FamilyErrorCode;
+import hotspot.user.family.domain.FamilySubscription;
+import hotspot.user.family.service.port.FamilySubscriptionRepository;
+import hotspot.user.member.domain.FamilyRole;
+import hotspot.user.policy.controller.port.FindFamilyBlockPolicyService;
+import hotspot.user.policy.controller.response.BlockPolicyResponse;
+import hotspot.user.policy.domain.mapper.BlockPolicyMapper;
+import hotspot.user.policy.service.port.BlockPolicyRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/**
+ * 우리 가족이 생성한 정책 조회 서비스 구현체
+ */
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class FindFamilyBlockPolicyServiceImpl implements FindFamilyBlockPolicyService {
+
+    private final BlockPolicyRepository blockPolicyRepository;
+    private final FamilySubscriptionRepository familySubscriptionRepository;
+
+    @Override
+    public List<BlockPolicyResponse> findAllByFamilyId(Long memberId, Long familyId) {
+
+        // DB에서 최신 가족 매핑 정보 조회
+        // 조회자가 가족 구성원에 소속되어있지 않으면 예외 처리
+        FamilySubscription familySub = familySubscriptionRepository.findByMemberId(memberId)
+                .orElseThrow(() -> new ApplicationException(FamilyErrorCode.FAMILY_SUBSCRIPTION_NOT_FOUND));
+
+        // 실제 구성된 familyId 일치 여부 확인
+        if(!familySub.getFamily().getId().equals(familyId)) {
+            throw new ApplicationException(FamilyErrorCode.NOT_FAMILY_MEMBER);
+        }
+
+        // OWNER or PARENT인지 확인
+        if (familySub.getFamilyRole() != FamilyRole.OWNER && familySub.getFamilyRole() != FamilyRole.PARENT) {
+            throw new ApplicationException(AuthErrorCode.ACCESS_DENIED);
+        }
+
+        return blockPolicyRepository.findAllByFamilyId(familyId).stream()
+                .map(BlockPolicyMapper::toBlockPolicyResponse)
+                .toList();
+    }
+}

--- a/src/main/java/hotspot/user/policy/service/port/BlockPolicyRepository.java
+++ b/src/main/java/hotspot/user/policy/service/port/BlockPolicyRepository.java
@@ -10,4 +10,5 @@ import hotspot.user.policy.domain.BlockPolicy;
 public interface BlockPolicyRepository {
     List<BlockPolicy> findAll();
     List<BlockPolicy> findAllById(List<Long> idList);
+    List<BlockPolicy> findAllByFamilyId(Long familyId);
 }

--- a/src/test/java/hotspot/user/policy/controller/BlockPolicyControllerTest.java
+++ b/src/test/java/hotspot/user/policy/controller/BlockPolicyControllerTest.java
@@ -15,6 +15,8 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.web.servlet.MockMvc;
 
 import hotspot.user.common.security.PrincipalDetails;
@@ -26,8 +28,6 @@ import hotspot.user.policy.controller.port.FindBlockPolicyService;
 import hotspot.user.policy.controller.port.FindFamilyBlockPolicyService;
 import hotspot.user.policy.controller.response.BlockPolicyResponse;
 import hotspot.user.policy.domain.PolicyType;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.context.SecurityContextHolder;
 
 /**
  * 정책 Controller 테스트 코드

--- a/src/test/java/hotspot/user/policy/controller/BlockPolicyControllerTest.java
+++ b/src/test/java/hotspot/user/policy/controller/BlockPolicyControllerTest.java
@@ -17,11 +17,17 @@ import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
+import hotspot.user.common.security.PrincipalDetails;
 import hotspot.user.common.security.jwt.JwtFilter;
 import hotspot.user.common.security.jwt.JwtProvider;
+import hotspot.user.member.domain.FamilyRole;
+import hotspot.user.member.domain.Status;
 import hotspot.user.policy.controller.port.FindBlockPolicyService;
+import hotspot.user.policy.controller.port.FindFamilyBlockPolicyService;
 import hotspot.user.policy.controller.response.BlockPolicyResponse;
 import hotspot.user.policy.domain.PolicyType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
 
 /**
  * 정책 Controller 테스트 코드
@@ -38,6 +44,9 @@ class BlockPolicyControllerTest {
     private FindBlockPolicyService findBlockPolicyService;
 
     @MockBean
+    private FindFamilyBlockPolicyService findFamilyBlockPolicyService;
+
+    @MockBean
     private JwtFilter jwtFilter;
 
     @MockBean
@@ -45,6 +54,20 @@ class BlockPolicyControllerTest {
 
     @MockBean
     private JpaMetamodelMappingContext jpaMetamodelMappingContext;
+
+    private void setAuthentication() {
+        PrincipalDetails principal = PrincipalDetails.builder()
+                .id(1L)
+                .email("test@test.com")
+                .familyId(100L)
+                .role(FamilyRole.OWNER)
+                .status(Status.APPROVED)
+                .build();
+
+        UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(
+                principal, null, principal.getAuthorities());
+        SecurityContextHolder.getContext().setAuthentication(auth);
+    }
 
     @Test
     @DisplayName("전체 정책 목록 조회 API 성공")
@@ -65,5 +88,27 @@ class BlockPolicyControllerTest {
                 .andExpect(jsonPath("$.status").value(200))
                 .andExpect(jsonPath("$.data[0].name").value("기본 정책"))
                 .andExpect(jsonPath("$.data[0].policyType").value("ONCE"));
+    }
+
+    @Test
+    @DisplayName("우리 가족 정책 목록 조회 API 성공")
+    void getFamilyPoliciesSuccess() throws Exception {
+        // given
+        setAuthentication();
+        BlockPolicyResponse response = BlockPolicyResponse.builder()
+                .id(10L)
+                .name("가족 정책")
+                .familyId(100L)
+                .build();
+
+        given(findFamilyBlockPolicyService.findAllByFamilyId(1L, 100L)).willReturn(List.of(response));
+
+        // when & then
+        mockMvc.perform(get("/api/v1/policies/families")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.data[0].name").value("가족 정책"))
+                .andExpect(jsonPath("$.data[0].familyId").value(100L));
     }
 }

--- a/src/test/java/hotspot/user/policy/infrastructure/BlockPolicyRepositoryImplTest.java
+++ b/src/test/java/hotspot/user/policy/infrastructure/BlockPolicyRepositoryImplTest.java
@@ -70,4 +70,26 @@ class BlockPolicyRepositoryImplTest {
         assertThat(result).hasSize(2);
         assertThat(result.get(0).getId()).isEqualTo(1L);
     }
+
+    @Test
+    @DisplayName("성공: 특정 가족 ID로 해당 가족이 생성한 정책 목록을 조회한다")
+    void findAllByFamilyIdSuccess() {
+        // given
+        Long familyId = 100L;
+        BlockPolicyEntity entity = BlockPolicyEntity.builder()
+                .blockPolicyId(10L)
+                .policyName("우리가족 정책")
+                .familyId(familyId)
+                .build();
+
+        given(blockPolicyJpaRepository.findAllByFamilyId(familyId)).willReturn(List.of(entity));
+
+        // when
+        List<BlockPolicy> result = blockPolicyRepository.findAllByFamilyId(familyId);
+
+        // then
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getFamilyId()).isEqualTo(familyId);
+        assertThat(result.get(0).getName()).isEqualTo("우리가족 정책");
+    }
 }

--- a/src/test/java/hotspot/user/policy/service/FindFamilyBlockPolicyServiceImplTest.java
+++ b/src/test/java/hotspot/user/policy/service/FindFamilyBlockPolicyServiceImplTest.java
@@ -1,0 +1,121 @@
+package hotspot.user.policy.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import hotspot.user.common.exception.ApplicationException;
+import hotspot.user.common.exception.code.AuthErrorCode;
+import hotspot.user.common.exception.code.FamilyErrorCode;
+import hotspot.user.family.domain.Family;
+import hotspot.user.family.domain.FamilySubscription;
+import hotspot.user.family.service.port.FamilySubscriptionRepository;
+import hotspot.user.member.domain.FamilyRole;
+import hotspot.user.policy.controller.response.BlockPolicyResponse;
+import hotspot.user.policy.domain.BlockPolicy;
+import hotspot.user.policy.service.port.BlockPolicyRepository;
+
+/**
+ * 우리 가족 정책 조회 서비스(FindFamilyBlockPolicyServiceImpl) 단위 테스트
+ */
+@ExtendWith(MockitoExtension.class)
+class FindFamilyBlockPolicyServiceImplTest {
+
+    @Mock
+    private BlockPolicyRepository blockPolicyRepository;
+
+    @Mock
+    private FamilySubscriptionRepository familySubscriptionRepository;
+
+    @InjectMocks
+    private FindFamilyBlockPolicyServiceImpl findFamilyBlockPolicyService;
+
+    @Test
+    @DisplayName("성공: OWNER 권한을 가진 사용자가 본인 가족의 정책 목록을 조회한다")
+    void findFamilyPoliciesSuccess() {
+        // given
+        Long memberId = 1L;
+        Long familyId = 100L;
+
+        Family family = Family.builder().id(familyId).build();
+        FamilySubscription familySub = FamilySubscription.builder()
+                .family(family)
+                .familyRole(FamilyRole.OWNER)
+                .build();
+
+        BlockPolicy policy = BlockPolicy.builder().id(10L).name("가족 정책").familyId(familyId).build();
+
+        given(familySubscriptionRepository.findByMemberId(memberId)).willReturn(Optional.of(familySub));
+        given(blockPolicyRepository.findAllByFamilyId(familyId)).willReturn(List.of(policy));
+
+        // when
+        List<BlockPolicyResponse> result = findFamilyBlockPolicyService.findAllByFamilyId(memberId, familyId);
+
+        // then
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).name()).isEqualTo("가족 정책");
+    }
+
+    @Test
+    @DisplayName("실패: 가족 서비스에 가입되지 않은 회원이 조회 시도 시 예외가 발생한다")
+    void findFamilyPoliciesFailByNotSubscribed() {
+        // given
+        Long memberId = 1L;
+        given(familySubscriptionRepository.findByMemberId(memberId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> findFamilyBlockPolicyService.findAllByFamilyId(memberId, 100L))
+                .isInstanceOf(ApplicationException.class)
+                .hasMessage(FamilyErrorCode.FAMILY_SUBSCRIPTION_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("실패: 요청한 가족 ID가 실제 소속된 가족 ID와 다를 경우 예외가 발생한다")
+    void findFamilyPoliciesFailByOtherFamily() {
+        // given
+        Long memberId = 1L;
+        Long myFamilyId = 100L;
+        Long otherFamilyId = 200L;
+
+        FamilySubscription familySub = FamilySubscription.builder()
+                .family(Family.builder().id(myFamilyId).build())
+                .build();
+
+        given(familySubscriptionRepository.findByMemberId(memberId)).willReturn(Optional.of(familySub));
+
+        // when & then
+        assertThatThrownBy(() -> findFamilyBlockPolicyService.findAllByFamilyId(memberId, otherFamilyId))
+                .isInstanceOf(ApplicationException.class)
+                .hasMessage(FamilyErrorCode.NOT_FAMILY_MEMBER.getMessage());
+    }
+
+    @Test
+    @DisplayName("실패: 조회 권한이 없는 역할(CHILD)이 조회 시도 시 예외가 발생한다")
+    void findFamilyPoliciesFailByAccessDenied() {
+        // given
+        Long memberId = 1L;
+        Long familyId = 100L;
+
+        FamilySubscription familySub = FamilySubscription.builder()
+                .family(Family.builder().id(familyId).build())
+                .familyRole(FamilyRole.CHILD) // 권한 없음
+                .build();
+
+        given(familySubscriptionRepository.findByMemberId(memberId)).willReturn(Optional.of(familySub));
+
+        // when & then
+        assertThatThrownBy(() -> findFamilyBlockPolicyService.findAllByFamilyId(memberId, familyId))
+                .isInstanceOf(ApplicationException.class)
+                .hasMessage(AuthErrorCode.ACCESS_DENIED.getMessage());
+    }
+}

--- a/src/test/java/hotspot/user/policy/service/FindFamilyBlockPolicyServiceImplTest.java
+++ b/src/test/java/hotspot/user/policy/service/FindFamilyBlockPolicyServiceImplTest.java
@@ -67,6 +67,32 @@ class FindFamilyBlockPolicyServiceImplTest {
     }
 
     @Test
+    @DisplayName("성공: PARENT 권한을 가진 사용자가 본인 가족의 정책 목록을 조회한다")
+    void findFamilyPoliciesSuccessWithParentRole() {
+        // given
+        Long memberId = 1L;
+        Long familyId = 100L;
+
+        Family family = Family.builder().id(familyId).build();
+        FamilySubscription familySub = FamilySubscription.builder()
+                .family(family)
+                .familyRole(FamilyRole.PARENT) // PARENT 역할
+                .build();
+
+        BlockPolicy policy = BlockPolicy.builder().id(10L).name("가족 정책").familyId(familyId).build();
+
+        given(familySubscriptionRepository.findByMemberId(memberId)).willReturn(Optional.of(familySub));
+        given(blockPolicyRepository.findAllByFamilyId(familyId)).willReturn(List.of(policy));
+
+        // when
+        List<BlockPolicyResponse> result = findFamilyBlockPolicyService.findAllByFamilyId(memberId, familyId);
+
+        // then
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).name()).isEqualTo("가족 정책");
+    }
+
+    @Test
     @DisplayName("실패: 가족 서비스에 가입되지 않은 회원이 조회 시도 시 예외가 발생한다")
     void findFamilyPoliciesFailByNotSubscribed() {
         // given

--- a/src/test/java/hotspot/user/usage/familyUsage/infrastructure/respository/FamilyUsageRedisRepositoryTest.java
+++ b/src/test/java/hotspot/user/usage/familyUsage/infrastructure/respository/FamilyUsageRedisRepositoryTest.java
@@ -6,7 +6,6 @@ import java.time.Clock;
 import java.time.Duration;
 import java.time.LocalDate;
 import java.time.ZoneId;
-import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;

--- a/src/test/java/hotspot/user/usage/familyUsage/infrastructure/respository/FamilyUsageRedisRepositoryTest.java
+++ b/src/test/java/hotspot/user/usage/familyUsage/infrastructure/respository/FamilyUsageRedisRepositoryTest.java
@@ -98,8 +98,7 @@ class FamilyUsageRedisRepositoryTest {
     @DisplayName("가족 사용량 정상 조회")
     void shouldReturnFamilyUsageSuccessfully() {
 
-        String yyyyMM = LocalDate.now()
-                .format(DateTimeFormatter.ofPattern("yyyyMM"));
+        String yyyyMM = "202602";
 
         // 가족 한도 20GB
         redisTemplate.opsForHash().put(


### PR DESCRIPTION
## 🎫 지라 티켓

<!-- 지라 티켓을 작성해주세요 ex) HOTSPOT-123 -->
HOTSPOT-201

---

## 🔗 GitHub 이슈
<!-- 자동 close를 원하면 아래 형식으로 작성
예) Closes #12
-->
#104 

---


## ✅ 작업 사항

<!-- 작업한 부분을 설명해주세요. -->

가족 전용 정책 조회 기능 추가

  ---


  1. Controller 
   * `BlockPolicyController`:
       * 우리 가족이 생성한 정책만 별도로 조회할 수 있는 `GET /api/v1/policies/families` 엔드포인트를 추가

<br/>

  2. Service
   * `FindFamilyBlockPolicyServiceImpl` (NEW):
       * 실시간 권한 확인: JWT 토큰 정보에 의존하지 않고, DB에서 해당 회원의 최신 정보를 직접 조회하여 OWNER/PARENT 권한을 검증
       * 소속 검증: 요청한 familyId가 사용자의 실제 현재 소속 가족과 일치하는지 확인하여 보안성을 강화
   * `BlockPolicyRepository`:
       *` findAllByFamilyId(Long familyId)` 메서드를 추가하여 특정 가족 소속 정책만 조회할 수 있도록 추가

<br/>

  3. Repository
   * `BlockPolicyRepositoryImpl`:
       * 포트의 규격에 맞춰 특정 가족 ID 기반의 조회 기능을 구현했습니다.
   * `BlockPolicyJpaRepository`:
       * Spring Data JPA의 쿼리 메소드 기능을 활용하여 `findAllByFamilyId`를 정의


---

## 📋 체크리스트

<!-- PR 제출 전 확인해주세요. 해당 항목에 [x]로 체크해주세요. -->

- [x] 코드가 정상적으로 빌드됩니다.
- [x] 관련 테스트 코드를 작성했습니다.
- [x] 기존 테스트가 모두 통과합니다.
- [x] 코드 스타일(Spotless, Checkstyle)을 준수합니다.
- [x] Jira 티켓 상태를 In Review / Done으로 변경했습니다.

---

## ⌨ 기타
