### PR TITLE
[HOTSPOT-201] 가족 정책 삭제 API 구현

### DIFF
--- a/src/main/java/hotspot/user/policy/controller/BlockPolicyController.java
+++ b/src/main/java/hotspot/user/policy/controller/BlockPolicyController.java
@@ -82,7 +82,7 @@ public class BlockPolicyController implements BlockPolicyApi {
     // 우리 가족 정책 삭제 (단일, 일괄 모두 가능)
     @Override
     @DeleteMapping
-    public ResponseEntity<Void> deleteFamilyBlockPolicies(
+    public ResponseEntity<ApiResponse<Void>> deleteFamilyBlockPolicies(
             @RequestParam List<Long> policyIdList,
             @AuthenticationPrincipal PrincipalDetails principal) {
 
@@ -90,7 +90,8 @@ public class BlockPolicyController implements BlockPolicyApi {
         Long familyId = principal.getFamilyId();
         deleteFamilyBlockPolicyService.delete(policyIdList, memberId, familyId);
 
-        return ResponseEntity.noContent().build();
+        return ResponseEntity.ok()
+                .body(ApiResponse.success());
     }
 
 }

--- a/src/main/java/hotspot/user/policy/controller/BlockPolicyController.java
+++ b/src/main/java/hotspot/user/policy/controller/BlockPolicyController.java
@@ -2,14 +2,17 @@ package hotspot.user.policy.controller;
 
 import java.util.List;
 
+import hotspot.user.policy.controller.port.DeleteFamilyBlockPolicyService;
 import jakarta.validation.Valid;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import hotspot.user.common.ApiResponse;
@@ -34,6 +37,7 @@ public class BlockPolicyController implements BlockPolicyApi {
     private final FindBlockPolicyService findBlockPolicyService;
     private final FindFamilyBlockPolicyService findFamilyBlockPolicyService; // 우리 가족이 생성한 정책 조회
     private final UpdateFamilyBlockPolicyStatusService updateFamilyBlockPolicyStatusService; // 우리 가족의 정책 상태 업데이트(비/활성화)
+    private final DeleteFamilyBlockPolicyService deleteFamilyBlockPolicyService; // 우리 가족 정책 삭제
 
     @Override
     @GetMapping
@@ -73,6 +77,20 @@ public class BlockPolicyController implements BlockPolicyApi {
 
         return ResponseEntity.ok()
                 .body(ApiResponse.success(policiesList));
+    }
+
+    // 우리 가족 정책 삭제 (단일, 일괄 모두 가능)
+    @Override
+    @DeleteMapping
+    public ResponseEntity<Void> deleteFamilyBlockPolicies(
+            @RequestParam List<Long> policyIdList,
+            @AuthenticationPrincipal PrincipalDetails principal) {
+
+        Long memberId = principal.getId();
+        Long familyId = principal.getFamilyId();
+        deleteFamilyBlockPolicyService.delete(policyIdList, memberId, familyId);
+
+        return ResponseEntity.noContent().build();
     }
 
 }

--- a/src/main/java/hotspot/user/policy/controller/BlockPolicyController.java
+++ b/src/main/java/hotspot/user/policy/controller/BlockPolicyController.java
@@ -81,7 +81,7 @@ public class BlockPolicyController implements BlockPolicyApi {
 
     // 우리 가족 정책 삭제 (단일, 일괄 모두 가능)
     @Override
-    @DeleteMapping
+    @DeleteMapping("/families")
     public ResponseEntity<ApiResponse<Void>> deleteFamilyBlockPolicies(
             @RequestParam List<Long> policyIdList,
             @AuthenticationPrincipal PrincipalDetails principal) {

--- a/src/main/java/hotspot/user/policy/controller/BlockPolicyController.java
+++ b/src/main/java/hotspot/user/policy/controller/BlockPolicyController.java
@@ -2,7 +2,6 @@ package hotspot.user.policy.controller;
 
 import java.util.List;
 
-import hotspot.user.policy.controller.port.DeleteFamilyBlockPolicyService;
 import jakarta.validation.Valid;
 
 import org.springframework.http.ResponseEntity;
@@ -17,6 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import hotspot.user.common.ApiResponse;
 import hotspot.user.common.security.PrincipalDetails;
+import hotspot.user.policy.controller.port.DeleteFamilyBlockPolicyService;
 import hotspot.user.policy.controller.port.FindBlockPolicyService;
 import hotspot.user.policy.controller.port.FindFamilyBlockPolicyService;
 import hotspot.user.policy.controller.port.UpdateFamilyBlockPolicyStatusService;

--- a/src/main/java/hotspot/user/policy/controller/port/DeleteFamilyBlockPolicyService.java
+++ b/src/main/java/hotspot/user/policy/controller/port/DeleteFamilyBlockPolicyService.java
@@ -1,0 +1,11 @@
+package hotspot.user.policy.controller.port;
+
+
+import java.util.List;
+
+/**
+ * 가족 정책 삭제 서비스
+ */
+public interface DeleteFamilyBlockPolicyService {
+    void delete(List<Long> policyIdList, Long memberId, Long familyId);
+}

--- a/src/main/java/hotspot/user/policy/controller/swagger/BlockPolicyApi.java
+++ b/src/main/java/hotspot/user/policy/controller/swagger/BlockPolicyApi.java
@@ -81,7 +81,7 @@ public interface BlockPolicyApi {
     @Operation(summary = "우리 가족 정책 삭제",
             description = "우리 가족이 생성한 정책들을 삭제(Soft Delete)합니다. OWNER 권한이 필요합니다.")
     @ApiResponses(value = {
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "204", description = "삭제 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "삭제 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "권한 없음\n"
                     + "- FAMILY_003: 해당 구성원은 동일한 가족 그룹에 속해 있지 않습니다.\n"
                     + "- AUTH_004: 해당 요청에 대한 접근 권한이 없습니다.\n"

--- a/src/main/java/hotspot/user/policy/controller/swagger/BlockPolicyApi.java
+++ b/src/main/java/hotspot/user/policy/controller/swagger/BlockPolicyApi.java
@@ -4,9 +4,11 @@ import java.util.List;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 
 import hotspot.user.common.ApiResponse;
 import hotspot.user.common.exception.ErrorResponse;
@@ -72,6 +74,28 @@ public interface BlockPolicyApi {
     @PatchMapping("/families")
     ResponseEntity<ApiResponse<UpdateFamilyBlockPolicyStatusResponse>> updateFamilyBlockPolicies(
             @RequestBody UpdateFamilyBlockPolicyStatusRequest request,
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal PrincipalDetails principal
+    );
+
+    @Operation(summary = "우리 가족 정책 삭제",
+            description = "우리 가족이 생성한 정책들을 삭제(Soft Delete)합니다. OWNER 권한이 필요합니다.")
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "204", description = "삭제 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "권한 없음\n"
+                    + "- FAMILY_003: 해당 구성원은 동일한 가족 그룹에 속해 있지 않습니다.\n"
+                    + "- AUTH_004: 해당 요청에 대한 접근 권한이 없습니다.\n"
+                    + "- POLICY_002: 관리자 또는 우리 가족이 직접 만든 정책만 사용할 수 있습니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "찾을 수 없음\n"
+                    + "- MEMBER_001: 회원 정보를 찾을 수 없습니다.\n"
+                    + "- POLICY_001: 해당 정책을 찾을 수 없습니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @DeleteMapping
+    ResponseEntity<Void> deleteFamilyBlockPolicies(
+            @Parameter(description = "삭제할 정책 ID 리스트")
+            @RequestParam List<Long> policyIdList,
             @Parameter(hidden = true)
             @AuthenticationPrincipal PrincipalDetails principal
     );

--- a/src/main/java/hotspot/user/policy/controller/swagger/BlockPolicyApi.java
+++ b/src/main/java/hotspot/user/policy/controller/swagger/BlockPolicyApi.java
@@ -93,7 +93,7 @@ public interface BlockPolicyApi {
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     @DeleteMapping
-    ResponseEntity<Void> deleteFamilyBlockPolicies(
+    ResponseEntity<ApiResponse<Void>> deleteFamilyBlockPolicies(
             @Parameter(description = "삭제할 정책 ID 리스트")
             @RequestParam List<Long> policyIdList,
             @Parameter(hidden = true)

--- a/src/main/java/hotspot/user/policy/infrastructure/BlockPolicyJpaRepository.java
+++ b/src/main/java/hotspot/user/policy/infrastructure/BlockPolicyJpaRepository.java
@@ -22,4 +22,9 @@ public interface BlockPolicyJpaRepository extends JpaRepository<BlockPolicyEntit
     @Modifying(clearAutomatically = true)
     @Query("UPDATE BlockPolicyEntity b SET b.isActive = true WHERE b.blockPolicyId IN :ids")
     void bulkActivate(@Param("ids") List<Long> ids);
+
+    // N+1 SELECT를 방지하기 위한 벌크 Delete 쿼리 (isDeleted = true)
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE BlockPolicyEntity b SET b.isDeleted = true, b.isActive = false WHERE b.blockPolicyId IN :ids")
+    void bulkDelete(@Param("ids") List<Long> ids);
 }

--- a/src/main/java/hotspot/user/policy/infrastructure/BlockPolicyRepositoryImpl.java
+++ b/src/main/java/hotspot/user/policy/infrastructure/BlockPolicyRepositoryImpl.java
@@ -46,4 +46,10 @@ public class BlockPolicyRepositoryImpl implements BlockPolicyRepository {
     public void bulkDeActive(List<Long> ids) {
         blockPolicyJpaRepository.bulkDeActive(ids);
     }
+
+    // 가족 정책 삭제
+    @Override
+    public void bulkDelete(List<Long> ids) {
+        blockPolicyJpaRepository.bulkDelete(ids);
+    }
 }

--- a/src/main/java/hotspot/user/policy/service/DeleteFamilyBlockPolicyServiceImpl.java
+++ b/src/main/java/hotspot/user/policy/service/DeleteFamilyBlockPolicyServiceImpl.java
@@ -1,0 +1,75 @@
+package hotspot.user.policy.service;
+
+import hotspot.user.policy.controller.port.DeleteFamilyBlockPolicyService;
+import hotspot.user.policy.service.port.BlockPolicyRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import hotspot.user.common.exception.ApplicationException;
+import hotspot.user.common.exception.code.AuthErrorCode;
+import hotspot.user.common.exception.code.FamilyErrorCode;
+import hotspot.user.common.exception.code.MemberErrorCode;
+import hotspot.user.common.exception.code.PolicyErrorCode;
+import hotspot.user.member.domain.FamilyRole;
+import hotspot.user.member.domain.MemberDetailInfo;
+import hotspot.user.member.service.port.MemberRepository;
+import hotspot.user.policy.domain.BlockPolicy;
+
+import hotspot.user.policy.service.port.PolicySubRepository;
+
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class DeleteFamilyBlockPolicyServiceImpl implements DeleteFamilyBlockPolicyService {
+    private final MemberRepository memberRepository;
+    private final BlockPolicyRepository blockPolicyRepository;
+    private final PolicySubRepository policySubRepository;
+
+    @Override
+    public void delete(List<Long> policyIdList, Long memberId, Long familyId) {
+        // 1. 요청자의 OWNER 권한 및 가족 소속 검증
+        validateOwnerAuthority(memberId, familyId);
+
+        // 2. 삭제 대상 정책들이 실제로 해당 가족의 소유인지 검증
+        List<BlockPolicy> targetPolicies = blockPolicyRepository.findAllById(policyIdList);
+        validatePolicyOwnership(policyIdList, targetPolicies, familyId);
+
+        // 3. 연관 데이터(policy_sub) 처리: 정책이 삭제되므로 적용 중인 회선에서도 비활성화
+        policySubRepository.bulkDeActiveByBlockPolicyIds(policyIdList);
+
+        // 4. 정책 벌크 삭제 (Soft Delete) 수행
+        blockPolicyRepository.bulkDelete(policyIdList);
+    }
+
+    // 요청자가 OWNER인지 권한 검증
+    private void validateOwnerAuthority(Long memberId, Long requesterFamilyId) {
+        MemberDetailInfo memberDetail = memberRepository.findDetailByIdAndEmail(memberId, null)
+                .orElseThrow(() -> new ApplicationException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+        if (!memberDetail.getFamilyId().equals(requesterFamilyId)) {
+            throw new ApplicationException(FamilyErrorCode.NOT_FAMILY_MEMBER);
+        }
+
+        if (memberDetail.getRole() != FamilyRole.OWNER) {
+            throw new ApplicationException(AuthErrorCode.ACCESS_DENIED);
+        }
+    }
+
+    // 정책이 존재하는지 & 우리 가족의 정책인지 확인
+    private void validatePolicyOwnership(List<Long> requestIds, List<BlockPolicy> targetPolicies, Long familyId) {
+        if (targetPolicies.size() != requestIds.size()) {
+            throw new ApplicationException(PolicyErrorCode.POLICY_NOT_FOUND);
+        }
+
+        boolean hasAnotherFamilyPolicy = targetPolicies.stream()
+                .anyMatch(p -> p.getFamilyId() == null || !p.getFamilyId().equals(familyId));
+
+        if (hasAnotherFamilyPolicy) {
+            throw new ApplicationException(PolicyErrorCode.POLICY_ACCESS_DENIED);
+        }
+    }
+}

--- a/src/main/java/hotspot/user/policy/service/DeleteFamilyBlockPolicyServiceImpl.java
+++ b/src/main/java/hotspot/user/policy/service/DeleteFamilyBlockPolicyServiceImpl.java
@@ -1,6 +1,7 @@
 package hotspot.user.policy.service;
 
 import java.util.List;
+import java.util.Objects;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -49,7 +50,7 @@ public class DeleteFamilyBlockPolicyServiceImpl implements DeleteFamilyBlockPoli
         MemberDetailInfo memberDetail = memberRepository.findDetailByIdAndEmail(memberId, null)
                 .orElseThrow(() -> new ApplicationException(MemberErrorCode.MEMBER_NOT_FOUND));
 
-        if (!memberDetail.getFamilyId().equals(requesterFamilyId)) {
+        if (!Objects.equals(memberDetail.getFamilyId(), requesterFamilyId)) {
             throw new ApplicationException(FamilyErrorCode.NOT_FAMILY_MEMBER);
         }
 
@@ -65,7 +66,7 @@ public class DeleteFamilyBlockPolicyServiceImpl implements DeleteFamilyBlockPoli
         }
 
         boolean hasAnotherFamilyPolicy = targetPolicies.stream()
-                .anyMatch(p -> p.getFamilyId() == null || !p.getFamilyId().equals(familyId));
+                .anyMatch(p -> !Objects.equals(p.getFamilyId(), familyId));
 
         if (hasAnotherFamilyPolicy) {
             throw new ApplicationException(PolicyErrorCode.POLICY_ACCESS_DENIED);

--- a/src/main/java/hotspot/user/policy/service/DeleteFamilyBlockPolicyServiceImpl.java
+++ b/src/main/java/hotspot/user/policy/service/DeleteFamilyBlockPolicyServiceImpl.java
@@ -1,12 +1,9 @@
 package hotspot.user.policy.service;
 
-import hotspot.user.policy.controller.port.DeleteFamilyBlockPolicyService;
-import hotspot.user.policy.service.port.BlockPolicyRepository;
-import lombok.RequiredArgsConstructor;
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
 
 import hotspot.user.common.exception.ApplicationException;
 import hotspot.user.common.exception.code.AuthErrorCode;
@@ -16,9 +13,11 @@ import hotspot.user.common.exception.code.PolicyErrorCode;
 import hotspot.user.member.domain.FamilyRole;
 import hotspot.user.member.domain.MemberDetailInfo;
 import hotspot.user.member.service.port.MemberRepository;
+import hotspot.user.policy.controller.port.DeleteFamilyBlockPolicyService;
 import hotspot.user.policy.domain.BlockPolicy;
-
+import hotspot.user.policy.service.port.BlockPolicyRepository;
 import hotspot.user.policy.service.port.PolicySubRepository;
+import lombok.RequiredArgsConstructor;
 
 
 @Service

--- a/src/main/java/hotspot/user/policy/service/UpdateFamilyBlockPolicyStatusServiceImpl.java
+++ b/src/main/java/hotspot/user/policy/service/UpdateFamilyBlockPolicyStatusServiceImpl.java
@@ -3,6 +3,7 @@ package hotspot.user.policy.service;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -90,7 +91,7 @@ public class UpdateFamilyBlockPolicyStatusServiceImpl implements UpdateFamilyBlo
         MemberDetailInfo memberDetail = memberRepository.findDetailByIdAndEmail(memberId, null)
                 .orElseThrow(() -> new ApplicationException(MemberErrorCode.MEMBER_NOT_FOUND));
 
-        if (!memberDetail.getFamilyId().equals(requesterFamilyId)) {
+        if (!Objects.equals(memberDetail.getFamilyId(), requesterFamilyId)) {
             throw new ApplicationException(FamilyErrorCode.NOT_FAMILY_MEMBER);
         }
 

--- a/src/main/java/hotspot/user/policy/service/port/BlockPolicyRepository.java
+++ b/src/main/java/hotspot/user/policy/service/port/BlockPolicyRepository.java
@@ -13,4 +13,5 @@ public interface BlockPolicyRepository {
     List<BlockPolicy> findAllByFamilyId(Long familyId);
     void bulkActivate(List<Long> ids);
     void bulkDeActive(List<Long> ids);
+    void bulkDelete(List<Long> ids);
 }

--- a/src/test/java/hotspot/user/policy/controller/BlockPolicyControllerTest.java
+++ b/src/test/java/hotspot/user/policy/controller/BlockPolicyControllerTest.java
@@ -190,7 +190,7 @@ class BlockPolicyControllerTest {
         doNothing().when(deleteFamilyBlockPolicyService).delete(anyList(), anyLong(), anyLong());
 
         // when & then
-        mockMvc.perform(delete("/api/v1/policies")
+        mockMvc.perform(delete("/api/v1/policies/families")
                         .param("policyIdList", "1", "2")
                         .contentType(MediaType.APPLICATION_JSON))
                 .andDo(print())

--- a/src/test/java/hotspot/user/policy/controller/BlockPolicyControllerTest.java
+++ b/src/test/java/hotspot/user/policy/controller/BlockPolicyControllerTest.java
@@ -1,8 +1,11 @@
 package hotspot.user.policy.controller;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -31,6 +34,7 @@ import hotspot.user.common.security.jwt.JwtFilter;
 import hotspot.user.common.security.jwt.JwtProvider;
 import hotspot.user.member.domain.FamilyRole;
 import hotspot.user.member.domain.Status;
+import hotspot.user.policy.controller.port.DeleteFamilyBlockPolicyService;
 import hotspot.user.policy.controller.port.FindBlockPolicyService;
 import hotspot.user.policy.controller.port.FindFamilyBlockPolicyService;
 import hotspot.user.policy.controller.port.UpdateFamilyBlockPolicyStatusService;
@@ -57,6 +61,9 @@ class BlockPolicyControllerTest {
 
     @MockBean
     private UpdateFamilyBlockPolicyStatusService updateFamilyBlockPolicyStatusService;
+
+    @MockBean
+    private DeleteFamilyBlockPolicyService deleteFamilyBlockPolicyService;
 
     @MockBean
     private JwtFilter jwtFilter;
@@ -173,5 +180,20 @@ class BlockPolicyControllerTest {
                         .content(objectMapper.writeValueAsString(request)))
                 .andDo(print())
                 .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("성공: 우리 가족 정책 삭제 API 호출 시 200 OK를 반환한다")
+    void deleteFamilyBlockPoliciesSuccess() throws Exception {
+        // given
+        List<Long> policyIds = List.of(1L, 2L);
+        doNothing().when(deleteFamilyBlockPolicyService).delete(anyList(), anyLong(), anyLong());
+
+        // when & then
+        mockMvc.perform(delete("/api/v1/policies")
+                        .param("policyIdList", "1", "2")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isOk());
     }
 }

--- a/src/test/java/hotspot/user/policy/infrastructure/BlockPolicyRepositoryImplTest.java
+++ b/src/test/java/hotspot/user/policy/infrastructure/BlockPolicyRepositoryImplTest.java
@@ -119,4 +119,17 @@ class BlockPolicyRepositoryImplTest {
         // then
         verify(blockPolicyJpaRepository).bulkDeActive(ids);
     }
+
+    @Test
+    @DisplayName("성공: 정책들을 일괄 삭제(Soft Delete)한다")
+    void bulkDeleteSuccess() {
+        // given
+        List<Long> ids = List.of(1L, 2L);
+
+        // when
+        blockPolicyRepository.bulkDelete(ids);
+
+        // then
+        verify(blockPolicyJpaRepository).bulkDelete(ids);
+    }
 }

--- a/src/test/java/hotspot/user/policy/service/DeleteFamilyBlockPolicyServiceImplTest.java
+++ b/src/test/java/hotspot/user/policy/service/DeleteFamilyBlockPolicyServiceImplTest.java
@@ -1,0 +1,170 @@
+package hotspot.user.policy.service;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import hotspot.user.common.exception.ApplicationException;
+import hotspot.user.common.exception.code.AuthErrorCode;
+import hotspot.user.common.exception.code.FamilyErrorCode;
+import hotspot.user.common.exception.code.MemberErrorCode;
+import hotspot.user.common.exception.code.PolicyErrorCode;
+import hotspot.user.member.domain.FamilyRole;
+import hotspot.user.member.domain.MemberDetailInfo;
+import hotspot.user.member.service.port.MemberRepository;
+import hotspot.user.policy.domain.BlockPolicy;
+import hotspot.user.policy.service.port.BlockPolicyRepository;
+import hotspot.user.policy.service.port.PolicySubRepository;
+
+@ExtendWith(MockitoExtension.class)
+class DeleteFamilyBlockPolicyServiceImplTest {
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private BlockPolicyRepository blockPolicyRepository;
+
+    @Mock
+    private PolicySubRepository policySubRepository;
+
+    @InjectMocks
+    private DeleteFamilyBlockPolicyServiceImpl deleteFamilyBlockPolicyService;
+
+    private static final Long MEMBER_ID = 1L;
+    private static final Long FAMILY_ID = 100L;
+
+    @Test
+    @DisplayName("성공: 우리 가족 정책을 일괄 삭제한다")
+    void deleteSuccess() {
+        // given
+        List<Long> policyIds = List.of(10L, 20L);
+        MemberDetailInfo memberDetail = MemberDetailInfo.builder()
+                .familyId(FAMILY_ID)
+                .role(FamilyRole.OWNER)
+                .build();
+
+        given(memberRepository.findDetailByIdAndEmail(anyLong(), isNull()))
+                .willReturn(Optional.of(memberDetail));
+
+        BlockPolicy policy1 = BlockPolicy.builder().id(10L).familyId(FAMILY_ID).build();
+        BlockPolicy policy2 = BlockPolicy.builder().id(20L).familyId(FAMILY_ID).build();
+        given(blockPolicyRepository.findAllById(policyIds)).willReturn(List.of(policy1, policy2));
+
+        // when
+        deleteFamilyBlockPolicyService.delete(policyIds, MEMBER_ID, FAMILY_ID);
+
+        // then
+        verify(policySubRepository).bulkDeActiveByBlockPolicyIds(policyIds);
+        verify(blockPolicyRepository).bulkDelete(policyIds);
+    }
+
+    @Test
+    @DisplayName("실패: 요청자가 가족의 OWNER가 아니면 예외가 발생한다")
+    void deleteFailNotOwner() {
+        // given
+        List<Long> policyIds = List.of(10L);
+        MemberDetailInfo memberDetail = MemberDetailInfo.builder()
+                .familyId(FAMILY_ID)
+                .role(FamilyRole.PARENT)
+                .build();
+
+        given(memberRepository.findDetailByIdAndEmail(anyLong(), isNull()))
+                .willReturn(Optional.of(memberDetail));
+
+        // when & then
+        assertThatThrownBy(() -> deleteFamilyBlockPolicyService.delete(policyIds, MEMBER_ID, FAMILY_ID))
+                .isInstanceOf(ApplicationException.class)
+                .hasFieldOrPropertyWithValue("code", AuthErrorCode.ACCESS_DENIED);
+    }
+
+    @Test
+    @DisplayName("실패: 요청된 정책 ID 중 존재하지 않는 ID가 있으면 예외가 발생한다")
+    void deleteFailPolicyNotFound() {
+        // given
+        List<Long> policyIds = List.of(10L, 999L);
+        MemberDetailInfo memberDetail = MemberDetailInfo.builder()
+                .familyId(FAMILY_ID)
+                .role(FamilyRole.OWNER)
+                .build();
+
+        given(memberRepository.findDetailByIdAndEmail(anyLong(), isNull()))
+                .willReturn(Optional.of(memberDetail));
+
+        // 10L은 존재하지만 999L은 DB에 없음
+        BlockPolicy policy1 = BlockPolicy.builder().id(10L).familyId(FAMILY_ID).build();
+        given(blockPolicyRepository.findAllById(policyIds)).willReturn(List.of(policy1));
+
+        // when & then
+        assertThatThrownBy(() -> deleteFamilyBlockPolicyService.delete(policyIds, MEMBER_ID, FAMILY_ID))
+                .isInstanceOf(ApplicationException.class)
+                .hasFieldOrPropertyWithValue("code", PolicyErrorCode.POLICY_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("실패: 요청된 정책 중 타인의 가족 정책이 포함되어 있으면 예외가 발생한다")
+    void deleteFailForeignPolicy() {
+        // given
+        List<Long> policyIds = List.of(10L, 50L);
+        MemberDetailInfo memberDetail = MemberDetailInfo.builder()
+                .familyId(FAMILY_ID)
+                .role(FamilyRole.OWNER)
+                .build();
+
+        given(memberRepository.findDetailByIdAndEmail(anyLong(), isNull()))
+                .willReturn(Optional.of(memberDetail));
+
+        BlockPolicy policy1 = BlockPolicy.builder().id(10L).familyId(FAMILY_ID).build();
+        BlockPolicy policy2 = BlockPolicy.builder().id(50L).familyId(200L).build(); // 타인 가족
+        given(blockPolicyRepository.findAllById(policyIds)).willReturn(List.of(policy1, policy2));
+
+        // when & then
+        assertThatThrownBy(() -> deleteFamilyBlockPolicyService.delete(policyIds, MEMBER_ID, FAMILY_ID))
+                .isInstanceOf(ApplicationException.class)
+                .hasFieldOrPropertyWithValue("code", PolicyErrorCode.POLICY_ACCESS_DENIED);
+    }
+
+    @Test
+    @DisplayName("실패: 회원을 찾을 수 없으면 예외가 발생한다")
+    void deleteFailMemberNotFound() {
+        // given
+        given(memberRepository.findDetailByIdAndEmail(anyLong(), isNull()))
+                .willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> deleteFamilyBlockPolicyService.delete(List.of(1L), MEMBER_ID, FAMILY_ID))
+                .isInstanceOf(ApplicationException.class)
+                .hasFieldOrPropertyWithValue("code", MemberErrorCode.MEMBER_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("실패: 요청자의 가족 ID와 회원의 소속 가족 ID가 다르면 예외가 발생한다")
+    void deleteFailDifferentFamily() {
+        // given
+        MemberDetailInfo memberDetail = MemberDetailInfo.builder()
+                .familyId(200L) // 다른 가족
+                .role(FamilyRole.OWNER)
+                .build();
+
+        given(memberRepository.findDetailByIdAndEmail(anyLong(), isNull()))
+                .willReturn(Optional.of(memberDetail));
+
+        // when & then
+        assertThatThrownBy(() -> deleteFamilyBlockPolicyService.delete(List.of(1L), MEMBER_ID, FAMILY_ID))
+                .isInstanceOf(ApplicationException.class)
+                .hasFieldOrPropertyWithValue("code", FamilyErrorCode.NOT_FAMILY_MEMBER);
+    }
+}

--- a/src/test/java/hotspot/user/policy/service/DeleteFamilyBlockPolicyServiceImplTest.java
+++ b/src/test/java/hotspot/user/policy/service/DeleteFamilyBlockPolicyServiceImplTest.java
@@ -1,7 +1,6 @@
 package hotspot.user.policy.service;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.BDDMockito.given;


### PR DESCRIPTION
## 🎫 지라 티켓

<!-- 지라 티켓을 작성해주세요 ex) HOTSPOT-123 -->
HOTSPOT-201

---

## 🔗 GitHub 이슈
<!-- 자동 close를 원하면 아래 형식으로 작성
예) Closes #12
-->
#104

---


## ✅ 작업 사항

<!-- 작업한 부분을 설명해주세요. -->

🚀 개요
  가족 관리자(OWNER)가 우리 가족이 생성한 정책들을 단일 / 일괄 삭제할 수 있는 기능을 구현

---

Controller & API
   * `BlockPolicyController`: `DELETE /api/v1/policies/families` 엔드포인트를 추가
     * 단일 및 일괄 삭제 요청(List)을 모두 지원

<br/>


Service `DeleteFamilyBlockPolicyServiceImpl`
   * 권한 및 소유권 검증:
       * 요청자가 해당 가족의 `OWNER` 권한을 가졌는지 검증
       * 삭제하려는 정책 ID들이 실제로 우리 가족이 생성한 정책인지 비교
   * 연쇄 상태 변경:
       * 정책이 삭제될 때, policy_sub 테이블에서 해당 정책을 적용 중인 모든 회선 매핑 정보를 즉시 `isActive = false`로 벌크 업데이트

<br/>


Repository
   * `BlockPolicyJpaRepository`:
       * 벌크 삭제 메서드(bulkDelete) 구현
       * 삭제 시 `is_deleted = true`와 함께 `is_active = false` 처리
---

## 📋 체크리스트

<!-- PR 제출 전 확인해주세요. 해당 항목에 [x]로 체크해주세요. -->

- [x] 코드가 정상적으로 빌드됩니다.
- [x] 관련 테스트 코드를 작성했습니다.
- [x] 기존 테스트가 모두 통과합니다.
- [x] 코드 스타일(Spotless, Checkstyle)을 준수합니다.
- [x] Jira 티켓 상태를 In Review / Done으로 변경했습니다.

---

## ⌨ 기타
