### PR TITLE
[HOTSPOT-201] 가족 생성 정책 상태 업데이트 (비/활성화) API 구현

### DIFF
--- a/src/main/java/hotspot/user/policy/controller/BlockPolicyController.java
+++ b/src/main/java/hotspot/user/policy/controller/BlockPolicyController.java
@@ -2,11 +2,12 @@ package hotspot.user.policy.controller;
 
 import java.util.List;
 
+import hotspot.user.policy.controller.port.UpdateFamilyBlockPolicyStatusService;
+import hotspot.user.policy.controller.request.UpdateFamilyBlockPolicyStatusRequest;
+import hotspot.user.policy.controller.response.UpdateFamilyBlockPolicyStatusResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import hotspot.user.common.ApiResponse;
 import hotspot.user.common.security.PrincipalDetails;
@@ -26,6 +27,7 @@ public class BlockPolicyController implements BlockPolicyApi {
 
     private final FindBlockPolicyService findBlockPolicyService;
     private final FindFamilyBlockPolicyService findFamilyBlockPolicyService; // 우리 가족이 생성한 정책 조회
+    private final UpdateFamilyBlockPolicyStatusService updateFamilyBlockPolicyStatusService; // 우리 가족의 정책 상태 업데이트(비/활성화)
 
     @Override
     @GetMapping
@@ -45,6 +47,21 @@ public class BlockPolicyController implements BlockPolicyApi {
         Long familyId = principal.getFamilyId();
 
         List<BlockPolicyResponse> policiesList = findFamilyBlockPolicyService.findAllByFamilyId(memberId, familyId);
+
+        return ResponseEntity.ok()
+                .body(ApiResponse.success(policiesList));
+    }
+
+    @Override
+    @PatchMapping("/families")
+    public ResponseEntity<ApiResponse<UpdateFamilyBlockPolicyStatusResponse>> updateFamilyBlockPolicies(
+            @RequestBody UpdateFamilyBlockPolicyStatusRequest request,
+            @AuthenticationPrincipal PrincipalDetails principal) {
+
+        Long memberId = principal.getId();
+        Long familyId = principal.getFamilyId();
+
+        UpdateFamilyBlockPolicyStatusResponse policiesList = updateFamilyBlockPolicyStatusService.updateFamilyBlockPolicyStatus(request, memberId, familyId);
 
         return ResponseEntity.ok()
                 .body(ApiResponse.success(policiesList));

--- a/src/main/java/hotspot/user/policy/controller/BlockPolicyController.java
+++ b/src/main/java/hotspot/user/policy/controller/BlockPolicyController.java
@@ -3,6 +3,7 @@ package hotspot.user.policy.controller;
 import java.util.List;
 
 import jakarta.validation.Valid;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;

--- a/src/main/java/hotspot/user/policy/controller/BlockPolicyController.java
+++ b/src/main/java/hotspot/user/policy/controller/BlockPolicyController.java
@@ -2,6 +2,7 @@ package hotspot.user.policy.controller;
 
 import java.util.List;
 
+import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -56,10 +57,11 @@ public class BlockPolicyController implements BlockPolicyApi {
                 .body(ApiResponse.success(policiesList));
     }
 
+    // 가족 정책 isActive 업데이트
     @Override
     @PatchMapping("/families")
     public ResponseEntity<ApiResponse<UpdateFamilyBlockPolicyStatusResponse>> updateFamilyBlockPolicies(
-            @RequestBody UpdateFamilyBlockPolicyStatusRequest request,
+            @RequestBody @Valid UpdateFamilyBlockPolicyStatusRequest request,
             @AuthenticationPrincipal PrincipalDetails principal) {
 
         Long memberId = principal.getId();

--- a/src/main/java/hotspot/user/policy/controller/BlockPolicyController.java
+++ b/src/main/java/hotspot/user/policy/controller/BlockPolicyController.java
@@ -2,18 +2,22 @@ package hotspot.user.policy.controller;
 
 import java.util.List;
 
-import hotspot.user.policy.controller.port.UpdateFamilyBlockPolicyStatusService;
-import hotspot.user.policy.controller.request.UpdateFamilyBlockPolicyStatusRequest;
-import hotspot.user.policy.controller.response.UpdateFamilyBlockPolicyStatusResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 import hotspot.user.common.ApiResponse;
 import hotspot.user.common.security.PrincipalDetails;
 import hotspot.user.policy.controller.port.FindBlockPolicyService;
 import hotspot.user.policy.controller.port.FindFamilyBlockPolicyService;
+import hotspot.user.policy.controller.port.UpdateFamilyBlockPolicyStatusService;
+import hotspot.user.policy.controller.request.UpdateFamilyBlockPolicyStatusRequest;
 import hotspot.user.policy.controller.response.BlockPolicyResponse;
+import hotspot.user.policy.controller.response.UpdateFamilyBlockPolicyStatusResponse;
 import hotspot.user.policy.controller.swagger.BlockPolicyApi;
 import lombok.RequiredArgsConstructor;
 
@@ -61,7 +65,8 @@ public class BlockPolicyController implements BlockPolicyApi {
         Long memberId = principal.getId();
         Long familyId = principal.getFamilyId();
 
-        UpdateFamilyBlockPolicyStatusResponse policiesList = updateFamilyBlockPolicyStatusService.updateFamilyBlockPolicyStatus(request, memberId, familyId);
+        UpdateFamilyBlockPolicyStatusResponse policiesList = updateFamilyBlockPolicyStatusService
+                .updateFamilyBlockPolicyStatus(request, memberId, familyId);
 
         return ResponseEntity.ok()
                 .body(ApiResponse.success(policiesList));

--- a/src/main/java/hotspot/user/policy/controller/port/UpdateFamilyBlockPolicyStatusService.java
+++ b/src/main/java/hotspot/user/policy/controller/port/UpdateFamilyBlockPolicyStatusService.java
@@ -1,10 +1,7 @@
 package hotspot.user.policy.controller.port;
 
-import hotspot.user.member.domain.FamilyRole;
 import hotspot.user.policy.controller.request.UpdateFamilyBlockPolicyStatusRequest;
-import hotspot.user.policy.controller.request.UpdatePolicySubRequest;
 import hotspot.user.policy.controller.response.UpdateFamilyBlockPolicyStatusResponse;
-import hotspot.user.policy.controller.response.UpdatePolicySubResponse;
 
 /**
  * 가족 정책 상태 업데이트 서비스 (비/활성화)

--- a/src/main/java/hotspot/user/policy/controller/port/UpdateFamilyBlockPolicyStatusService.java
+++ b/src/main/java/hotspot/user/policy/controller/port/UpdateFamilyBlockPolicyStatusService.java
@@ -1,0 +1,17 @@
+package hotspot.user.policy.controller.port;
+
+import hotspot.user.member.domain.FamilyRole;
+import hotspot.user.policy.controller.request.UpdateFamilyBlockPolicyStatusRequest;
+import hotspot.user.policy.controller.request.UpdatePolicySubRequest;
+import hotspot.user.policy.controller.response.UpdateFamilyBlockPolicyStatusResponse;
+import hotspot.user.policy.controller.response.UpdatePolicySubResponse;
+
+/**
+ * 가족 정책 상태 업데이트 서비스 (비/활성화)
+ */
+public interface UpdateFamilyBlockPolicyStatusService {
+    UpdateFamilyBlockPolicyStatusResponse updateFamilyBlockPolicyStatus(
+            UpdateFamilyBlockPolicyStatusRequest request,
+            Long memberId,
+            Long requesterFamilyId);
+}

--- a/src/main/java/hotspot/user/policy/controller/request/UpdateFamilyBlockPolicyStatusRequest.java
+++ b/src/main/java/hotspot/user/policy/controller/request/UpdateFamilyBlockPolicyStatusRequest.java
@@ -1,8 +1,8 @@
 package hotspot.user.policy.controller.request;
 
-import jakarta.validation.constraints.NotNull;
-
 import java.util.List;
+
+import jakarta.validation.constraints.NotNull;
 
 
 

--- a/src/main/java/hotspot/user/policy/controller/request/UpdateFamilyBlockPolicyStatusRequest.java
+++ b/src/main/java/hotspot/user/policy/controller/request/UpdateFamilyBlockPolicyStatusRequest.java
@@ -1,0 +1,17 @@
+package hotspot.user.policy.controller.request;
+
+import jakarta.validation.constraints.NotNull;
+
+import java.util.List;
+
+
+
+/** 가족 정책 상태 업데이트 (비/활성화)
+ * @param familyId
+ * @param blockPolicyIdList
+ */
+public record UpdateFamilyBlockPolicyStatusRequest(
+        @NotNull Long familyId,
+        @NotNull List<Long> blockPolicyIdList
+) {
+}

--- a/src/main/java/hotspot/user/policy/controller/response/UpdateFamilyBlockPolicyStatusResponse.java
+++ b/src/main/java/hotspot/user/policy/controller/response/UpdateFamilyBlockPolicyStatusResponse.java
@@ -1,8 +1,8 @@
 package hotspot.user.policy.controller.response;
 
-import lombok.Builder;
-
 import java.util.List;
+
+import lombok.Builder;
 
 /**
  * 가족 정책 중 활성화된 정책 ID만 리턴하는 응답 dto

--- a/src/main/java/hotspot/user/policy/controller/response/UpdateFamilyBlockPolicyStatusResponse.java
+++ b/src/main/java/hotspot/user/policy/controller/response/UpdateFamilyBlockPolicyStatusResponse.java
@@ -1,0 +1,17 @@
+package hotspot.user.policy.controller.response;
+
+import lombok.Builder;
+
+import java.util.List;
+
+/**
+ * 가족 정책 중 활성화된 정책 ID만 리턴하는 응답 dto
+ * @param familyId
+ * @param blockedPolicyIdList
+ */
+@Builder
+public record UpdateFamilyBlockPolicyStatusResponse(
+        Long familyId,
+        List<Long> blockedPolicyIdList
+) {
+}

--- a/src/main/java/hotspot/user/policy/controller/swagger/BlockPolicyApi.java
+++ b/src/main/java/hotspot/user/policy/controller/swagger/BlockPolicyApi.java
@@ -61,9 +61,13 @@ public interface BlockPolicyApi {
     @ApiResponses(value = {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "업데이트 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "권한 없음\n"
-                    + "- AUTH_004: 해당 요청에 대한 접근 권한이 없습니다."),
+                    + "- FAMILY_003: 해당 구성원은 동일한 가족 그룹에 속해 있지 않습니다.\n"
+                    + "- AUTH_004: 해당 요청에 대한 접근 권한이 없습니다.\n"
+                    + "- POLICY_002: 관리자 또는 우리 가족이 직접 만든 정책만 사용할 수 있습니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "찾을 수 없음\n"
-                    + "- AUTH_001: 회원을 찾을 수 없습니다.")
+                    + "- MEMBER_001: 회원 정보를 찾을 수 없습니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     @PatchMapping("/families")
     ResponseEntity<ApiResponse<UpdateFamilyBlockPolicyStatusResponse>> updateFamilyBlockPolicies(

--- a/src/main/java/hotspot/user/policy/controller/swagger/BlockPolicyApi.java
+++ b/src/main/java/hotspot/user/policy/controller/swagger/BlockPolicyApi.java
@@ -15,7 +15,17 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import hotspot.user.policy.controller.request.UpdateFamilyBlockPolicyStatusRequest;
+import hotspot.user.policy.controller.response.UpdateFamilyBlockPolicyStatusResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "Policy", description = "차단 정책 관련 API")
 public interface BlockPolicyApi {
@@ -48,6 +58,21 @@ public interface BlockPolicyApi {
     })
     @GetMapping("/families")
     ResponseEntity<ApiResponse<List<BlockPolicyResponse>>> getFamilyPolicies(
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal PrincipalDetails principal
+    );
+
+    @Operation(summary = "우리 가족 정책 상태 업데이트 (비/활성화)", description = "우리 가족이 생성한 정책들의 활성화 상태를 일괄 업데이트합니다. OWNER 권한이 필요합니다.")
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "업데이트 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "권한 없음\n"
+                    + "- AUTH_004: 해당 요청에 대한 접근 권한이 없습니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "찾을 수 없음\n"
+                    + "- AUTH_001: 회원을 찾을 수 없습니다.")
+    })
+    @PatchMapping("/families")
+    ResponseEntity<ApiResponse<UpdateFamilyBlockPolicyStatusResponse>> updateFamilyBlockPolicies(
+            @RequestBody UpdateFamilyBlockPolicyStatusRequest request,
             @Parameter(hidden = true)
             @AuthenticationPrincipal PrincipalDetails principal
     );

--- a/src/main/java/hotspot/user/policy/controller/swagger/BlockPolicyApi.java
+++ b/src/main/java/hotspot/user/policy/controller/swagger/BlockPolicyApi.java
@@ -5,17 +5,14 @@ import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 
 import hotspot.user.common.ApiResponse;
 import hotspot.user.common.exception.ErrorResponse;
 import hotspot.user.common.security.PrincipalDetails;
-import hotspot.user.policy.controller.response.BlockPolicyResponse;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import hotspot.user.policy.controller.request.UpdateFamilyBlockPolicyStatusRequest;
+import hotspot.user.policy.controller.response.BlockPolicyResponse;
 import hotspot.user.policy.controller.response.UpdateFamilyBlockPolicyStatusResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -23,9 +20,6 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "Policy", description = "차단 정책 관련 API")
 public interface BlockPolicyApi {
@@ -62,7 +56,8 @@ public interface BlockPolicyApi {
             @AuthenticationPrincipal PrincipalDetails principal
     );
 
-    @Operation(summary = "우리 가족 정책 상태 업데이트 (비/활성화)", description = "우리 가족이 생성한 정책들의 활성화 상태를 일괄 업데이트합니다. OWNER 권한이 필요합니다.")
+    @Operation(summary = "우리 가족 정책 상태 업데이트 (비/활성화)",
+            description = "우리 가족이 생성한 정책들의 활성화 상태를 일괄 업데이트합니다. OWNER 권한이 필요합니다.")
     @ApiResponses(value = {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "업데이트 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "권한 없음\n"

--- a/src/main/java/hotspot/user/policy/domain/BlockPolicy.java
+++ b/src/main/java/hotspot/user/policy/domain/BlockPolicy.java
@@ -29,4 +29,9 @@ public class BlockPolicy {
         return this.familyId == null || this.familyId.equals(requesterFamilyId);
     }
 
+    // 정책 상태 업데이트
+    public void updateIsActive(boolean isActive) {
+        this.isActive = isActive;
+    }
+
 }

--- a/src/main/java/hotspot/user/policy/domain/mapper/PolicySubMapper.java
+++ b/src/main/java/hotspot/user/policy/domain/mapper/PolicySubMapper.java
@@ -19,7 +19,7 @@ public class PolicySubMapper {
         }
 
         return BlockPolicyResponse.builder()
-                .id(policySub.getId())
+                .id(blockPolicy.getId()) // policy_sub_id 대신 실제 block_policy_id 사용
                 .name(blockPolicy.getName())
                 .familyId(blockPolicy.getFamilyId())
                 .policyType(blockPolicy.getPolicyType())

--- a/src/main/java/hotspot/user/policy/infrastructure/BlockPolicyJpaRepository.java
+++ b/src/main/java/hotspot/user/policy/infrastructure/BlockPolicyJpaRepository.java
@@ -4,10 +4,23 @@ import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
 import hotspot.user.policy.infrastructure.entity.BlockPolicyEntity;
 
 public interface BlockPolicyJpaRepository extends JpaRepository<BlockPolicyEntity, Long> {
     List<BlockPolicyEntity> findAllByIsActiveTrueAndFamilyIdIsNull();
     List<BlockPolicyEntity> findAllByFamilyId(Long familyId); // 우리 가족이 생성한 정책 조회
 
+    // N+1 SELECT를 방지하기 위한 벌크 UPDATE 쿼리 (비활성화, isActive = false)
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE BlockPolicyEntity b SET b.isActive = false WHERE b.blockPolicyId IN :ids")
+    void bulkDeActive(@Param("ids") List<Long> ids);
+
+    // N+1 SELECT를 방지하기 위한 벌크 UPDATE 쿼리 (활성화, isActive = true)
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE BlockPolicyEntity b SET b.isActive = true WHERE b.blockPolicyId IN :ids")
+    void bulkActivate(@Param("ids") List<Long> ids);
 }

--- a/src/main/java/hotspot/user/policy/infrastructure/BlockPolicyJpaRepository.java
+++ b/src/main/java/hotspot/user/policy/infrastructure/BlockPolicyJpaRepository.java
@@ -3,7 +3,6 @@ package hotspot.user.policy.infrastructure;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;

--- a/src/main/java/hotspot/user/policy/infrastructure/BlockPolicyRepositoryImpl.java
+++ b/src/main/java/hotspot/user/policy/infrastructure/BlockPolicyRepositoryImpl.java
@@ -36,4 +36,14 @@ public class BlockPolicyRepositoryImpl implements BlockPolicyRepository {
                 .map(BlockPolicyEntity::entityToDomain)
                 .toList();
     }
+
+    @Override
+    public void bulkActivate(List<Long> ids) {
+        blockPolicyJpaRepository.bulkActivate(ids);
+    }
+
+    @Override
+    public void bulkDeActive(List<Long> ids) {
+        blockPolicyJpaRepository.bulkDeActive(ids);
+    }
 }

--- a/src/main/java/hotspot/user/policy/infrastructure/PolicySubJpaRepository.java
+++ b/src/main/java/hotspot/user/policy/infrastructure/PolicySubJpaRepository.java
@@ -24,4 +24,9 @@ public interface PolicySubJpaRepository extends JpaRepository<PolicySubEntity, L
     @Modifying(clearAutomatically = true)
     @Query("UPDATE PolicySubEntity p SET p.isActive = true WHERE p.policySubId IN :ids")
     void bulkActivate(@Param("ids") List<Long> ids);
+
+    // 정책(BlockPolicy)이 비활성화될 때 해당 정책을 적용 중인 모든 회선 매핑 정보를 비활성화 처리
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE PolicySubEntity p SET p.isActive = false WHERE p.blockPolicy.blockPolicyId IN :blockPolicyIds")
+    void bulkDeActiveByBlockPolicyIds(@Param("blockPolicyIds") List<Long> blockPolicyIds);
 }

--- a/src/main/java/hotspot/user/policy/infrastructure/PolicySubRepositoryImpl.java
+++ b/src/main/java/hotspot/user/policy/infrastructure/PolicySubRepositoryImpl.java
@@ -70,4 +70,10 @@ public class PolicySubRepositoryImpl implements PolicySubRepository {
                 .map(PolicySubEntity::entityToDomain)
                 .toList();
     }
+
+    // 비활성화된 정책이 적용되어 있는 policy_sub 모두 isActive = false로 만들기
+    @Override
+    public void bulkDeActiveByBlockPolicyIds(List<Long> blockPolicyIds) {
+        policySubJpaRepository.bulkDeActiveByBlockPolicyIds(blockPolicyIds);
+    }
 }

--- a/src/main/java/hotspot/user/policy/service/UpdateFamilyBlockPolicyStatusServiceImpl.java
+++ b/src/main/java/hotspot/user/policy/service/UpdateFamilyBlockPolicyStatusServiceImpl.java
@@ -1,6 +1,8 @@
 package hotspot.user.policy.service;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -49,18 +51,21 @@ public class UpdateFamilyBlockPolicyStatusServiceImpl implements UpdateFamilyBlo
 
         // 3. 요청받은 ID 리스트가 모두 우리 가족의 정책인지 검증한다.
         List<Long> requestActiveIds = request.blockPolicyIdList();
-        validateAllPoliciesBelongToFamily(requestActiveIds, allFamilyPolicies);
+        Set<Long> requestActiveIdsSet = new HashSet<>(requestActiveIds);
+        validateAllPoliciesBelongToFamily(requestActiveIdsSet, allFamilyPolicies);
 
         // 4. 활성화할 ID 리스트와 비활성화할 ID 리스트를 분류한다.
-        List<Long> toActivate = allFamilyPolicies.stream()
-                .filter(p -> requestActiveIds.contains(p.getId()))
+        // 단일 순회 및 O(1) 조회로 최적화하기 위해 Map으로 변경
+        Map<Boolean, List<BlockPolicy>> partitionedPolicies = allFamilyPolicies.stream()
+                .collect(Collectors.partitioningBy(p -> requestActiveIdsSet.contains(p.getId())));
+
+        List<Long> toActivate = partitionedPolicies.get(true).stream()
                 .filter(p -> !p.isActive()) // 현재 꺼져있는 것만 켬
                 .map(BlockPolicy::getId)
                 .collect(Collectors.toList());
 
-        List<Long> toDeactivate = allFamilyPolicies.stream()
-                .filter(p -> !requestActiveIds.contains(p.getId()))
-                .filter(p -> p.isActive()) // 현재 켜져있는 것만 끔
+        List<Long> toDeactivate = partitionedPolicies.get(false).stream()
+                .filter(BlockPolicy::isActive) // 현재 켜져있는 것만 끔
                 .map(BlockPolicy::getId)
                 .collect(Collectors.toList());
 
@@ -94,7 +99,7 @@ public class UpdateFamilyBlockPolicyStatusServiceImpl implements UpdateFamilyBlo
         }
     }
 
-    private void validateAllPoliciesBelongToFamily(List<Long> requestIds, List<BlockPolicy> familyPolicies) {
+    private void validateAllPoliciesBelongToFamily(Set<Long> requestIds, List<BlockPolicy> familyPolicies) {
         Set<Long> familyPolicyIds = familyPolicies.stream()
                 .map(BlockPolicy::getId)
                 .collect(Collectors.toSet());

--- a/src/main/java/hotspot/user/policy/service/UpdateFamilyBlockPolicyStatusServiceImpl.java
+++ b/src/main/java/hotspot/user/policy/service/UpdateFamilyBlockPolicyStatusServiceImpl.java
@@ -1,0 +1,106 @@
+package hotspot.user.policy.service;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import hotspot.user.common.exception.ApplicationException;
+import hotspot.user.common.exception.code.AuthErrorCode;
+import hotspot.user.common.exception.code.FamilyErrorCode;
+import hotspot.user.common.exception.code.MemberErrorCode;
+import hotspot.user.common.exception.code.PolicyErrorCode;
+import hotspot.user.member.domain.FamilyRole;
+import hotspot.user.member.domain.MemberDetailInfo;
+import hotspot.user.member.service.port.MemberRepository;
+import hotspot.user.policy.controller.port.UpdateFamilyBlockPolicyStatusService;
+import hotspot.user.policy.controller.request.UpdateFamilyBlockPolicyStatusRequest;
+import hotspot.user.policy.controller.response.UpdateFamilyBlockPolicyStatusResponse;
+import hotspot.user.policy.domain.BlockPolicy;
+import hotspot.user.policy.service.port.BlockPolicyRepository;
+import hotspot.user.policy.service.port.PolicySubRepository;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 우리 가족이 생성한 정책의 상태 (비/활성화) 업데이트하는 서비스 구현체
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class UpdateFamilyBlockPolicyStatusServiceImpl implements UpdateFamilyBlockPolicyStatusService {
+
+    private final MemberRepository memberRepository;
+    private final BlockPolicyRepository blockPolicyRepository;
+    private final PolicySubRepository policySubRepository;
+
+    @Override
+    public UpdateFamilyBlockPolicyStatusResponse updateFamilyBlockPolicyStatus(
+            UpdateFamilyBlockPolicyStatusRequest request,
+            Long memberId,
+            Long requesterFamilyId) {
+
+        // 1. 요청자의 권한과 가족 소속을 검증한다. (OWNER만 가능)
+        validateOwnerAuthority(memberId, requesterFamilyId);
+
+        // 2. 해당 가족이 생성한 모든 정책을 조회한다.
+        List<BlockPolicy> allFamilyPolicies = blockPolicyRepository.findAllByFamilyId(requesterFamilyId);
+
+        // 3. 요청받은 ID 리스트가 모두 우리 가족의 정책인지 검증한다.
+        List<Long> requestActiveIds = request.blockPolicyIdList();
+        validateAllPoliciesBelongToFamily(requestActiveIds, allFamilyPolicies);
+
+        // 4. 활성화할 ID 리스트와 비활성화할 ID 리스트를 분류한다.
+        List<Long> toActivate = allFamilyPolicies.stream()
+                .filter(p -> requestActiveIds.contains(p.getId()))
+                .filter(p -> !p.isActive()) // 현재 꺼져있는 것만 켬
+                .map(BlockPolicy::getId)
+                .collect(Collectors.toList());
+
+        List<Long> toDeactivate = allFamilyPolicies.stream()
+                .filter(p -> !requestActiveIds.contains(p.getId()))
+                .filter(p -> p.isActive()) // 현재 켜져있는 것만 끔
+                .map(BlockPolicy::getId)
+                .collect(Collectors.toList());
+
+        // 5. 벌크 업데이트 수행
+        if (!toActivate.isEmpty()) {
+            blockPolicyRepository.bulkActivate(toActivate);
+        }
+        if (!toDeactivate.isEmpty()) {
+            blockPolicyRepository.bulkDeActive(toDeactivate);
+            // 정책이 비활성화되면 해당 정책을 적용 중인 모든 회선 매핑 정보도 비활성화 처리
+            policySubRepository.bulkDeActiveByBlockPolicyIds(toDeactivate);
+        }
+
+        return UpdateFamilyBlockPolicyStatusResponse.builder()
+                .familyId(requesterFamilyId)
+                .blockedPolicyIdList(requestActiveIds)
+                .build();
+    }
+
+    private void validateOwnerAuthority(Long memberId, Long requesterFamilyId) {
+        // MemberDetailInfo를 통해 역할(Role)과 소속 가족(FamilyId)을 한 번에 확인
+        MemberDetailInfo memberDetail = memberRepository.findDetailByIdAndEmail(memberId, null)
+                .orElseThrow(() -> new ApplicationException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+        if (!memberDetail.getFamilyId().equals(requesterFamilyId)) {
+            throw new ApplicationException(FamilyErrorCode.NOT_FAMILY_MEMBER);
+        }
+
+        if (memberDetail.getRole() != FamilyRole.OWNER) {
+            throw new ApplicationException(AuthErrorCode.ACCESS_DENIED);
+        }
+    }
+
+    private void validateAllPoliciesBelongToFamily(List<Long> requestIds, List<BlockPolicy> familyPolicies) {
+        Set<Long> familyPolicyIds = familyPolicies.stream()
+                .map(BlockPolicy::getId)
+                .collect(Collectors.toSet());
+
+        if (!familyPolicyIds.containsAll(requestIds)) {
+            throw new ApplicationException(PolicyErrorCode.POLICY_ACCESS_DENIED);
+        }
+    }
+}

--- a/src/main/java/hotspot/user/policy/service/port/BlockPolicyRepository.java
+++ b/src/main/java/hotspot/user/policy/service/port/BlockPolicyRepository.java
@@ -11,4 +11,6 @@ public interface BlockPolicyRepository {
     List<BlockPolicy> findAll();
     List<BlockPolicy> findAllById(List<Long> idList);
     List<BlockPolicy> findAllByFamilyId(Long familyId);
+    void bulkActivate(List<Long> ids);
+    void bulkDeActive(List<Long> ids);
 }

--- a/src/main/java/hotspot/user/policy/service/port/PolicySubRepository.java
+++ b/src/main/java/hotspot/user/policy/service/port/PolicySubRepository.java
@@ -13,4 +13,7 @@ public interface PolicySubRepository {
     List<PolicySub> findActiveBySubId(Long subId); // 활성화된 정책만 조회
 
     List<PolicySub> saveAll(List<PolicySub> policySubList);
+
+    // 비활성화된 정책이 적용되어 있는 policy_sub 모두 isActive = false로 만들기
+    void bulkDeActiveByBlockPolicyIds(List<Long> blockPolicyIds);
 }

--- a/src/test/java/hotspot/user/policy/controller/BlockPolicyControllerTest.java
+++ b/src/test/java/hotspot/user/policy/controller/BlockPolicyControllerTest.java
@@ -95,7 +95,8 @@ class BlockPolicyControllerTest {
                 .blockedPolicyIdList(activeIds)
                 .build();
 
-        given(updateFamilyBlockPolicyStatusService.updateFamilyBlockPolicyStatus(any(UpdateFamilyBlockPolicyStatusRequest.class), anyLong(), anyLong()))
+        given(updateFamilyBlockPolicyStatusService.updateFamilyBlockPolicyStatus(
+                any(UpdateFamilyBlockPolicyStatusRequest.class), anyLong(), anyLong()))
                 .willReturn(mockResponse);
 
         // when & then

--- a/src/test/java/hotspot/user/policy/controller/BlockPolicyControllerTest.java
+++ b/src/test/java/hotspot/user/policy/controller/BlockPolicyControllerTest.java
@@ -1,12 +1,16 @@
 package hotspot.user.policy.controller;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.util.List;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,6 +23,8 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.web.servlet.MockMvc;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import hotspot.user.common.security.PrincipalDetails;
 import hotspot.user.common.security.jwt.JwtFilter;
 import hotspot.user.common.security.jwt.JwtProvider;
@@ -26,12 +32,9 @@ import hotspot.user.member.domain.FamilyRole;
 import hotspot.user.member.domain.Status;
 import hotspot.user.policy.controller.port.FindBlockPolicyService;
 import hotspot.user.policy.controller.port.FindFamilyBlockPolicyService;
-import hotspot.user.policy.controller.response.BlockPolicyResponse;
-import hotspot.user.policy.domain.PolicyType;
-
-/**
- * 정책 Controller 테스트 코드
- */
+import hotspot.user.policy.controller.port.UpdateFamilyBlockPolicyStatusService;
+import hotspot.user.policy.controller.request.UpdateFamilyBlockPolicyStatusRequest;
+import hotspot.user.policy.controller.response.UpdateFamilyBlockPolicyStatusResponse;
 
 @WebMvcTest(BlockPolicyController.class)
 @AutoConfigureMockMvc(addFilters = false)
@@ -40,11 +43,17 @@ class BlockPolicyControllerTest {
     @Autowired
     private MockMvc mockMvc;
 
+    @Autowired
+    private ObjectMapper objectMapper;
+
     @MockBean
     private FindBlockPolicyService findBlockPolicyService;
 
     @MockBean
     private FindFamilyBlockPolicyService findFamilyBlockPolicyService;
+
+    @MockBean
+    private UpdateFamilyBlockPolicyStatusService updateFamilyBlockPolicyStatusService;
 
     @MockBean
     private JwtFilter jwtFilter;
@@ -55,60 +64,63 @@ class BlockPolicyControllerTest {
     @MockBean
     private JpaMetamodelMappingContext jpaMetamodelMappingContext;
 
-    private void setAuthentication() {
-        PrincipalDetails principal = PrincipalDetails.builder()
-                .id(1L)
-                .email("test@test.com")
-                .familyId(100L)
-                .role(FamilyRole.OWNER)
-                .status(Status.APPROVED)
-                .build();
+    private static final Long MEMBER_ID = 1L;
+    private static final Long FAMILY_ID = 100L;
+
+    @BeforeEach
+    void setUp() {
+        // PrincipalDetails Mocking 설정 (SecurityContext에 저장)
+        PrincipalDetails principal = new PrincipalDetails(
+                MEMBER_ID,
+                "test@email.com",
+                FAMILY_ID,
+                FamilyRole.OWNER,
+                Status.APPROVED);
 
         UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(
-                principal, null, principal.getAuthorities());
+                principal,
+                null,
+                principal.getAuthorities());
         SecurityContextHolder.getContext().setAuthentication(auth);
     }
 
     @Test
-    @DisplayName("전체 정책 목록 조회 API 성공")
-    void getAllPoliciesSuccess() throws Exception {
+    @DisplayName("성공: 우리 가족 정책 상태 업데이트 API 호출 시 200 OK와 결과를 반환한다")
+    void updateFamilyBlockPoliciesSuccess() throws Exception {
         // given
-        BlockPolicyResponse response = BlockPolicyResponse.builder()
-                .id(1L)
-                .name("기본 정책")
-                .policyType(PolicyType.ONCE)
+        List<Long> activeIds = List.of(1L, 2L);
+        UpdateFamilyBlockPolicyStatusRequest request = new UpdateFamilyBlockPolicyStatusRequest(FAMILY_ID, activeIds);
+        UpdateFamilyBlockPolicyStatusResponse mockResponse = UpdateFamilyBlockPolicyStatusResponse.builder()
+                .familyId(FAMILY_ID)
+                .blockedPolicyIdList(activeIds)
                 .build();
 
-        given(findBlockPolicyService.findAll()).willReturn(List.of(response));
+        given(updateFamilyBlockPolicyStatusService.updateFamilyBlockPolicyStatus(any(UpdateFamilyBlockPolicyStatusRequest.class), anyLong(), anyLong()))
+                .willReturn(mockResponse);
 
         // when & then
-        mockMvc.perform(get("/api/v1/policies")
-                        .contentType(MediaType.APPLICATION_JSON))
+        mockMvc.perform(patch("/api/v1/policies/families")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.status").value(200))
-                .andExpect(jsonPath("$.data[0].name").value("기본 정책"))
-                .andExpect(jsonPath("$.data[0].policyType").value("ONCE"));
+                .andExpect(jsonPath("$.data.familyId").value(FAMILY_ID))
+                .andExpect(jsonPath("$.data.blockedPolicyIdList").isArray())
+                .andExpect(jsonPath("$.data.blockedPolicyIdList[0]").value(1L))
+                .andExpect(jsonPath("$.data.blockedPolicyIdList[1]").value(2L));
     }
 
     @Test
-    @DisplayName("우리 가족 정책 목록 조회 API 성공")
-    void getFamilyPoliciesSuccess() throws Exception {
+    @DisplayName("실패: 필수 파라미터(familyId)가 누락된 경우 400 에러를 반환한다")
+    void updateFamilyBlockPoliciesFailNullFamilyId() throws Exception {
         // given
-        setAuthentication();
-        BlockPolicyResponse response = BlockPolicyResponse.builder()
-                .id(10L)
-                .name("가족 정책")
-                .familyId(100L)
-                .build();
-
-        given(findFamilyBlockPolicyService.findAllByFamilyId(1L, 100L)).willReturn(List.of(response));
+        UpdateFamilyBlockPolicyStatusRequest request = new UpdateFamilyBlockPolicyStatusRequest(null, List.of(1L));
 
         // when & then
-        mockMvc.perform(get("/api/v1/policies/families")
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.status").value(200))
-                .andExpect(jsonPath("$.data[0].name").value("가족 정책"))
-                .andExpect(jsonPath("$.data[0].familyId").value(100L));
+        mockMvc.perform(patch("/api/v1/policies/families")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isBadRequest());
     }
 }

--- a/src/test/java/hotspot/user/policy/controller/BlockPolicyControllerTest.java
+++ b/src/test/java/hotspot/user/policy/controller/BlockPolicyControllerTest.java
@@ -3,6 +3,7 @@ package hotspot.user.policy.controller;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -34,7 +35,9 @@ import hotspot.user.policy.controller.port.FindBlockPolicyService;
 import hotspot.user.policy.controller.port.FindFamilyBlockPolicyService;
 import hotspot.user.policy.controller.port.UpdateFamilyBlockPolicyStatusService;
 import hotspot.user.policy.controller.request.UpdateFamilyBlockPolicyStatusRequest;
+import hotspot.user.policy.controller.response.BlockPolicyResponse;
 import hotspot.user.policy.controller.response.UpdateFamilyBlockPolicyStatusResponse;
+import hotspot.user.policy.domain.PolicyType;
 
 @WebMvcTest(BlockPolicyController.class)
 @AutoConfigureMockMvc(addFilters = false)
@@ -82,6 +85,53 @@ class BlockPolicyControllerTest {
                 null,
                 principal.getAuthorities());
         SecurityContextHolder.getContext().setAuthentication(auth);
+    }
+
+    @Test
+    @DisplayName("성공: 전체 정책 목록 조회 시 200 OK와 목록을 반환한다")
+    void getAllPoliciesSuccess() throws Exception {
+        // given
+        BlockPolicyResponse policy = BlockPolicyResponse.builder()
+                .id(1L)
+                .name("Admin Policy")
+                .policyType(PolicyType.SCHEDULED)
+                .isActive(true)
+                .build();
+        given(findBlockPolicyService.findAll()).willReturn(List.of(policy));
+
+        // when & then
+        mockMvc.perform(get("/api/v1/policies")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data").isArray())
+                .andExpect(jsonPath("$.data[0].id").value(1L))
+                .andExpect(jsonPath("$.data[0].name").value("Admin Policy"));
+    }
+
+    @Test
+    @DisplayName("성공: 우리 가족 정책 목록 조회 시 200 OK와 목록을 반환한다")
+    void getFamilyPoliciesSuccess() throws Exception {
+        // given
+        BlockPolicyResponse policy = BlockPolicyResponse.builder()
+                .id(10L)
+                .name("Family Policy")
+                .familyId(FAMILY_ID)
+                .policyType(PolicyType.SCHEDULED)
+                .isActive(true)
+                .build();
+        given(findFamilyBlockPolicyService.findAllByFamilyId(anyLong(), anyLong()))
+                .willReturn(List.of(policy));
+
+        // when & then
+        mockMvc.perform(get("/api/v1/policies/families")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data").isArray())
+                .andExpect(jsonPath("$.data[0].id").value(10L))
+                .andExpect(jsonPath("$.data[0].familyId").value(FAMILY_ID))
+                .andExpect(jsonPath("$.data[0].name").value("Family Policy"));
     }
 
     @Test

--- a/src/test/java/hotspot/user/policy/domain/BlockPolicyTest.java
+++ b/src/test/java/hotspot/user/policy/domain/BlockPolicyTest.java
@@ -1,0 +1,75 @@
+package hotspot.user.policy.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class BlockPolicyTest {
+
+    @Test
+    @DisplayName("성공: 정책 상태 변경 시 isActive 필드가 업데이트된다")
+    void updateIsActiveSuccess() {
+        // given
+        BlockPolicy policy = BlockPolicy.builder()
+                .id(1L)
+                .name("정책1")
+                .isActive(false)
+                .build();
+
+        // when
+        policy.updateIsActive(true);
+
+        // then
+        assertThat(policy.isActive()).isTrue();
+    }
+
+    @Test
+    @DisplayName("성공: 요청자 가족 ID가 자신의 가족 ID와 같으면 접근을 허용한다")
+    void isAllowedToSuccessSameFamily() {
+        // given
+        Long familyId = 100L;
+        BlockPolicy policy = BlockPolicy.builder()
+                .id(1L)
+                .familyId(familyId)
+                .build();
+
+        // when
+        boolean result = policy.isAllowedTo(familyId);
+
+        // then
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    @DisplayName("성공: 관리자 정책(familyId=null)은 모든 가족의 접근을 허용한다")
+    void isAllowedToSuccessAdminPolicy() {
+        // given
+        BlockPolicy policy = BlockPolicy.builder()
+                .id(1L)
+                .familyId(null)
+                .build();
+
+        // when
+        boolean result = policy.isAllowedTo(100L);
+
+        // then
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    @DisplayName("실패: 요청자 가족 ID가 정책의 가족 ID와 다르면 접근을 거부한다")
+    void isAllowedToFailDifferentFamily() {
+        // given
+        BlockPolicy policy = BlockPolicy.builder()
+                .id(1L)
+                .familyId(100L)
+                .build();
+
+        // when
+        boolean result = policy.isAllowedTo(200L);
+
+        // then
+        assertThat(result).isFalse();
+    }
+}

--- a/src/test/java/hotspot/user/policy/infrastructure/BlockPolicyRepositoryImplTest.java
+++ b/src/test/java/hotspot/user/policy/infrastructure/BlockPolicyRepositoryImplTest.java
@@ -3,6 +3,7 @@ package hotspot.user.policy.infrastructure;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
 
 import java.util.List;
 
@@ -91,5 +92,31 @@ class BlockPolicyRepositoryImplTest {
         assertThat(result).hasSize(1);
         assertThat(result.get(0).getFamilyId()).isEqualTo(familyId);
         assertThat(result.get(0).getName()).isEqualTo("우리가족 정책");
+    }
+
+    @Test
+    @DisplayName("성공: 정책들의 활성화 상태를 벌크 업데이트한다")
+    void bulkActivateSuccess() {
+        // given
+        List<Long> ids = List.of(1L, 2L);
+
+        // when
+        blockPolicyRepository.bulkActivate(ids);
+
+        // then
+        verify(blockPolicyJpaRepository).bulkActivate(ids);
+    }
+
+    @Test
+    @DisplayName("성공: 정책들의 비활성화 상태를 벌크 업데이트한다")
+    void bulkDeActiveSuccess() {
+        // given
+        List<Long> ids = List.of(1L, 2L);
+
+        // when
+        blockPolicyRepository.bulkDeActive(ids);
+
+        // then
+        verify(blockPolicyJpaRepository).bulkDeActive(ids);
     }
 }

--- a/src/test/java/hotspot/user/policy/infrastructure/PolicySubRepositoryImplTest.java
+++ b/src/test/java/hotspot/user/policy/infrastructure/PolicySubRepositoryImplTest.java
@@ -100,6 +100,19 @@ class PolicySubRepositoryImplTest {
     }
 
     @Test
+    @DisplayName("성공: 정책 ID 리스트로 해당 정책을 적용 중인 모든 회선 매핑 정보를 벌크 비활성화한다")
+    void bulkDeActiveByBlockPolicyIdsSuccess() {
+        // given
+        List<Long> blockPolicyIds = List.of(50L, 60L);
+
+        // when
+        repository.bulkDeActiveByBlockPolicyIds(blockPolicyIds);
+
+        // then
+        verify(jpaRepository).bulkDeActiveByBlockPolicyIds(blockPolicyIds);
+    }
+
+    @Test
     @DisplayName("성공: 신규 데이터만 있는 경우 벌크 업데이트는 호출되지 않는다")
     void saveAllOnlyNewSuccess() {
         // given

--- a/src/test/java/hotspot/user/policy/service/UpdateFamilyBlockPolicyStatusServiceImplTest.java
+++ b/src/test/java/hotspot/user/policy/service/UpdateFamilyBlockPolicyStatusServiceImplTest.java
@@ -20,7 +20,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import hotspot.user.common.exception.ApplicationException;
 import hotspot.user.common.exception.code.AuthErrorCode;
 import hotspot.user.common.exception.code.FamilyErrorCode;
-import hotspot.user.common.exception.code.MemberErrorCode;
 import hotspot.user.common.exception.code.PolicyErrorCode;
 import hotspot.user.member.domain.FamilyRole;
 import hotspot.user.member.domain.MemberDetailInfo;
@@ -46,8 +45,8 @@ class UpdateFamilyBlockPolicyStatusServiceImplTest {
     @InjectMocks
     private UpdateFamilyBlockPolicyStatusServiceImpl service;
 
-    private final Long MEMBER_ID = 1L;
-    private final Long FAMILY_ID = 100L;
+    private static final Long MEMBER_ID = 1L;
+    private static final Long FAMILY_ID = 100L;
 
     @Test
     @DisplayName("성공: 가족 소유 정책 상태를 일괄 동기화한다")
@@ -55,7 +54,8 @@ class UpdateFamilyBlockPolicyStatusServiceImplTest {
         // given
         // 1. 요청: 정책 1, 2를 활성화하고 싶음 (기존 3은 목록에 없음 -> 비활성화 대상)
         List<Long> requestActiveIds = List.of(1L, 2L);
-        UpdateFamilyBlockPolicyStatusRequest request = new UpdateFamilyBlockPolicyStatusRequest(FAMILY_ID, requestActiveIds);
+        UpdateFamilyBlockPolicyStatusRequest request = new UpdateFamilyBlockPolicyStatusRequest(
+                FAMILY_ID, requestActiveIds);
 
         // 2. 권한 검증용 Mock
         MemberDetailInfo memberDetail = MemberDetailInfo.builder()
@@ -71,7 +71,8 @@ class UpdateFamilyBlockPolicyStatusServiceImplTest {
         given(blockPolicyRepository.findAllByFamilyId(FAMILY_ID)).willReturn(List.of(p1, p2, p3));
 
         // when
-        UpdateFamilyBlockPolicyStatusResponse response = service.updateFamilyBlockPolicyStatus(request, MEMBER_ID, FAMILY_ID);
+        UpdateFamilyBlockPolicyStatusResponse response = service
+                .updateFamilyBlockPolicyStatus(request, MEMBER_ID, FAMILY_ID);
 
         // then
         // - p2는 켜져야 함 (Activate)
@@ -89,7 +90,8 @@ class UpdateFamilyBlockPolicyStatusServiceImplTest {
     @DisplayName("실패: 요청자가 가족의 OWNER가 아니면 예외가 발생한다")
     void validateOwnerAuthorityFailNotOwner() {
         // given
-        UpdateFamilyBlockPolicyStatusRequest request = new UpdateFamilyBlockPolicyStatusRequest(FAMILY_ID, List.of(1L));
+        UpdateFamilyBlockPolicyStatusRequest request = new UpdateFamilyBlockPolicyStatusRequest(
+                FAMILY_ID, List.of(1L));
         MemberDetailInfo memberDetail = MemberDetailInfo.builder()
                 .familyId(FAMILY_ID)
                 .role(FamilyRole.PARENT) // PARENT는 권한 없음
@@ -106,7 +108,8 @@ class UpdateFamilyBlockPolicyStatusServiceImplTest {
     @DisplayName("실패: 요청자의 가족 ID와 회원의 소속 가족 ID가 다르면 예외가 발생한다")
     void validateOwnerAuthorityFailDifferentFamily() {
         // given
-        UpdateFamilyBlockPolicyStatusRequest request = new UpdateFamilyBlockPolicyStatusRequest(FAMILY_ID, List.of(1L));
+        UpdateFamilyBlockPolicyStatusRequest request = new UpdateFamilyBlockPolicyStatusRequest(
+                FAMILY_ID, List.of(1L));
         MemberDetailInfo memberDetail = MemberDetailInfo.builder()
                 .familyId(200L) // 다른 가족
                 .role(FamilyRole.OWNER)
@@ -125,7 +128,8 @@ class UpdateFamilyBlockPolicyStatusServiceImplTest {
         // given
         // 요청에는 1번(가족꺼), 999번(타인꺼) 포함
         List<Long> requestActiveIds = List.of(1L, 999L);
-        UpdateFamilyBlockPolicyStatusRequest request = new UpdateFamilyBlockPolicyStatusRequest(FAMILY_ID, requestActiveIds);
+        UpdateFamilyBlockPolicyStatusRequest request = new UpdateFamilyBlockPolicyStatusRequest(
+                FAMILY_ID, requestActiveIds);
 
         MemberDetailInfo memberDetail = MemberDetailInfo.builder()
                 .familyId(FAMILY_ID)
@@ -149,7 +153,8 @@ class UpdateFamilyBlockPolicyStatusServiceImplTest {
     void updateNoChangesNoBulkCall() {
         // given
         List<Long> requestActiveIds = List.of(1L);
-        UpdateFamilyBlockPolicyStatusRequest request = new UpdateFamilyBlockPolicyStatusRequest(FAMILY_ID, requestActiveIds);
+        UpdateFamilyBlockPolicyStatusRequest request = new UpdateFamilyBlockPolicyStatusRequest(
+                FAMILY_ID, requestActiveIds);
 
         MemberDetailInfo memberDetail = MemberDetailInfo.builder()
                 .familyId(FAMILY_ID)

--- a/src/test/java/hotspot/user/policy/service/UpdateFamilyBlockPolicyStatusServiceImplTest.java
+++ b/src/test/java/hotspot/user/policy/service/UpdateFamilyBlockPolicyStatusServiceImplTest.java
@@ -1,0 +1,173 @@
+package hotspot.user.policy.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import hotspot.user.common.exception.ApplicationException;
+import hotspot.user.common.exception.code.AuthErrorCode;
+import hotspot.user.common.exception.code.FamilyErrorCode;
+import hotspot.user.common.exception.code.MemberErrorCode;
+import hotspot.user.common.exception.code.PolicyErrorCode;
+import hotspot.user.member.domain.FamilyRole;
+import hotspot.user.member.domain.MemberDetailInfo;
+import hotspot.user.member.service.port.MemberRepository;
+import hotspot.user.policy.controller.request.UpdateFamilyBlockPolicyStatusRequest;
+import hotspot.user.policy.controller.response.UpdateFamilyBlockPolicyStatusResponse;
+import hotspot.user.policy.domain.BlockPolicy;
+import hotspot.user.policy.service.port.BlockPolicyRepository;
+import hotspot.user.policy.service.port.PolicySubRepository;
+
+@ExtendWith(MockitoExtension.class)
+class UpdateFamilyBlockPolicyStatusServiceImplTest {
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private BlockPolicyRepository blockPolicyRepository;
+
+    @Mock
+    private PolicySubRepository policySubRepository;
+
+    @InjectMocks
+    private UpdateFamilyBlockPolicyStatusServiceImpl service;
+
+    private final Long MEMBER_ID = 1L;
+    private final Long FAMILY_ID = 100L;
+
+    @Test
+    @DisplayName("성공: 가족 소유 정책 상태를 일괄 동기화한다")
+    void updateFamilyBlockPolicyStatusSuccess() {
+        // given
+        // 1. 요청: 정책 1, 2를 활성화하고 싶음 (기존 3은 목록에 없음 -> 비활성화 대상)
+        List<Long> requestActiveIds = List.of(1L, 2L);
+        UpdateFamilyBlockPolicyStatusRequest request = new UpdateFamilyBlockPolicyStatusRequest(FAMILY_ID, requestActiveIds);
+
+        // 2. 권한 검증용 Mock
+        MemberDetailInfo memberDetail = MemberDetailInfo.builder()
+                .familyId(FAMILY_ID)
+                .role(FamilyRole.OWNER)
+                .build();
+        given(memberRepository.findDetailByIdAndEmail(MEMBER_ID, null)).willReturn(Optional.of(memberDetail));
+
+        // 3. 기존 가족 정책 Mock (1: 이미 활성, 2: 비활성, 3: 활성)
+        BlockPolicy p1 = BlockPolicy.builder().id(1L).isActive(true).build();
+        BlockPolicy p2 = BlockPolicy.builder().id(2L).isActive(false).build();
+        BlockPolicy p3 = BlockPolicy.builder().id(3L).isActive(true).build();
+        given(blockPolicyRepository.findAllByFamilyId(FAMILY_ID)).willReturn(List.of(p1, p2, p3));
+
+        // when
+        UpdateFamilyBlockPolicyStatusResponse response = service.updateFamilyBlockPolicyStatus(request, MEMBER_ID, FAMILY_ID);
+
+        // then
+        // - p2는 켜져야 함 (Activate)
+        verify(blockPolicyRepository).bulkActivate(List.of(2L));
+        // - p3는 꺼져야 함 (Deactivate)
+        verify(blockPolicyRepository).bulkDeActive(List.of(3L));
+        // - 정책이 꺼졌으므로 policy_sub 연관 데이터도 비활성화되어야 함
+        verify(policySubRepository).bulkDeActiveByBlockPolicyIds(List.of(3L));
+
+        assertThat(response.familyId()).isEqualTo(FAMILY_ID);
+        assertThat(response.blockedPolicyIdList()).containsExactlyInAnyOrder(1L, 2L);
+    }
+
+    @Test
+    @DisplayName("실패: 요청자가 가족의 OWNER가 아니면 예외가 발생한다")
+    void validateOwnerAuthorityFailNotOwner() {
+        // given
+        UpdateFamilyBlockPolicyStatusRequest request = new UpdateFamilyBlockPolicyStatusRequest(FAMILY_ID, List.of(1L));
+        MemberDetailInfo memberDetail = MemberDetailInfo.builder()
+                .familyId(FAMILY_ID)
+                .role(FamilyRole.PARENT) // PARENT는 권한 없음
+                .build();
+        given(memberRepository.findDetailByIdAndEmail(MEMBER_ID, null)).willReturn(Optional.of(memberDetail));
+
+        // when & then
+        assertThatThrownBy(() -> service.updateFamilyBlockPolicyStatus(request, MEMBER_ID, FAMILY_ID))
+                .isInstanceOf(ApplicationException.class)
+                .hasFieldOrPropertyWithValue("code", AuthErrorCode.ACCESS_DENIED);
+    }
+
+    @Test
+    @DisplayName("실패: 요청자의 가족 ID와 회원의 소속 가족 ID가 다르면 예외가 발생한다")
+    void validateOwnerAuthorityFailDifferentFamily() {
+        // given
+        UpdateFamilyBlockPolicyStatusRequest request = new UpdateFamilyBlockPolicyStatusRequest(FAMILY_ID, List.of(1L));
+        MemberDetailInfo memberDetail = MemberDetailInfo.builder()
+                .familyId(200L) // 다른 가족
+                .role(FamilyRole.OWNER)
+                .build();
+        given(memberRepository.findDetailByIdAndEmail(MEMBER_ID, null)).willReturn(Optional.of(memberDetail));
+
+        // when & then
+        assertThatThrownBy(() -> service.updateFamilyBlockPolicyStatus(request, MEMBER_ID, FAMILY_ID))
+                .isInstanceOf(ApplicationException.class)
+                .hasFieldOrPropertyWithValue("code", FamilyErrorCode.NOT_FAMILY_MEMBER);
+    }
+
+    @Test
+    @DisplayName("실패: 요청한 정책 ID 중 우리 가족이 생성하지 않은 ID가 포함되어 있으면 예외가 발생한다")
+    void validateAllPoliciesBelongToFamilyFail() {
+        // given
+        // 요청에는 1번(가족꺼), 999번(타인꺼) 포함
+        List<Long> requestActiveIds = List.of(1L, 999L);
+        UpdateFamilyBlockPolicyStatusRequest request = new UpdateFamilyBlockPolicyStatusRequest(FAMILY_ID, requestActiveIds);
+
+        MemberDetailInfo memberDetail = MemberDetailInfo.builder()
+                .familyId(FAMILY_ID)
+                .role(FamilyRole.OWNER)
+                .build();
+        given(memberRepository.findDetailByIdAndEmail(MEMBER_ID, null)).willReturn(Optional.of(memberDetail));
+
+        // 우리 가족 정책은 1, 2번뿐
+        BlockPolicy p1 = BlockPolicy.builder().id(1L).isActive(true).build();
+        BlockPolicy p2 = BlockPolicy.builder().id(2L).isActive(false).build();
+        given(blockPolicyRepository.findAllByFamilyId(FAMILY_ID)).willReturn(List.of(p1, p2));
+
+        // when & then
+        assertThatThrownBy(() -> service.updateFamilyBlockPolicyStatus(request, MEMBER_ID, FAMILY_ID))
+                .isInstanceOf(ApplicationException.class)
+                .hasFieldOrPropertyWithValue("code", PolicyErrorCode.POLICY_ACCESS_DENIED);
+    }
+
+    @Test
+    @DisplayName("성공: 변경 사항이 없는 경우(이미 요청 상태와 동일한 경우) 벌크 업데이트를 호출하지 않는다")
+    void updateNoChangesNoBulkCall() {
+        // given
+        List<Long> requestActiveIds = List.of(1L);
+        UpdateFamilyBlockPolicyStatusRequest request = new UpdateFamilyBlockPolicyStatusRequest(FAMILY_ID, requestActiveIds);
+
+        MemberDetailInfo memberDetail = MemberDetailInfo.builder()
+                .familyId(FAMILY_ID)
+                .role(FamilyRole.OWNER)
+                .build();
+        given(memberRepository.findDetailByIdAndEmail(MEMBER_ID, null)).willReturn(Optional.of(memberDetail));
+
+        // 이미 1번은 켜져있고, 2번은 꺼져있음 -> 요청(1번만 켜기)과 동일함
+        BlockPolicy p1 = BlockPolicy.builder().id(1L).isActive(true).build();
+        BlockPolicy p2 = BlockPolicy.builder().id(2L).isActive(false).build();
+        given(blockPolicyRepository.findAllByFamilyId(FAMILY_ID)).willReturn(List.of(p1, p2));
+
+        // when
+        service.updateFamilyBlockPolicyStatus(request, MEMBER_ID, FAMILY_ID);
+
+        // then
+        verify(blockPolicyRepository, never()).bulkActivate(anyList());
+        verify(blockPolicyRepository, never()).bulkDeActive(anyList());
+        verify(policySubRepository, never()).bulkDeActiveByBlockPolicyIds(anyList());
+    }
+}


### PR DESCRIPTION
## 🎫 지라 티켓

<!-- 지라 티켓을 작성해주세요 ex) HOTSPOT-123 -->
HOTSPOT-201

---

## 🔗 GitHub 이슈
<!-- 자동 close를 원하면 아래 형식으로 작성
예) Closes #12
-->
#104 

---


## ✅ 작업 사항

<!-- 작업한 부분을 설명해주세요. -->

 1. 기능 개요
  가족 관리자(OWNER)가 우리 가족이 생성한 정책들의 활성화 상태를 바꿀 수 있는 기능 (비활성화 <-> 활성화) API구현

---

  Controller
   * API 엔드포인트: `PATCH /api/v1/policies/families`

<br/>

  Service
   * 요청받은 ID 리스트를 기준으로 '활성화 대상'과 '비활성화 대상'을 분류하여 처리

<br/>


  Repository & Entity
   * 벌크 업데이트 도입: N+1 문제를 방지하기 위해 `@Modifying`과 `@Query`를 이용한 벌크 업데이트(bulkActivate, bulkDeActive) 방식 적용
   * 연쇄 비활성화 로직: 정책 마스터(`BlockPolicy`)가 비활성화될 때, 해당 정책을 적용 중인 모든 회선 매핑 정보(`PolicySub`)도 즉시 비활성화되도록 벌크 쿼리 추가

<br/>

  Domain
   * `BlockPolicy`
     * 도메인 모델 내에서 상태를 변경할 수 있는 updateIsActive 메서드 추가
     * 가족 소속 여부를 확인하는 권한 로직 보완

---

## 📋 체크리스트

<!-- PR 제출 전 확인해주세요. 해당 항목에 [x]로 체크해주세요. -->

- [x] 코드가 정상적으로 빌드됩니다.
- [x] 관련 테스트 코드를 작성했습니다.
- [x] 기존 테스트가 모두 통과합니다.
- [x] 코드 스타일(Spotless, Checkstyle)을 준수합니다.
- [x] Jira 티켓 상태를 In Review / Done으로 변경했습니다.

---

## ⌨ 기타
