### PR TITLE
[HOTSPOT-168] 가족 구성원 삭제 신청 API 분리

### DIFF
--- a/src/main/java/hotspot/user/family/controller/FamilyApplyController.java
+++ b/src/main/java/hotspot/user/family/controller/FamilyApplyController.java
@@ -13,10 +13,13 @@ import hotspot.user.common.ApiResponse;
 import hotspot.user.common.security.PrincipalDetails;
 import hotspot.user.family.controller.port.AddFamilyMemberService;
 import hotspot.user.family.controller.port.CreateNewFamilyService;
+import hotspot.user.family.controller.port.RemoveFamilyMemberService;
 import hotspot.user.family.controller.request.AddFamilyMemberRequest;
 import hotspot.user.family.controller.request.CreateNewFamilyRequest;
+import hotspot.user.family.controller.request.RemoveFamilyMemberRequest;
 import hotspot.user.family.controller.response.AddFamilyMemberResponse;
 import hotspot.user.family.controller.response.CreateNewFamilyResponse;
+import hotspot.user.family.controller.response.RemoveFamilyMemberResponse;
 import hotspot.user.family.controller.swagger.FamilyApplyApi;
 import lombok.RequiredArgsConstructor;
 
@@ -30,6 +33,7 @@ public class FamilyApplyController implements FamilyApplyApi {
 
     private final CreateNewFamilyService createNewFamilyService; // 가족 신규 생성
     private final AddFamilyMemberService addFamilyMemberService; // 가족 구성원 추가 신청
+    private final RemoveFamilyMemberService removeFamilyMemberService; // 가족 구성원 삭제 신청
 
     // 가족 신규 생성
     @Override
@@ -46,7 +50,7 @@ public class FamilyApplyController implements FamilyApplyApi {
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
-    // 가족 구성원 추가 신청 (다건)
+    // 가족 구성원 추가 신청
     @Override
     @PostMapping("/add")
     public ResponseEntity<ApiResponse<AddFamilyMemberResponse>> addFamilyMember(
@@ -58,6 +62,18 @@ public class FamilyApplyController implements FamilyApplyApi {
                 principal.getFamilyId(),
                 request
         );
+
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    // 가족 구성원 삭제 신청
+    @Override
+    @PostMapping("/delete")
+    public ResponseEntity<ApiResponse<RemoveFamilyMemberResponse>> removeFamilyMember(
+            @Valid @RequestBody RemoveFamilyMemberRequest request,
+            @AuthenticationPrincipal PrincipalDetails principal) {
+
+        RemoveFamilyMemberResponse response = removeFamilyMemberService.removeFamilyMember(principal.getId(), request);
 
         return ResponseEntity.ok(ApiResponse.success(response));
     }

--- a/src/main/java/hotspot/user/family/controller/port/RemoveFamilyMemberService.java
+++ b/src/main/java/hotspot/user/family/controller/port/RemoveFamilyMemberService.java
@@ -1,0 +1,11 @@
+package hotspot.user.family.controller.port;
+
+import hotspot.user.family.controller.request.RemoveFamilyMemberRequest;
+import hotspot.user.family.controller.response.RemoveFamilyMemberResponse;
+
+/**
+ * 가족 구성원 삭제 신청 서비스
+ */
+public interface RemoveFamilyMemberService {
+    RemoveFamilyMemberResponse removeFamilyMember(Long requesterMemberId, RemoveFamilyMemberRequest request);
+}

--- a/src/main/java/hotspot/user/family/controller/request/RemoveFamilyMemberRequest.java
+++ b/src/main/java/hotspot/user/family/controller/request/RemoveFamilyMemberRequest.java
@@ -1,7 +1,8 @@
 package hotspot.user.family.controller.request;
 
-import lombok.Builder;
 import java.util.List;
+
+import lombok.Builder;
 
 /**
  * 가족 구성원 삭제 신청 request dto

--- a/src/main/java/hotspot/user/family/controller/request/RemoveFamilyMemberRequest.java
+++ b/src/main/java/hotspot/user/family/controller/request/RemoveFamilyMemberRequest.java
@@ -1,0 +1,14 @@
+package hotspot.user.family.controller.request;
+
+import lombok.Builder;
+import java.util.List;
+
+/**
+ * 가족 구성원 삭제 신청 request dto
+ * @param targetSubIdList
+ */
+@Builder
+public record RemoveFamilyMemberRequest(
+        List<Long> targetSubIdList
+) {
+}

--- a/src/main/java/hotspot/user/family/controller/request/RemoveFamilyMemberRequest.java
+++ b/src/main/java/hotspot/user/family/controller/request/RemoveFamilyMemberRequest.java
@@ -2,6 +2,8 @@ package hotspot.user.family.controller.request;
 
 import java.util.List;
 
+import jakarta.validation.constraints.NotEmpty;
+
 import lombok.Builder;
 
 /**
@@ -10,6 +12,7 @@ import lombok.Builder;
  */
 @Builder
 public record RemoveFamilyMemberRequest(
+        @NotEmpty(message = "삭제 대상 회선 ID 목록은 비어 있을 수 없습니다.")
         List<Long> targetSubIdList
 ) {
 }

--- a/src/main/java/hotspot/user/family/controller/response/RemoveFamilyMemberResponse.java
+++ b/src/main/java/hotspot/user/family/controller/response/RemoveFamilyMemberResponse.java
@@ -12,7 +12,7 @@ import lombok.Builder;
  * @param familyId
  * @param subIdList
  * @param status
- * @param schueduleDate
+ * @param scheduleDate
  */
 @Builder
 public record RemoveFamilyMemberResponse(
@@ -20,6 +20,6 @@ public record RemoveFamilyMemberResponse(
         Long familyId,
         List<Long> subIdList,
         DeleteStatus status,
-        LocalDate schueduleDate
+        LocalDate scheduleDate
 ) {
 }

--- a/src/main/java/hotspot/user/family/controller/response/RemoveFamilyMemberResponse.java
+++ b/src/main/java/hotspot/user/family/controller/response/RemoveFamilyMemberResponse.java
@@ -3,18 +3,18 @@ package hotspot.user.family.controller.response;
 import hotspot.user.family.domain.DeleteStatus;
 import lombok.Builder;
 
+import java.util.List;
+
 /**
  * 가족 구성원 삭제 신청 결과 response dto
  * @param familyApplyId
  * @param familyId
- * @param subId
- * @param deleteStatus
+ * @param subIdList
  */
 @Builder
 public record RemoveFamilyMemberResponse(
         Long familyApplyId,
         Long familyId,
-        Long subId,
-        DeleteStatus deleteStatus
+        List<Long> subIdList
 ) {
 }

--- a/src/main/java/hotspot/user/family/controller/response/RemoveFamilyMemberResponse.java
+++ b/src/main/java/hotspot/user/family/controller/response/RemoveFamilyMemberResponse.java
@@ -1,10 +1,10 @@
 package hotspot.user.family.controller.response;
 
-import hotspot.user.family.domain.DeleteStatus;
-import lombok.Builder;
-
 import java.time.LocalDate;
 import java.util.List;
+
+import hotspot.user.family.domain.DeleteStatus;
+import lombok.Builder;
 
 /**
  * 가족 구성원 삭제 신청 결과 response dto

--- a/src/main/java/hotspot/user/family/controller/response/RemoveFamilyMemberResponse.java
+++ b/src/main/java/hotspot/user/family/controller/response/RemoveFamilyMemberResponse.java
@@ -1,0 +1,20 @@
+package hotspot.user.family.controller.response;
+
+import hotspot.user.family.domain.DeleteStatus;
+import lombok.Builder;
+
+/**
+ * 가족 구성원 삭제 신청 결과 response dto
+ * @param familyApplyId
+ * @param familyId
+ * @param subId
+ * @param deleteStatus
+ */
+@Builder
+public record RemoveFamilyMemberResponse(
+        Long familyApplyId,
+        Long familyId,
+        Long subId,
+        DeleteStatus deleteStatus
+) {
+}

--- a/src/main/java/hotspot/user/family/controller/response/RemoveFamilyMemberResponse.java
+++ b/src/main/java/hotspot/user/family/controller/response/RemoveFamilyMemberResponse.java
@@ -3,6 +3,7 @@ package hotspot.user.family.controller.response;
 import hotspot.user.family.domain.DeleteStatus;
 import lombok.Builder;
 
+import java.time.LocalDate;
 import java.util.List;
 
 /**
@@ -10,11 +11,15 @@ import java.util.List;
  * @param familyApplyId
  * @param familyId
  * @param subIdList
+ * @param status
+ * @param schueduleDate
  */
 @Builder
 public record RemoveFamilyMemberResponse(
         Long familyApplyId,
         Long familyId,
-        List<Long> subIdList
+        List<Long> subIdList,
+        DeleteStatus status,
+        LocalDate schueduleDate
 ) {
 }

--- a/src/main/java/hotspot/user/family/controller/swagger/FamilyApplyApi.java
+++ b/src/main/java/hotspot/user/family/controller/swagger/FamilyApplyApi.java
@@ -11,8 +11,10 @@ import hotspot.user.common.exception.ErrorResponse;
 import hotspot.user.common.security.PrincipalDetails;
 import hotspot.user.family.controller.request.AddFamilyMemberRequest;
 import hotspot.user.family.controller.request.CreateNewFamilyRequest;
+import hotspot.user.family.controller.request.RemoveFamilyMemberRequest;
 import hotspot.user.family.controller.response.AddFamilyMemberResponse;
 import hotspot.user.family.controller.response.CreateNewFamilyResponse;
+import hotspot.user.family.controller.response.RemoveFamilyMemberResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -65,5 +67,24 @@ public interface FamilyApplyApi {
     })
     ResponseEntity<ApiResponse<AddFamilyMemberResponse>> addFamilyMember(
             @Valid @RequestBody AddFamilyMemberRequest request,
+            @Parameter(hidden = true) @AuthenticationPrincipal PrincipalDetails principal);
+
+    @Operation(summary = "가족 구성원 삭제 신청",
+               description = "가족 OWNER가 한 명 or 여러 명의 구성원을 가족에서 삭제하기 위해 신청을 생성합니다. (다음 달 1일 삭제 예정)")
+    @ApiResponses(value = {
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "신청 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청\n"
+                                         + "- FAMILY_003: 해당 구성원은 동일한 가족 그룹에 속해 있지 않습니다.",
+                     content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "권한 없음\n"
+                                         + "- FAMILY_002: 가족에 가입된 회선 정보를 찾을 수 없습니다.\n"
+                                         + "- FAMILY_010: 가족 관리자(OWNER)만 구성원 관리가 가능합니다.",
+                     content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "충돌\n"
+                                         + "- FAMILY_015: 이미 처리 대기 중인 신청이 존재합니다.",
+                     content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    ResponseEntity<ApiResponse<RemoveFamilyMemberResponse>> removeFamilyMember(
+            @Valid @RequestBody RemoveFamilyMemberRequest request,
             @Parameter(hidden = true) @AuthenticationPrincipal PrincipalDetails principal);
 }

--- a/src/main/java/hotspot/user/family/domain/DeleteStatus.java
+++ b/src/main/java/hotspot/user/family/domain/DeleteStatus.java
@@ -1,0 +1,10 @@
+package hotspot.user.family.domain;
+
+/**
+ * 가족 구성원 스케쥴러 완료 상태 Enum
+ */
+public enum DeleteStatus {
+    SCHEDULED,
+    COMPLETED,
+    FAILED
+}

--- a/src/main/java/hotspot/user/family/domain/FamilyRemoveSchedule.java
+++ b/src/main/java/hotspot/user/family/domain/FamilyRemoveSchedule.java
@@ -1,0 +1,16 @@
+package hotspot.user.family.domain;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@Builder
+public class FamilyRemoveSchedule {
+    private Long id;
+    private Long targetSubId;
+    private Long familyId;
+    private DeleteStatus status;
+    private LocalDate scheduleDate;
+}

--- a/src/main/java/hotspot/user/family/domain/FamilyRemoveSchedule.java
+++ b/src/main/java/hotspot/user/family/domain/FamilyRemoveSchedule.java
@@ -1,9 +1,9 @@
 package hotspot.user.family.domain;
 
+import java.time.LocalDate;
+
 import lombok.Builder;
 import lombok.Getter;
-
-import java.time.LocalDate;
 
 @Getter
 @Builder

--- a/src/main/java/hotspot/user/family/domain/mapper/RemoveFamilyMemberMapper.java
+++ b/src/main/java/hotspot/user/family/domain/mapper/RemoveFamilyMemberMapper.java
@@ -53,7 +53,7 @@ public class RemoveFamilyMemberMapper {
                 .familyId(familyApply.getFamilyId())
                 .subIdList(subIdList)
                 .status(status)
-                .schueduleDate(scheduleDate)
+                .scheduleDate(scheduleDate)
                 .build();
     }
 }

--- a/src/main/java/hotspot/user/family/domain/mapper/RemoveFamilyMemberMapper.java
+++ b/src/main/java/hotspot/user/family/domain/mapper/RemoveFamilyMemberMapper.java
@@ -1,0 +1,21 @@
+package hotspot.user.family.domain.mapper;
+
+import hotspot.user.family.controller.response.RemoveFamilyMemberResponse;
+import hotspot.user.family.domain.FamilyApply;
+
+/**
+ * 가족 구성원 삭제 신청 Mapper
+ */
+public class RemoveFamilyMemberMapper {
+
+    // requeset -> domain
+    public static FamilyApply toFamilyApply() {
+        return FamilyApply.builder()
+                .build();
+    }
+
+    // domain -> response
+    public static RemoveFamilyMemberResponse toRemoveFamilyMemberResponse() {
+
+    }
+}

--- a/src/main/java/hotspot/user/family/domain/mapper/RemoveFamilyMemberMapper.java
+++ b/src/main/java/hotspot/user/family/domain/mapper/RemoveFamilyMemberMapper.java
@@ -15,7 +15,7 @@ import hotspot.user.family.domain.FamilyRemoveSchedule;
  */
 public class RemoveFamilyMemberMapper {
 
-    // request -> domain (FamilyApply 신청서 생성)
+    // request -> domain
     public static FamilyApply toFamilyApply(Long requesterSubId, Long familyId) {
         return FamilyApply.builder()
                 .requesterSubId(requesterSubId)
@@ -25,7 +25,7 @@ public class RemoveFamilyMemberMapper {
                 .build();
     }
 
-    // domain (개별 삭제 스케줄 생성)
+    // 개별 삭제 스케줄 생성
     public static FamilyRemoveSchedule toFamilyRemoveSchedule(Long familyId, Long targetSubId, LocalDate scheduleDate) {
         return FamilyRemoveSchedule.builder()
                 .familyId(familyId)

--- a/src/main/java/hotspot/user/family/domain/mapper/RemoveFamilyMemberMapper.java
+++ b/src/main/java/hotspot/user/family/domain/mapper/RemoveFamilyMemberMapper.java
@@ -1,21 +1,59 @@
 package hotspot.user.family.domain.mapper;
 
+import java.time.LocalDate;
+import java.util.List;
+
 import hotspot.user.family.controller.response.RemoveFamilyMemberResponse;
+import hotspot.user.family.domain.ApplyStatus;
+import hotspot.user.family.domain.ApplyType;
+import hotspot.user.family.domain.DeleteStatus;
 import hotspot.user.family.domain.FamilyApply;
+import hotspot.user.family.domain.FamilyRemoveSchedule;
 
 /**
  * 가족 구성원 삭제 신청 Mapper
  */
 public class RemoveFamilyMemberMapper {
 
-    // requeset -> domain
-    public static FamilyApply toFamilyApply() {
+    // request -> domain (FamilyApply 신청서 생성)
+    public static FamilyApply toFamilyApply(Long requesterSubId, Long familyId) {
         return FamilyApply.builder()
+                .requesterSubId(requesterSubId)
+                .familyId(familyId)
+                .applyType(ApplyType.REMOVE)
+                .status(ApplyStatus.PENDING)
+                .build();
+    }
+
+    // domain (개별 삭제 스케줄 생성)
+    public static FamilyRemoveSchedule toFamilyRemoveSchedule(Long familyId, Long targetSubId, LocalDate scheduleDate) {
+        return FamilyRemoveSchedule.builder()
+                .familyId(familyId)
+                .targetSubId(targetSubId)
+                .scheduleDate(scheduleDate)
+                .status(DeleteStatus.SCHEDULED)
                 .build();
     }
 
     // domain -> response
-    public static RemoveFamilyMemberResponse toRemoveFamilyMemberResponse() {
+    public static RemoveFamilyMemberResponse toRemoveFamilyMemberResponse(
+            FamilyApply familyApply,
+            List<FamilyRemoveSchedule> schedules) {
 
+        List<Long> subIdList = schedules.stream()
+                .map(FamilyRemoveSchedule::getTargetSubId)
+                .toList();
+
+        // 모든 스케줄의 날짜와 상태는 동일하므로 첫 번째 것을 참조
+        LocalDate scheduleDate = schedules.isEmpty() ? null : schedules.get(0).getScheduleDate();
+        DeleteStatus status = schedules.isEmpty() ? null : schedules.get(0).getStatus();
+
+        return RemoveFamilyMemberResponse.builder()
+                .familyApplyId(familyApply.getId())
+                .familyId(familyApply.getFamilyId())
+                .subIdList(subIdList)
+                .status(status)
+                .schueduleDate(scheduleDate)
+                .build();
     }
 }

--- a/src/main/java/hotspot/user/family/infrastructure/FamilyRemoveScheduleJpaRepository.java
+++ b/src/main/java/hotspot/user/family/infrastructure/FamilyRemoveScheduleJpaRepository.java
@@ -1,0 +1,11 @@
+package hotspot.user.family.infrastructure;
+
+import hotspot.user.family.infrastructure.entity.FamilyApplyEntity;
+import hotspot.user.family.infrastructure.entity.FamilyRemoveScheduleEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * 가족 구성원 삭제 스케쥴러
+ */
+public interface FamilyRemoveScheduleJpaRepository extends JpaRepository<FamilyRemoveScheduleEntity, Long> {
+}

--- a/src/main/java/hotspot/user/family/infrastructure/FamilyRemoveScheduleJpaRepository.java
+++ b/src/main/java/hotspot/user/family/infrastructure/FamilyRemoveScheduleJpaRepository.java
@@ -1,10 +1,11 @@
 package hotspot.user.family.infrastructure;
 
-import hotspot.user.family.domain.DeleteStatus;
-import hotspot.user.family.infrastructure.entity.FamilyRemoveScheduleEntity;
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.List;
+import hotspot.user.family.domain.DeleteStatus;
+import hotspot.user.family.infrastructure.entity.FamilyRemoveScheduleEntity;
 
 /**
  * 가족 구성원 삭제 스케쥴러

--- a/src/main/java/hotspot/user/family/infrastructure/FamilyRemoveScheduleJpaRepository.java
+++ b/src/main/java/hotspot/user/family/infrastructure/FamilyRemoveScheduleJpaRepository.java
@@ -1,11 +1,14 @@
 package hotspot.user.family.infrastructure;
 
-import hotspot.user.family.infrastructure.entity.FamilyApplyEntity;
+import hotspot.user.family.domain.DeleteStatus;
 import hotspot.user.family.infrastructure.entity.FamilyRemoveScheduleEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
 
 /**
  * 가족 구성원 삭제 스케쥴러
  */
 public interface FamilyRemoveScheduleJpaRepository extends JpaRepository<FamilyRemoveScheduleEntity, Long> {
+    List<FamilyRemoveScheduleEntity> findAllByTargetSubIdInAndStatus(List<Long> targetSubIds, DeleteStatus status);
 }

--- a/src/main/java/hotspot/user/family/infrastructure/FamilyRemoveScheduleRepositoryImpl.java
+++ b/src/main/java/hotspot/user/family/infrastructure/FamilyRemoveScheduleRepositoryImpl.java
@@ -1,0 +1,34 @@
+package hotspot.user.family.infrastructure;
+
+
+import hotspot.user.family.domain.FamilyRemoveSchedule;
+
+import hotspot.user.family.infrastructure.entity.FamilyRemoveScheduleEntity;
+
+import hotspot.user.family.service.port.FamilyRemoveScheduleRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+/**
+ * 가족 구성원 삭제 신청 스케쥴러 repository 구현체
+ */
+@Repository
+@RequiredArgsConstructor
+public class FamilyRemoveScheduleRepositoryImpl implements FamilyRemoveScheduleRepository {
+    private final FamilyRemoveScheduleJpaRepository familyRemoveScheduleJpaRepository;
+
+    @Override
+    public List<FamilyRemoveSchedule> saveAll(List<FamilyRemoveSchedule> familyRemoveScheduleList) {
+        List<FamilyRemoveScheduleEntity> familyRemoveScheduleEntityList = familyRemoveScheduleList.stream()
+                .map(FamilyRemoveScheduleEntity::domainToEntity)
+                .toList();
+
+        List<FamilyRemoveScheduleEntity> saved = familyRemoveScheduleJpaRepository.saveAll(familyRemoveScheduleEntityList);
+
+        return saved.stream()
+                .map(FamilyRemoveScheduleEntity::entityToDomain)
+                .toList();
+    }
+}

--- a/src/main/java/hotspot/user/family/infrastructure/FamilyRemoveScheduleRepositoryImpl.java
+++ b/src/main/java/hotspot/user/family/infrastructure/FamilyRemoveScheduleRepositoryImpl.java
@@ -24,7 +24,8 @@ public class FamilyRemoveScheduleRepositoryImpl implements FamilyRemoveScheduleR
                 .map(FamilyRemoveScheduleEntity::domainToEntity)
                 .toList();
 
-        List<FamilyRemoveScheduleEntity> saved = familyRemoveScheduleJpaRepository.saveAll(familyRemoveScheduleEntityList);
+        List<FamilyRemoveScheduleEntity> saved = familyRemoveScheduleJpaRepository
+                .saveAll(familyRemoveScheduleEntityList);
 
         return saved.stream()
                 .map(FamilyRemoveScheduleEntity::entityToDomain)

--- a/src/main/java/hotspot/user/family/infrastructure/FamilyRemoveScheduleRepositoryImpl.java
+++ b/src/main/java/hotspot/user/family/infrastructure/FamilyRemoveScheduleRepositoryImpl.java
@@ -1,15 +1,14 @@
 package hotspot.user.family.infrastructure;
 
+import java.util.List;
 
-import hotspot.user.family.domain.FamilyRemoveSchedule;
-
-import hotspot.user.family.infrastructure.entity.FamilyRemoveScheduleEntity;
-
-import hotspot.user.family.service.port.FamilyRemoveScheduleRepository;
-import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
+import hotspot.user.family.domain.DeleteStatus;
+import hotspot.user.family.domain.FamilyRemoveSchedule;
+import hotspot.user.family.infrastructure.entity.FamilyRemoveScheduleEntity;
+import hotspot.user.family.service.port.FamilyRemoveScheduleRepository;
+import lombok.RequiredArgsConstructor;
 
 /**
  * 가족 구성원 삭제 신청 스케쥴러 repository 구현체
@@ -28,6 +27,13 @@ public class FamilyRemoveScheduleRepositoryImpl implements FamilyRemoveScheduleR
         List<FamilyRemoveScheduleEntity> saved = familyRemoveScheduleJpaRepository.saveAll(familyRemoveScheduleEntityList);
 
         return saved.stream()
+                .map(FamilyRemoveScheduleEntity::entityToDomain)
+                .toList();
+    }
+
+    @Override
+    public List<FamilyRemoveSchedule> findAllByTargetSubIdInAndStatus(List<Long> subIds, DeleteStatus status) {
+        return familyRemoveScheduleJpaRepository.findAllByTargetSubIdInAndStatus(subIds, status).stream()
                 .map(FamilyRemoveScheduleEntity::entityToDomain)
                 .toList();
     }

--- a/src/main/java/hotspot/user/family/infrastructure/entity/FamilyRemoveScheduleEntity.java
+++ b/src/main/java/hotspot/user/family/infrastructure/entity/FamilyRemoveScheduleEntity.java
@@ -2,7 +2,14 @@ package hotspot.user.family.infrastructure.entity;
 
 import java.time.LocalDate;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 
 import hotspot.user.common.BaseEntity;
 import hotspot.user.family.domain.DeleteStatus;

--- a/src/main/java/hotspot/user/family/infrastructure/entity/FamilyRemoveScheduleEntity.java
+++ b/src/main/java/hotspot/user/family/infrastructure/entity/FamilyRemoveScheduleEntity.java
@@ -1,0 +1,56 @@
+package hotspot.user.family.infrastructure.entity;
+
+import hotspot.user.common.BaseEntity;
+import hotspot.user.family.domain.DeleteStatus;
+import hotspot.user.family.domain.FamilyRemoveSchedule;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+
+/**
+ * 가족 삭제 스케쥴러 entity
+ */
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Table(name = "family_remove_schedule")
+public class FamilyRemoveScheduleEntity extends BaseEntity {
+
+    @Id
+    @Column(name = "family_remove_schedule_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long targetSubId;
+    private Long familyId;
+
+    @Builder.Default
+    private DeleteStatus status = DeleteStatus.SCHEDULED;
+    private LocalDate scheduleDate;
+
+    public static FamilyRemoveScheduleEntity domainToEntity(FamilyRemoveSchedule familyRemoveSchedule) {
+        return FamilyRemoveScheduleEntity.builder()
+                .id(familyRemoveSchedule.getId())
+                .targetSubId(familyRemoveSchedule.getTargetSubId())
+                .familyId(familyRemoveSchedule.getFamilyId())
+                .status(familyRemoveSchedule.getStatus())
+                .scheduleDate(familyRemoveSchedule.getScheduleDate())
+                .build();
+    }
+
+    public FamilyRemoveSchedule entityToDomain() {
+        return FamilyRemoveSchedule.builder()
+                .id(this.id)
+                .targetSubId(this.targetSubId)
+                .familyId(this.familyId)
+                .status(this.status)
+                .scheduleDate(this.scheduleDate)
+                .build();
+    }
+
+
+}

--- a/src/main/java/hotspot/user/family/infrastructure/entity/FamilyRemoveScheduleEntity.java
+++ b/src/main/java/hotspot/user/family/infrastructure/entity/FamilyRemoveScheduleEntity.java
@@ -2,12 +2,7 @@ package hotspot.user.family.infrastructure.entity;
 
 import java.time.LocalDate;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 
 import hotspot.user.common.BaseEntity;
 import hotspot.user.family.domain.DeleteStatus;
@@ -38,8 +33,11 @@ public class FamilyRemoveScheduleEntity extends BaseEntity {
     private Long targetSubId;
     private Long familyId;
 
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
     @Builder.Default
     private DeleteStatus status = DeleteStatus.SCHEDULED;
+
     private LocalDate scheduleDate;
 
     public static FamilyRemoveScheduleEntity domainToEntity(FamilyRemoveSchedule familyRemoveSchedule) {

--- a/src/main/java/hotspot/user/family/infrastructure/entity/FamilyRemoveScheduleEntity.java
+++ b/src/main/java/hotspot/user/family/infrastructure/entity/FamilyRemoveScheduleEntity.java
@@ -1,12 +1,22 @@
 package hotspot.user.family.infrastructure.entity;
 
+import java.time.LocalDate;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
 import hotspot.user.common.BaseEntity;
 import hotspot.user.family.domain.DeleteStatus;
 import hotspot.user.family.domain.FamilyRemoveSchedule;
-import jakarta.persistence.*;
-import lombok.*;
-
-import java.time.LocalDate;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 /**
  * 가족 삭제 스케쥴러 entity

--- a/src/main/java/hotspot/user/family/service/RemoveFamilyMemberServiceImpl.java
+++ b/src/main/java/hotspot/user/family/service/RemoveFamilyMemberServiceImpl.java
@@ -2,8 +2,6 @@ package hotspot.user.family.service;
 
 import java.time.LocalDate;
 import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -57,35 +55,25 @@ public class RemoveFamilyMemberServiceImpl implements RemoveFamilyMemberService 
         // 3. 삭제 대상자들의 가족 소속 확인 및 중복 신청 여부 확인 (N+1 방지)
         List<FamilySubscription> targetFsList = familySubscriptionRepository.findAllBySubIdIn(targetSubIds);
 
-        // 회선 존재 여부 검증 (요청한 ID들이 모두 가족 매핑 테이블에 존재하는지 확인)
+        // 회선 존재 여부 검증
         if (targetFsList.size() != targetSubIds.size()) {
             throw new ApplicationException(FamilyErrorCode.FAMILY_SUBSCRIPTION_NOT_FOUND);
         }
 
-        // 해당 가족에 속한 subId Set 생성
-        Set<Long> validFamilySubIds = targetFsList.stream()
-                .filter(fs -> fs.getFamily().getId().equals(familyId))
-                .map(fs -> fs.getSubscription().getId())
-                .collect(Collectors.toSet());
+        // 모든 대상이 현재 방장과 같은 가족 소속인지 확인
+        boolean allInSameFamily = targetFsList.stream()
+                .allMatch(fs -> fs.getFamily().getId().equals(familyId));
 
-        // 이미 삭제 스케줄이 잡혀있는 subId Set 생성 (중복 신청 방지)
-        Set<Long> alreadyScheduledSubIds = familyRemoveScheduleRepository
-                .findAllByTargetSubIdInAndStatus(targetSubIds, DeleteStatus.SCHEDULED)
-                .stream()
-                .map(FamilyRemoveSchedule::getTargetSubId)
-                .collect(Collectors.toSet());
+        if (!allInSameFamily) {
+            throw new ApplicationException(FamilyErrorCode.NOT_FAMILY_MEMBER);
+        }
 
-        for (Long targetSubId : targetSubIds) {
+        // 이미 처리 대기 중인(SCHEDULED) 신청이 있는지 확인
+        List<FamilyRemoveSchedule> existingSchedules = familyRemoveScheduleRepository
+                .findAllByTargetSubIdInAndStatus(targetSubIds, DeleteStatus.SCHEDULED);
 
-            // 같은 가족 소속인지 확인 (가족이 아닌 사람을 삭제하려 할 경우 차단)
-            if (!validFamilySubIds.contains(targetSubId)) {
-                throw new ApplicationException(FamilyErrorCode.NOT_FAMILY_MEMBER);
-            }
-
-            // 이미 처리 대기 중인 신청이 있는지 확인
-            if (alreadyScheduledSubIds.contains(targetSubId)) {
-                throw new ApplicationException(FamilyErrorCode.DUPLICATE_FAMILY_APPLY);
-            }
+        if (!existingSchedules.isEmpty()) {
+            throw new ApplicationException(FamilyErrorCode.DUPLICATE_FAMILY_APPLY);
         }
 
         // 4. 신청서 저장

--- a/src/main/java/hotspot/user/family/service/RemoveFamilyMemberServiceImpl.java
+++ b/src/main/java/hotspot/user/family/service/RemoveFamilyMemberServiceImpl.java
@@ -48,7 +48,7 @@ public class RemoveFamilyMemberServiceImpl implements RemoveFamilyMemberService 
         }
 
         Long familyId = requesterFs.getFamily().getId();
-        
+
         // 2. 요청 리스트 중복 제거 및 데이터 준비
         List<Long> targetSubIds = request.targetSubIdList().stream()
                 .distinct()
@@ -56,7 +56,7 @@ public class RemoveFamilyMemberServiceImpl implements RemoveFamilyMemberService 
 
         // 3. 삭제 대상자들의 가족 소속 확인 및 중복 신청 여부 확인 (N+1 방지)
         List<FamilySubscription> targetFsList = familySubscriptionRepository.findAllBySubIdIn(targetSubIds);
-        
+
         // 회선 존재 여부 검증 (요청한 ID들이 모두 가족 매핑 테이블에 존재하는지 확인)
         if (targetFsList.size() != targetSubIds.size()) {
             throw new ApplicationException(FamilyErrorCode.FAMILY_SUBSCRIPTION_NOT_FOUND);
@@ -69,7 +69,8 @@ public class RemoveFamilyMemberServiceImpl implements RemoveFamilyMemberService 
                 .collect(Collectors.toSet());
 
         // 이미 삭제 스케줄이 잡혀있는 subId Set 생성 (중복 신청 방지)
-        Set<Long> alreadyScheduledSubIds = familyRemoveScheduleRepository.findAllByTargetSubIdInAndStatus(targetSubIds, DeleteStatus.SCHEDULED)
+        Set<Long> alreadyScheduledSubIds = familyRemoveScheduleRepository
+                .findAllByTargetSubIdInAndStatus(targetSubIds, DeleteStatus.SCHEDULED)
                 .stream()
                 .map(FamilyRemoveSchedule::getTargetSubId)
                 .collect(Collectors.toSet());
@@ -93,7 +94,7 @@ public class RemoveFamilyMemberServiceImpl implements RemoveFamilyMemberService 
 
         // 5. 삭제 스케줄 생성 및 저장 - 다음 달 1일로 설정
         LocalDate scheduleDate = LocalDate.now().plusMonths(1).withDayOfMonth(1);
-        
+
         List<FamilyRemoveSchedule> schedules = targetSubIds.stream()
                 .map(subId -> RemoveFamilyMemberMapper.toFamilyRemoveSchedule(familyId, subId, scheduleDate))
                 .toList();

--- a/src/main/java/hotspot/user/family/service/RemoveFamilyMemberServiceImpl.java
+++ b/src/main/java/hotspot/user/family/service/RemoveFamilyMemberServiceImpl.java
@@ -1,0 +1,106 @@
+package hotspot.user.family.service;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import hotspot.user.common.exception.ApplicationException;
+import hotspot.user.common.exception.code.FamilyErrorCode;
+import hotspot.user.family.controller.port.RemoveFamilyMemberService;
+import hotspot.user.family.controller.request.RemoveFamilyMemberRequest;
+import hotspot.user.family.controller.response.RemoveFamilyMemberResponse;
+import hotspot.user.family.domain.DeleteStatus;
+import hotspot.user.family.domain.FamilyApply;
+import hotspot.user.family.domain.FamilyRemoveSchedule;
+import hotspot.user.family.domain.FamilySubscription;
+import hotspot.user.family.domain.mapper.RemoveFamilyMemberMapper;
+import hotspot.user.family.service.port.FamilyApplyRepository;
+import hotspot.user.family.service.port.FamilyRemoveScheduleRepository;
+import hotspot.user.family.service.port.FamilySubscriptionRepository;
+import hotspot.user.member.domain.FamilyRole;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 가족 구성원 삭제 신청 서비스 구현체
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class RemoveFamilyMemberServiceImpl implements RemoveFamilyMemberService {
+
+    private final FamilyApplyRepository familyApplyRepository;
+    private final FamilySubscriptionRepository familySubscriptionRepository;
+    private final FamilyRemoveScheduleRepository familyRemoveScheduleRepository;
+
+    @Override
+    public RemoveFamilyMemberResponse removeFamilyMember(Long requesterMemberId, RemoveFamilyMemberRequest request) {
+
+        // 1. 요청자 권한 및 소속 확인 (방장 여부)
+        FamilySubscription requesterFs = familySubscriptionRepository.findByMemberId(requesterMemberId)
+                .orElseThrow(() -> new ApplicationException(FamilyErrorCode.FAMILY_SUBSCRIPTION_NOT_FOUND));
+
+        if (requesterFs.getFamilyRole() != FamilyRole.OWNER) {
+            throw new ApplicationException(FamilyErrorCode.ONLY_OWNER_CAN_MANAGE);
+        }
+
+        Long familyId = requesterFs.getFamily().getId();
+        
+        // 2. 요청 리스트 중복 제거 및 데이터 준비
+        List<Long> targetSubIds = request.targetSubIdList().stream()
+                .distinct()
+                .toList();
+
+        // 3. 삭제 대상자들의 가족 소속 확인 및 중복 신청 여부 확인 (N+1 방지)
+        List<FamilySubscription> targetFsList = familySubscriptionRepository.findAllBySubIdIn(targetSubIds);
+        
+        // 회선 존재 여부 검증 (요청한 ID들이 모두 가족 매핑 테이블에 존재하는지 확인)
+        if (targetFsList.size() != targetSubIds.size()) {
+            throw new ApplicationException(FamilyErrorCode.FAMILY_SUBSCRIPTION_NOT_FOUND);
+        }
+
+        // 해당 가족에 속한 subId Set 생성
+        Set<Long> validFamilySubIds = targetFsList.stream()
+                .filter(fs -> fs.getFamily().getId().equals(familyId))
+                .map(fs -> fs.getSubscription().getId())
+                .collect(Collectors.toSet());
+
+        // 이미 삭제 스케줄이 잡혀있는 subId Set 생성 (중복 신청 방지)
+        Set<Long> alreadyScheduledSubIds = familyRemoveScheduleRepository.findAllByTargetSubIdInAndStatus(targetSubIds, DeleteStatus.SCHEDULED)
+                .stream()
+                .map(FamilyRemoveSchedule::getTargetSubId)
+                .collect(Collectors.toSet());
+
+        for (Long targetSubId : targetSubIds) {
+
+            // 같은 가족 소속인지 확인 (가족이 아닌 사람을 삭제하려 할 경우 차단)
+            if (!validFamilySubIds.contains(targetSubId)) {
+                throw new ApplicationException(FamilyErrorCode.NOT_FAMILY_MEMBER);
+            }
+
+            // 이미 처리 대기 중인 신청이 있는지 확인
+            if (alreadyScheduledSubIds.contains(targetSubId)) {
+                throw new ApplicationException(FamilyErrorCode.DUPLICATE_FAMILY_APPLY);
+            }
+        }
+
+        // 4. 신청서 저장
+        FamilyApply apply = RemoveFamilyMemberMapper.toFamilyApply(requesterFs.getSubscription().getId(), familyId);
+        FamilyApply savedApply = familyApplyRepository.save(apply);
+
+        // 5. 삭제 스케줄 생성 및 저장 - 다음 달 1일로 설정
+        LocalDate scheduleDate = LocalDate.now().plusMonths(1).withDayOfMonth(1);
+        
+        List<FamilyRemoveSchedule> schedules = targetSubIds.stream()
+                .map(subId -> RemoveFamilyMemberMapper.toFamilyRemoveSchedule(familyId, subId, scheduleDate))
+                .toList();
+
+        List<FamilyRemoveSchedule> savedSchedules = familyRemoveScheduleRepository.saveAll(schedules);
+
+        // 6. 응답 변환
+        return RemoveFamilyMemberMapper.toRemoveFamilyMemberResponse(savedApply, savedSchedules);
+    }
+}

--- a/src/main/java/hotspot/user/family/service/port/FamilyRemoveScheduleRepository.java
+++ b/src/main/java/hotspot/user/family/service/port/FamilyRemoveScheduleRepository.java
@@ -1,5 +1,6 @@
 package hotspot.user.family.service.port;
 
+import hotspot.user.family.domain.DeleteStatus;
 import hotspot.user.family.domain.FamilyRemoveSchedule;
 
 import java.util.List;
@@ -9,4 +10,5 @@ import java.util.List;
  */
 public interface FamilyRemoveScheduleRepository {
     List<FamilyRemoveSchedule> saveAll(List<FamilyRemoveSchedule> familyRemoveScheduleList);
+    List<FamilyRemoveSchedule> findAllByTargetSubIdInAndStatus(List<Long> subIds, DeleteStatus status);
 }

--- a/src/main/java/hotspot/user/family/service/port/FamilyRemoveScheduleRepository.java
+++ b/src/main/java/hotspot/user/family/service/port/FamilyRemoveScheduleRepository.java
@@ -1,9 +1,9 @@
 package hotspot.user.family.service.port;
 
+import java.util.List;
+
 import hotspot.user.family.domain.DeleteStatus;
 import hotspot.user.family.domain.FamilyRemoveSchedule;
-
-import java.util.List;
 
 /**
  * 가족 구성원 삭제 신청 repository

--- a/src/main/java/hotspot/user/family/service/port/FamilyRemoveScheduleRepository.java
+++ b/src/main/java/hotspot/user/family/service/port/FamilyRemoveScheduleRepository.java
@@ -1,0 +1,12 @@
+package hotspot.user.family.service.port;
+
+import hotspot.user.family.domain.FamilyRemoveSchedule;
+
+import java.util.List;
+
+/**
+ * 가족 구성원 삭제 신청 repository
+ */
+public interface FamilyRemoveScheduleRepository {
+    List<FamilyRemoveSchedule> saveAll(List<FamilyRemoveSchedule> familyRemoveScheduleList);
+}

--- a/src/test/java/hotspot/user/family/controller/FamilyApplyControllerTest.java
+++ b/src/test/java/hotspot/user/family/controller/FamilyApplyControllerTest.java
@@ -26,11 +26,14 @@ import hotspot.user.common.security.jwt.JwtFilter;
 import hotspot.user.common.security.jwt.JwtProvider;
 import hotspot.user.family.controller.port.AddFamilyMemberService;
 import hotspot.user.family.controller.port.CreateNewFamilyService;
+import hotspot.user.family.controller.port.RemoveFamilyMemberService;
 import hotspot.user.family.controller.request.AddFamilyMemberRequest;
 import hotspot.user.family.controller.request.CreateNewFamilyRequest;
 import hotspot.user.family.controller.request.FamilyMemberRequest;
+import hotspot.user.family.controller.request.RemoveFamilyMemberRequest;
 import hotspot.user.family.controller.response.AddFamilyMemberResponse;
 import hotspot.user.family.controller.response.CreateNewFamilyResponse;
+import hotspot.user.family.controller.response.RemoveFamilyMemberResponse;
 import hotspot.user.family.domain.ApplyType;
 import hotspot.user.member.domain.FamilyRole;
 
@@ -45,6 +48,8 @@ class FamilyApplyControllerTest {
     private AddFamilyMemberService addFamilyMemberService;
     @MockBean
     private CreateNewFamilyService createNewFamilyService;
+    @MockBean
+    private RemoveFamilyMemberService removeFamilyMemberService;
     @MockBean
     private JwtFilter jwtFilter;
     @MockBean
@@ -127,5 +132,31 @@ class FamilyApplyControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("성공: 가족 구성원 삭제 신청 API 호출 시 200 OK를 반환한다")
+    void removeFamilyMemberSuccess() throws Exception {
+        // given
+        setAuthentication(1L, 100L, FamilyRole.OWNER);
+        RemoveFamilyMemberRequest request = new RemoveFamilyMemberRequest(List.of(200L, 201L));
+
+        RemoveFamilyMemberResponse response = RemoveFamilyMemberResponse.builder()
+                .familyApplyId(1L)
+                .familyId(100L)
+                .subIdList(List.of(200L, 201L))
+                .status(hotspot.user.family.domain.DeleteStatus.SCHEDULED)
+                .build();
+
+        given(removeFamilyMemberService.removeFamilyMember(eq(1L), any(RemoveFamilyMemberRequest.class)))
+                .willReturn(response);
+
+        // when & then
+        mockMvc.perform(post("/api/v1/families/delete")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("200"))
+                .andExpect(jsonPath("$.data.familyApplyId").value(1L));
     }
 }

--- a/src/test/java/hotspot/user/family/domain/mapper/RemoveFamilyMemberMapperTest.java
+++ b/src/test/java/hotspot/user/family/domain/mapper/RemoveFamilyMemberMapperTest.java
@@ -52,7 +52,8 @@ class RemoveFamilyMemberMapperTest {
                 .targetSubId(20L).scheduleDate(LocalDate.now()).status(DeleteStatus.SCHEDULED).build();
 
         // when
-        RemoveFamilyMemberResponse response = RemoveFamilyMemberMapper.toRemoveFamilyMemberResponse(apply, List.of(schedule));
+        RemoveFamilyMemberResponse response = RemoveFamilyMemberMapper
+                .toRemoveFamilyMemberResponse(apply, List.of(schedule));
 
         // then
         assertThat(response.familyApplyId()).isEqualTo(100L);

--- a/src/test/java/hotspot/user/family/domain/mapper/RemoveFamilyMemberMapperTest.java
+++ b/src/test/java/hotspot/user/family/domain/mapper/RemoveFamilyMemberMapperTest.java
@@ -1,0 +1,62 @@
+package hotspot.user.family.domain.mapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import hotspot.user.family.controller.response.RemoveFamilyMemberResponse;
+import hotspot.user.family.domain.ApplyStatus;
+import hotspot.user.family.domain.ApplyType;
+import hotspot.user.family.domain.DeleteStatus;
+import hotspot.user.family.domain.FamilyApply;
+import hotspot.user.family.domain.FamilyRemoveSchedule;
+
+class RemoveFamilyMemberMapperTest {
+
+    @Test
+    @DisplayName("성공: 삭제 신청서(FamilyApply) 도메인으로 변환한다.")
+    void toFamilyApplySuccess() {
+        // when
+        FamilyApply result = RemoveFamilyMemberMapper.toFamilyApply(10L, 1L);
+
+        // then
+        assertThat(result.getRequesterSubId()).isEqualTo(10L);
+        assertThat(result.getApplyType()).isEqualTo(ApplyType.REMOVE);
+        assertThat(result.getStatus()).isEqualTo(ApplyStatus.PENDING);
+    }
+
+    @Test
+    @DisplayName("성공: 개별 삭제 스케줄 도메인으로 변환한다.")
+    void toFamilyRemoveScheduleSuccess() {
+        LocalDate date = LocalDate.now();
+        // when
+        FamilyRemoveSchedule result = RemoveFamilyMemberMapper.toFamilyRemoveSchedule(1L, 20L, date);
+
+        // then
+        assertThat(result.getFamilyId()).isEqualTo(1L);
+        assertThat(result.getTargetSubId()).isEqualTo(20L);
+        assertThat(result.getScheduleDate()).isEqualTo(date);
+        assertThat(result.getStatus()).isEqualTo(DeleteStatus.SCHEDULED);
+    }
+
+    @Test
+    @DisplayName("성공: 삭제 스케줄 리스트를 최종 응답 DTO로 변환한다.")
+    void toRemoveFamilyMemberResponseSuccess() {
+        // given
+        FamilyApply apply = FamilyApply.builder().id(100L).familyId(1L).build();
+        FamilyRemoveSchedule schedule = FamilyRemoveSchedule.builder()
+                .targetSubId(20L).scheduleDate(LocalDate.now()).status(DeleteStatus.SCHEDULED).build();
+
+        // when
+        RemoveFamilyMemberResponse response = RemoveFamilyMemberMapper.toRemoveFamilyMemberResponse(apply, List.of(schedule));
+
+        // then
+        assertThat(response.familyApplyId()).isEqualTo(100L);
+        assertThat(response.subIdList()).containsExactly(20L);
+        assertThat(response.status()).isEqualTo(DeleteStatus.SCHEDULED);
+    }
+}

--- a/src/test/java/hotspot/user/family/infrastructure/FamilyRemoveScheduleRepositoryImplTest.java
+++ b/src/test/java/hotspot/user/family/infrastructure/FamilyRemoveScheduleRepositoryImplTest.java
@@ -1,0 +1,70 @@
+package hotspot.user.family.infrastructure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.BDDMockito.given;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import hotspot.user.family.domain.DeleteStatus;
+import hotspot.user.family.domain.FamilyRemoveSchedule;
+import hotspot.user.family.infrastructure.entity.FamilyRemoveScheduleEntity;
+
+@ExtendWith(MockitoExtension.class)
+class FamilyRemoveScheduleRepositoryImplTest {
+
+    @InjectMocks
+    private FamilyRemoveScheduleRepositoryImpl familyRemoveScheduleRepository;
+
+    @Mock
+    private FamilyRemoveScheduleJpaRepository familyRemoveScheduleJpaRepository;
+
+    @Test
+    @DisplayName("성공: 여러 개의 삭제 스케줄을 한꺼번에 저장한다.")
+    void saveAllSuccess() {
+        // given
+        FamilyRemoveSchedule schedule1 = FamilyRemoveSchedule.builder()
+                .targetSubId(10L).familyId(1L).scheduleDate(LocalDate.now()).status(DeleteStatus.SCHEDULED).build();
+        FamilyRemoveSchedule schedule2 = FamilyRemoveSchedule.builder()
+                .targetSubId(11L).familyId(1L).scheduleDate(LocalDate.now()).status(DeleteStatus.SCHEDULED).build();
+
+        given(familyRemoveScheduleJpaRepository.saveAll(anyList())).willReturn(List.of(
+                FamilyRemoveScheduleEntity.domainToEntity(schedule1),
+                FamilyRemoveScheduleEntity.domainToEntity(schedule2)
+        ));
+
+        // when
+        List<FamilyRemoveSchedule> result = familyRemoveScheduleRepository.saveAll(List.of(schedule1, schedule2));
+
+        // then
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).getTargetSubId()).isEqualTo(10L);
+    }
+
+    @Test
+    @DisplayName("성공: 특정 회선 ID 리스트와 상태로 삭제 스케줄을 조회한다.")
+    void findAllByTargetSubIdInAndStatusSuccess() {
+        // given
+        List<Long> subIds = List.of(10L, 11L);
+        FamilyRemoveScheduleEntity entity = FamilyRemoveScheduleEntity.builder()
+                .targetSubId(10L).familyId(1L).status(DeleteStatus.SCHEDULED).build();
+
+        given(familyRemoveScheduleJpaRepository.findAllByTargetSubIdInAndStatus(subIds, DeleteStatus.SCHEDULED))
+                .willReturn(List.of(entity));
+
+        // when
+        List<FamilyRemoveSchedule> result = familyRemoveScheduleRepository.findAllByTargetSubIdInAndStatus(subIds, DeleteStatus.SCHEDULED);
+
+        // then
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getTargetSubId()).isEqualTo(10L);
+    }
+}

--- a/src/test/java/hotspot/user/family/infrastructure/FamilyRemoveScheduleRepositoryImplTest.java
+++ b/src/test/java/hotspot/user/family/infrastructure/FamilyRemoveScheduleRepositoryImplTest.java
@@ -61,7 +61,8 @@ class FamilyRemoveScheduleRepositoryImplTest {
                 .willReturn(List.of(entity));
 
         // when
-        List<FamilyRemoveSchedule> result = familyRemoveScheduleRepository.findAllByTargetSubIdInAndStatus(subIds, DeleteStatus.SCHEDULED);
+        List<FamilyRemoveSchedule> result = familyRemoveScheduleRepository
+                .findAllByTargetSubIdInAndStatus(subIds, DeleteStatus.SCHEDULED);
 
         // then
         assertThat(result).hasSize(1);

--- a/src/test/java/hotspot/user/family/service/RemoveFamilyMemberServiceImplTest.java
+++ b/src/test/java/hotspot/user/family/service/RemoveFamilyMemberServiceImplTest.java
@@ -1,0 +1,156 @@
+package hotspot.user.family.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import hotspot.user.common.exception.ApplicationException;
+import hotspot.user.common.exception.code.FamilyErrorCode;
+import hotspot.user.family.controller.request.RemoveFamilyMemberRequest;
+import hotspot.user.family.controller.response.RemoveFamilyMemberResponse;
+import hotspot.user.family.domain.DeleteStatus;
+import hotspot.user.family.domain.Family;
+import hotspot.user.family.domain.FamilyApply;
+import hotspot.user.family.domain.FamilyRemoveSchedule;
+import hotspot.user.family.domain.FamilySubscription;
+import hotspot.user.family.service.port.FamilyApplyRepository;
+import hotspot.user.family.service.port.FamilyRemoveScheduleRepository;
+import hotspot.user.family.service.port.FamilySubscriptionRepository;
+import hotspot.user.member.domain.FamilyRole;
+import hotspot.user.subscription.domain.Subscription;
+
+@ExtendWith(MockitoExtension.class)
+class RemoveFamilyMemberServiceImplTest {
+
+    @InjectMocks
+    private RemoveFamilyMemberServiceImpl removeFamilyMemberService;
+
+    @Mock
+    private FamilyApplyRepository familyApplyRepository;
+
+    @Mock
+    private FamilySubscriptionRepository familySubscriptionRepository;
+
+    @Mock
+    private FamilyRemoveScheduleRepository familyRemoveScheduleRepository;
+
+    @Test
+    @DisplayName("성공: OWNER가 자신을 포함한 가족 구성원 삭제 신청을 하면 성공한다.")
+    void removeFamilyMemberSuccess() {
+        // given
+        Long requesterMemberId = 1L;
+        Long familyId = 10L;
+        Long requesterSubId = 100L;
+        Long targetSubId = 200L;
+
+        // 방장 정보 설정
+        FamilySubscription requesterFs = createFs(familyId, requesterSubId, FamilyRole.OWNER);
+        given(familySubscriptionRepository.findByMemberId(requesterMemberId)).willReturn(Optional.of(requesterFs));
+
+        // 삭제 대상 리스트 (본인 포함)
+        RemoveFamilyMemberRequest request = new RemoveFamilyMemberRequest(List.of(requesterSubId, targetSubId));
+
+        // 일괄 조회 모킹
+        FamilySubscription targetFs = createFs(familyId, targetSubId, FamilyRole.CHILD);
+        given(familySubscriptionRepository.findAllBySubIdIn(anyList())).willReturn(List.of(requesterFs, targetFs));
+        given(familyRemoveScheduleRepository.findAllByTargetSubIdInAndStatus(anyList(), eq(DeleteStatus.SCHEDULED)))
+                .willReturn(List.of()); // 중복 신청 없음
+
+        given(familyApplyRepository.save(any())).willReturn(FamilyApply.builder().id(1L).familyId(familyId).build());
+        given(familyRemoveScheduleRepository.saveAll(anyList())).willReturn(List.of(
+                FamilyRemoveSchedule.builder().targetSubId(requesterSubId).build(),
+                FamilyRemoveSchedule.builder().targetSubId(targetSubId).build()
+        ));
+
+        // when
+        RemoveFamilyMemberResponse response = removeFamilyMemberService.removeFamilyMember(requesterMemberId, request);
+
+        // then
+        assertThat(response.subIdList()).hasSize(2);
+        assertThat(response.familyId()).isEqualTo(familyId);
+    }
+
+    @Test
+    @DisplayName("실패: 요청자가 OWNER가 아니면 예외가 발생한다.")
+    void removeFamilyMemberFailNotOwner() {
+        // given
+        FamilySubscription requesterFs = createFs(10L, 100L, FamilyRole.CHILD); // OWNER 아님
+        given(familySubscriptionRepository.findByMemberId(anyLong())).willReturn(Optional.of(requesterFs));
+
+        RemoveFamilyMemberRequest request = new RemoveFamilyMemberRequest(List.of());
+
+        // when & then
+        assertThatThrownBy(() -> removeFamilyMemberService.removeFamilyMember(1L, request))
+                .isInstanceOf(ApplicationException.class)
+                .hasMessage(FamilyErrorCode.ONLY_OWNER_CAN_MANAGE.getMessage());
+    }
+
+    @Test
+    @DisplayName("실패: 삭제 대상 중 다른 가족 구성원이 포함되어 있으면 예외가 발생한다.")
+    void removeFamilyMemberFailNotMyFamily() {
+        // given
+        Long requesterMemberId = 1L;
+        Long myFamilyId = 10L;
+        given(familySubscriptionRepository.findByMemberId(requesterMemberId))
+                .willReturn(Optional.of(createFs(myFamilyId, 100L, FamilyRole.OWNER)));
+
+        Long otherFamilySubId = 999L;
+        RemoveFamilyMemberRequest request = new RemoveFamilyMemberRequest(List.of(otherFamilySubId));
+
+        // 다른 가족 소속인 구성원 모킹
+        FamilySubscription otherFs = createFs(20L, otherFamilySubId, FamilyRole.CHILD); // familyId가 20임
+        given(familySubscriptionRepository.findAllBySubIdIn(anyList())).willReturn(List.of(otherFs));
+
+        // when & then
+        assertThatThrownBy(() -> removeFamilyMemberService.removeFamilyMember(requesterMemberId, request))
+                .isInstanceOf(ApplicationException.class)
+                .hasMessage(FamilyErrorCode.NOT_FAMILY_MEMBER.getMessage());
+    }
+
+    @Test
+    @DisplayName("실패: 이미 삭제 예정인 구성원을 다시 삭제 신청하면 예외가 발생한다.")
+    void removeFamilyMemberFailDuplicateApply() {
+        // given
+        Long requesterMemberId = 1L;
+        Long familyId = 10L;
+        given(familySubscriptionRepository.findByMemberId(requesterMemberId))
+                .willReturn(Optional.of(createFs(familyId, 100L, FamilyRole.OWNER)));
+
+        Long targetSubId = 200L;
+        RemoveFamilyMemberRequest request = new RemoveFamilyMemberRequest(List.of(targetSubId));
+
+        given(familySubscriptionRepository.findAllBySubIdIn(anyList()))
+                .willReturn(List.of(createFs(familyId, targetSubId, FamilyRole.CHILD)));
+
+        // 이미 스케줄이 존재함 모킹
+        given(familyRemoveScheduleRepository.findAllByTargetSubIdInAndStatus(anyList(), eq(DeleteStatus.SCHEDULED)))
+                .willReturn(List.of(FamilyRemoveSchedule.builder().targetSubId(targetSubId).build()));
+
+        // when & then
+        assertThatThrownBy(() -> removeFamilyMemberService.removeFamilyMember(requesterMemberId, request))
+                .isInstanceOf(ApplicationException.class)
+                .hasMessage(FamilyErrorCode.DUPLICATE_FAMILY_APPLY.getMessage());
+    }
+
+    private FamilySubscription createFs(Long familyId, Long subId, FamilyRole role) {
+        return FamilySubscription.builder()
+                .family(Family.builder().id(familyId).build())
+                .subscription(Subscription.builder().id(subId).build())
+                .familyRole(role)
+                .build();
+    }
+}


### PR DESCRIPTION
## 🎫 지라 티켓

<!-- 지라 티켓을 작성해주세요 ex) HOTSPOT-123 -->
HOTSPOT-168

---

## 🔗 GitHub 이슈
<!-- 자동 close를 원하면 아래 형식으로 작성
예) Closes #12
-->
Closes #113

---


## ✅ 작업 사항

<!-- 작업한 부분을 설명해주세요. -->

가족 내 구성원 삭제 신청 및 배치 예약(Schedule) 기능을 구현
즉시 삭제가 아닌, 신청 익월 1일에 일괄 처리되는 비즈니스 정책 반영

---

  1. Controller
   * `POST /api/v1/families/delete`를 통해 삭제 신청 접수 처리
   * 다건 처리 지원: 리스트 형태의 targetSubIdList를 통해 여러 명을 한 번에 삭제 신청 가능

<br/>

  2. Service
   * 권한 및 소속 검증: 삭제 대상자들이 실제 요청자와 동일한 가족 그룹에 속해 있는지 IN 절 일괄 조회를 통해 검증
   * 중복 신청 방지: 이미 삭제가 예정(`SCHEDULED` 상태)된 대상자에 대한 중복 신청 차단 로직 추가
   * 삭제 정책 반영: 삭제 예정일(`scheduleDate`)을 신청일 기준 익월 1일로 자동 계산 로직 구현
   * 성능 최적화: Set 자료구조와 일괄 조회 로직을 활용하여 시간 복잡도를 $O(N)$으로 최적화 및 N+1 문제 해결

<br/>

  3. Repository / Infrastructure
   * 일괄 처리 기능
     * `FamilyRemoveScheduleRepository`에 `saveAll` 및 상태별 일괄 조회(`findAllByTargetSubIdInAndStatus`) 메서드 추가

<br/>

  4. Domain / Mapper 계층
   * 1:N 구조 지원: 부모인 FamilyApply와 자식인 FamilyRemoveSchedule 간의 데이터 연계 로직 구현.

---

## 📋 체크리스트

<!-- PR 제출 전 확인해주세요. 해당 항목에 [x]로 체크해주세요. -->

- [x] 코드가 정상적으로 빌드됩니다.
- [x] 관련 테스트 코드를 작성했습니다.
- [x] 기존 테스트가 모두 통과합니다.
- [x] 코드 스타일(Spotless, Checkstyle)을 준수합니다.
- [x] Jira 티켓 상태를 In Review / Done으로 변경했습니다.

---

## ⌨ 기타
