### PR TITLE
[HOTSPOT-216] 가족 구성원 삭제 신청 로직 수정 & 요금제 데이터 사용량 데이터 타입 변경

### DIFF
--- a/src/main/java/hotspot/user/family/controller/response/RemoveFamilyMemberResponse.java
+++ b/src/main/java/hotspot/user/family/controller/response/RemoveFamilyMemberResponse.java
@@ -1,9 +1,7 @@
 package hotspot.user.family.controller.response;
 
-import java.time.LocalDate;
 import java.util.List;
 
-import hotspot.user.family.domain.DeleteStatus;
 import lombok.Builder;
 
 /**
@@ -11,15 +9,11 @@ import lombok.Builder;
  * @param familyApplyId
  * @param familyId
  * @param subIdList
- * @param status
- * @param scheduleDate
  */
 @Builder
 public record RemoveFamilyMemberResponse(
         Long familyApplyId,
         Long familyId,
-        List<Long> subIdList,
-        DeleteStatus status,
-        LocalDate scheduleDate
+        List<Long> subIdList
 ) {
 }

--- a/src/main/java/hotspot/user/family/controller/swagger/FamilyApplyApi.java
+++ b/src/main/java/hotspot/user/family/controller/swagger/FamilyApplyApi.java
@@ -32,7 +32,7 @@ public interface FamilyApplyApi {
         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청\n"
                                          + "- FAMILY_013: 이미 가족에 속해있는 구성원입니다.\n"
                                          + "- FAMILY_017: 타인에게 OWNER 역할을 부여할 수 없습니다.\n"
-                                         + "- FAMILY_019: 유효하지 않은 신청 타입입니다.",
+                                         + "- FAMILY_019: 가족 신규 생성 신청 시에는 CREATE 타입만 가능합니다.",
                      content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "찾을 수 없음\n"
                                          + "- SUB_001: 회선 정보를 찾을 수 없습니다.",
@@ -45,14 +45,14 @@ public interface FamilyApplyApi {
             @Valid @RequestBody CreateNewFamilyRequest request,
             @Parameter(hidden = true) @AuthenticationPrincipal PrincipalDetails principal);
 
-    @Operation(summary = "가족 구성원 추가 신청 (다건)",
-               description = "가족 OWNER가 여러 명의 새로운 구성원을 가족으로 추가하기 위해 신청을 생성합니다.")
+    @Operation(summary = "가족 구성원 추가 신청",
+               description = "가족 OWNER가 여러 명의 새로운 구성원을 가족으로 추가하기 위해 신청을 생성합니다. (ApplyType: ADD)")
     @ApiResponses(value = {
         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "신청 성공"),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청\n"
                                          + "- FAMILY_013: 이미 가족에 속해있는 구성원입니다.\n"
                                          + "- FAMILY_017: 타인에게 OWNER 역할을 부여할 수 없습니다.\n"
-                                         + "- FAMILY_019: 유효하지 않은 신청 타입입니다.",
+                                         + "- FAMILY_019: 가족 구성원 추가 신청 시에는 ADD 타입만 가능합니다.",
                      content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "권한 없음\n"
                                          + "- FAMILY_002: 가족에 가입된 회선 정보를 찾을 수 없습니다.\n"
@@ -70,7 +70,7 @@ public interface FamilyApplyApi {
             @Parameter(hidden = true) @AuthenticationPrincipal PrincipalDetails principal);
 
     @Operation(summary = "가족 구성원 삭제 신청",
-               description = "가족 OWNER가 한 명 or 여러 명의 구성원을 가족에서 삭제하기 위해 신청을 생성합니다. (다음 달 1일 삭제 예정)")
+               description = "가족 OWNER가 자신을 포함한 여러 명의 구성원을 가족에서 삭제하기 위한 신청을 생성합니다. (익월 1일 일괄 삭제 예정)")
     @ApiResponses(value = {
         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "신청 성공"),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청\n"

--- a/src/main/java/hotspot/user/family/domain/mapper/FamilyApplyMapper.java
+++ b/src/main/java/hotspot/user/family/domain/mapper/FamilyApplyMapper.java
@@ -5,6 +5,7 @@ import java.util.Map;
 
 import hotspot.user.family.controller.request.AddFamilyMemberRequest;
 import hotspot.user.family.controller.request.CreateNewFamilyRequest;
+import hotspot.user.family.controller.request.RemoveFamilyMemberRequest;
 import hotspot.user.family.controller.response.AddFamilyMemberResponse;
 import hotspot.user.family.controller.response.CreateNewFamilyResponse;
 import hotspot.user.family.controller.response.FamilyMemberResponse;
@@ -42,7 +43,17 @@ public class FamilyApplyMapper {
                 .build();
     }
 
-    // 3. 타겟 도메인 생성
+    // 3. 삭제 신청용 (RemoveFamilyMemberRequest 대응)
+    public static FamilyApply toFamilyApply(Long requesterSubId, Long familyId, RemoveFamilyMemberRequest request) {
+        return FamilyApply.builder()
+                .requesterSubId(requesterSubId)
+                .familyId(familyId)
+                .applyType(ApplyType.REMOVE)
+                .status(ApplyStatus.PENDING)
+                .build();
+    }
+
+    // 4. 타겟 도메인 생성
     public static FamilyApplyTarget toFamilyApplyTarget(Long familyApplyId, Long targetSubId, FamilyRole role) {
         return FamilyApplyTarget.builder()
                 .familyApplyId(familyApplyId)

--- a/src/main/java/hotspot/user/family/domain/mapper/RemoveFamilyMemberMapper.java
+++ b/src/main/java/hotspot/user/family/domain/mapper/RemoveFamilyMemberMapper.java
@@ -1,14 +1,13 @@
 package hotspot.user.family.domain.mapper;
 
-import java.time.LocalDate;
 import java.util.List;
 
+import hotspot.user.family.controller.request.RemoveFamilyMemberRequest;
 import hotspot.user.family.controller.response.RemoveFamilyMemberResponse;
 import hotspot.user.family.domain.ApplyStatus;
 import hotspot.user.family.domain.ApplyType;
-import hotspot.user.family.domain.DeleteStatus;
 import hotspot.user.family.domain.FamilyApply;
-import hotspot.user.family.domain.FamilyRemoveSchedule;
+import hotspot.user.family.domain.FamilyApplyTarget;
 
 /**
  * 가족 구성원 삭제 신청 Mapper
@@ -16,7 +15,7 @@ import hotspot.user.family.domain.FamilyRemoveSchedule;
 public class RemoveFamilyMemberMapper {
 
     // request -> domain
-    public static FamilyApply toFamilyApply(Long requesterSubId, Long familyId) {
+    public static FamilyApply toFamilyApply(Long requesterSubId, Long familyId, RemoveFamilyMemberRequest request) {
         return FamilyApply.builder()
                 .requesterSubId(requesterSubId)
                 .familyId(familyId)
@@ -25,35 +24,19 @@ public class RemoveFamilyMemberMapper {
                 .build();
     }
 
-    // 개별 삭제 스케줄 생성
-    public static FamilyRemoveSchedule toFamilyRemoveSchedule(Long familyId, Long targetSubId, LocalDate scheduleDate) {
-        return FamilyRemoveSchedule.builder()
-                .familyId(familyId)
-                .targetSubId(targetSubId)
-                .scheduleDate(scheduleDate)
-                .status(DeleteStatus.SCHEDULED)
-                .build();
-    }
-
     // domain -> response
     public static RemoveFamilyMemberResponse toRemoveFamilyMemberResponse(
             FamilyApply familyApply,
-            List<FamilyRemoveSchedule> schedules) {
+            List<FamilyApplyTarget> targets) {
 
-        List<Long> subIdList = schedules.stream()
-                .map(FamilyRemoveSchedule::getTargetSubId)
+        List<Long> subIdList = targets.stream()
+                .map(FamilyApplyTarget::getTargetSubId)
                 .toList();
-
-        // 모든 스케줄의 날짜와 상태는 동일하므로 첫 번째 것을 참조
-        LocalDate scheduleDate = schedules.isEmpty() ? null : schedules.get(0).getScheduleDate();
-        DeleteStatus status = schedules.isEmpty() ? null : schedules.get(0).getStatus();
 
         return RemoveFamilyMemberResponse.builder()
                 .familyApplyId(familyApply.getId())
                 .familyId(familyApply.getFamilyId())
                 .subIdList(subIdList)
-                .status(status)
-                .scheduleDate(scheduleDate)
                 .build();
     }
 }

--- a/src/main/java/hotspot/user/family/service/RemoveFamilyMemberServiceImpl.java
+++ b/src/main/java/hotspot/user/family/service/RemoveFamilyMemberServiceImpl.java
@@ -1,7 +1,8 @@
 package hotspot.user.family.service;
 
-import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -11,13 +12,13 @@ import hotspot.user.common.exception.code.FamilyErrorCode;
 import hotspot.user.family.controller.port.RemoveFamilyMemberService;
 import hotspot.user.family.controller.request.RemoveFamilyMemberRequest;
 import hotspot.user.family.controller.response.RemoveFamilyMemberResponse;
-import hotspot.user.family.domain.DeleteStatus;
 import hotspot.user.family.domain.FamilyApply;
-import hotspot.user.family.domain.FamilyRemoveSchedule;
+import hotspot.user.family.domain.FamilyApplyTarget;
 import hotspot.user.family.domain.FamilySubscription;
+import hotspot.user.family.domain.mapper.FamilyApplyMapper;
 import hotspot.user.family.domain.mapper.RemoveFamilyMemberMapper;
 import hotspot.user.family.service.port.FamilyApplyRepository;
-import hotspot.user.family.service.port.FamilyRemoveScheduleRepository;
+import hotspot.user.family.service.port.FamilyApplyTargetRepository;
 import hotspot.user.family.service.port.FamilySubscriptionRepository;
 import hotspot.user.member.domain.FamilyRole;
 import lombok.RequiredArgsConstructor;
@@ -32,7 +33,7 @@ public class RemoveFamilyMemberServiceImpl implements RemoveFamilyMemberService 
 
     private final FamilyApplyRepository familyApplyRepository;
     private final FamilySubscriptionRepository familySubscriptionRepository;
-    private final FamilyRemoveScheduleRepository familyRemoveScheduleRepository;
+    private final FamilyApplyTargetRepository familyApplyTargetRepository;
 
     @Override
     public RemoveFamilyMemberResponse removeFamilyMember(Long requesterMemberId, RemoveFamilyMemberRequest request) {
@@ -60,7 +61,7 @@ public class RemoveFamilyMemberServiceImpl implements RemoveFamilyMemberService 
             throw new ApplicationException(FamilyErrorCode.FAMILY_SUBSCRIPTION_NOT_FOUND);
         }
 
-        // 모든 대상이 현재 방장과 같은 가족 소속인지 확인
+        // 모든 대상이 현재 방장과 같은 가족 소속인지 확인 (선언적 검증)
         boolean allInSameFamily = targetFsList.stream()
                 .allMatch(fs -> fs.getFamily().getId().equals(familyId));
 
@@ -68,28 +69,33 @@ public class RemoveFamilyMemberServiceImpl implements RemoveFamilyMemberService 
             throw new ApplicationException(FamilyErrorCode.NOT_FAMILY_MEMBER);
         }
 
-        // 이미 처리 대기 중인(SCHEDULED) 신청이 있는지 확인
-        List<FamilyRemoveSchedule> existingSchedules = familyRemoveScheduleRepository
-                .findAllByTargetSubIdInAndStatus(targetSubIds, DeleteStatus.SCHEDULED);
+        // 이미 처리 대기 중인(PENDING) 신청이 있는지 확인 (FamilyApplyTarget 테이블 조회)
+        List<FamilyApplyTarget> existingApplies = familyApplyTargetRepository
+                .findAllPendingByTargetSubIdIn(targetSubIds);
 
-        if (!existingSchedules.isEmpty()) {
+        if (!existingApplies.isEmpty()) {
             throw new ApplicationException(FamilyErrorCode.DUPLICATE_FAMILY_APPLY);
         }
 
-        // 4. 신청서 저장
-        FamilyApply apply = RemoveFamilyMemberMapper.toFamilyApply(requesterFs.getSubscription().getId(), familyId);
+        // 4. 신청서 저장 (부모)
+        FamilyApply apply = FamilyApplyMapper.toFamilyApply(requesterFs.getSubscription().getId(), familyId, request);
         FamilyApply savedApply = familyApplyRepository.save(apply);
 
-        // 5. 삭제 스케줄 생성 및 저장 - 다음 달 1일로 설정
-        LocalDate scheduleDate = LocalDate.now().plusMonths(1).withDayOfMonth(1);
+        // 5. 삭제 대상자 리스트 생성 및 일괄 저장 (자식)
+        // 이미 조회된 targetFsList를 활용해 각 사용자의 현재 역할을 주입
+        Map<Long, FamilyRole> subIdToRoleMap = targetFsList.stream()
+                .collect(Collectors.toMap(fs -> fs.getSubscription().getId(), FamilySubscription::getFamilyRole));
 
-        List<FamilyRemoveSchedule> schedules = targetSubIds.stream()
-                .map(subId -> RemoveFamilyMemberMapper.toFamilyRemoveSchedule(familyId, subId, scheduleDate))
+        List<FamilyApplyTarget> targets = targetSubIds.stream()
+                .map(subId -> FamilyApplyMapper.toFamilyApplyTarget(
+                        savedApply.getId(),
+                        subId,
+                        subIdToRoleMap.get(subId)))
                 .toList();
 
-        List<FamilyRemoveSchedule> savedSchedules = familyRemoveScheduleRepository.saveAll(schedules);
+        List<FamilyApplyTarget> savedTargets = familyApplyTargetRepository.saveAll(targets);
 
-        // 6. 응답 변환
-        return RemoveFamilyMemberMapper.toRemoveFamilyMemberResponse(savedApply, savedSchedules);
+        // 6. 응답 반환
+        return RemoveFamilyMemberMapper.toRemoveFamilyMemberResponse(savedApply, savedTargets);
     }
 }

--- a/src/main/java/hotspot/user/plan/controller/response/PlanResponse.java
+++ b/src/main/java/hotspot/user/plan/controller/response/PlanResponse.java
@@ -4,7 +4,7 @@ import hotspot.user.plan.domain.DataPeriod;
 
 public record PlanResponse(
         String name,
-        int dataAmount,
+        long dataAmount,
         DataPeriod dataPeriod
 ) {
 }

--- a/src/main/java/hotspot/user/plan/domain/Plan.java
+++ b/src/main/java/hotspot/user/plan/domain/Plan.java
@@ -13,6 +13,6 @@ import lombok.Getter;
 public class Plan {
     private final Long id; // DB 저장 전에는 null, 저장 후 ID 할당됨
     private final String name;
-    private final int dataAmount;
+    private final Long dataAmount;
     private final DataPeriod dataPeriod;
 }

--- a/src/main/java/hotspot/user/plan/infrastructure/entity/PlanEntity.java
+++ b/src/main/java/hotspot/user/plan/infrastructure/entity/PlanEntity.java
@@ -40,7 +40,7 @@ public class PlanEntity extends BaseEntity {
     @Column(length = 20, nullable = false)
     private String planName;
 
-    private int planDataAmount;
+    private Long planDataAmount;
 
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)

--- a/src/test/java/hotspot/user/family/controller/FamilyApplyControllerTest.java
+++ b/src/test/java/hotspot/user/family/controller/FamilyApplyControllerTest.java
@@ -145,7 +145,6 @@ class FamilyApplyControllerTest {
                 .familyApplyId(1L)
                 .familyId(100L)
                 .subIdList(List.of(200L, 201L))
-                .status(hotspot.user.family.domain.DeleteStatus.SCHEDULED)
                 .build();
 
         given(removeFamilyMemberService.removeFamilyMember(eq(1L), any(RemoveFamilyMemberRequest.class)))

--- a/src/test/java/hotspot/user/family/domain/mapper/RemoveFamilyMemberMapperTest.java
+++ b/src/test/java/hotspot/user/family/domain/mapper/RemoveFamilyMemberMapperTest.java
@@ -2,26 +2,29 @@ package hotspot.user.family.domain.mapper;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.time.LocalDate;
 import java.util.List;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import hotspot.user.family.controller.request.RemoveFamilyMemberRequest;
 import hotspot.user.family.controller.response.RemoveFamilyMemberResponse;
 import hotspot.user.family.domain.ApplyStatus;
 import hotspot.user.family.domain.ApplyType;
-import hotspot.user.family.domain.DeleteStatus;
 import hotspot.user.family.domain.FamilyApply;
-import hotspot.user.family.domain.FamilyRemoveSchedule;
+import hotspot.user.family.domain.FamilyApplyTarget;
+import hotspot.user.member.domain.FamilyRole;
 
 class RemoveFamilyMemberMapperTest {
 
     @Test
     @DisplayName("성공: 삭제 신청서(FamilyApply) 도메인으로 변환한다.")
     void toFamilyApplySuccess() {
+        // given
+        RemoveFamilyMemberRequest request = new RemoveFamilyMemberRequest(List.of(20L));
+
         // when
-        FamilyApply result = RemoveFamilyMemberMapper.toFamilyApply(10L, 1L);
+        FamilyApply result = RemoveFamilyMemberMapper.toFamilyApply(10L, 1L, request);
 
         // then
         assertThat(result.getRequesterSubId()).isEqualTo(10L);
@@ -30,34 +33,19 @@ class RemoveFamilyMemberMapperTest {
     }
 
     @Test
-    @DisplayName("성공: 개별 삭제 스케줄 도메인으로 변환한다.")
-    void toFamilyRemoveScheduleSuccess() {
-        LocalDate date = LocalDate.now();
-        // when
-        FamilyRemoveSchedule result = RemoveFamilyMemberMapper.toFamilyRemoveSchedule(1L, 20L, date);
-
-        // then
-        assertThat(result.getFamilyId()).isEqualTo(1L);
-        assertThat(result.getTargetSubId()).isEqualTo(20L);
-        assertThat(result.getScheduleDate()).isEqualTo(date);
-        assertThat(result.getStatus()).isEqualTo(DeleteStatus.SCHEDULED);
-    }
-
-    @Test
-    @DisplayName("성공: 삭제 스케줄 리스트를 최종 응답 DTO로 변환한다.")
+    @DisplayName("성공: 신청 대상자(FamilyApplyTarget) 리스트를 최종 응답 DTO로 변환한다.")
     void toRemoveFamilyMemberResponseSuccess() {
         // given
         FamilyApply apply = FamilyApply.builder().id(100L).familyId(1L).build();
-        FamilyRemoveSchedule schedule = FamilyRemoveSchedule.builder()
-                .targetSubId(20L).scheduleDate(LocalDate.now()).status(DeleteStatus.SCHEDULED).build();
+        FamilyApplyTarget target = FamilyApplyTarget.builder()
+                .targetSubId(20L).targetFamilyRole(FamilyRole.CHILD).build();
 
         // when
         RemoveFamilyMemberResponse response = RemoveFamilyMemberMapper
-                .toRemoveFamilyMemberResponse(apply, List.of(schedule));
+                .toRemoveFamilyMemberResponse(apply, List.of(target));
 
         // then
         assertThat(response.familyApplyId()).isEqualTo(100L);
         assertThat(response.subIdList()).containsExactly(20L);
-        assertThat(response.status()).isEqualTo(DeleteStatus.SCHEDULED);
     }
 }

--- a/src/test/java/hotspot/user/family/service/RemoveFamilyMemberServiceImplTest.java
+++ b/src/test/java/hotspot/user/family/service/RemoveFamilyMemberServiceImplTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 
 import java.util.List;
@@ -22,13 +21,12 @@ import hotspot.user.common.exception.ApplicationException;
 import hotspot.user.common.exception.code.FamilyErrorCode;
 import hotspot.user.family.controller.request.RemoveFamilyMemberRequest;
 import hotspot.user.family.controller.response.RemoveFamilyMemberResponse;
-import hotspot.user.family.domain.DeleteStatus;
 import hotspot.user.family.domain.Family;
 import hotspot.user.family.domain.FamilyApply;
-import hotspot.user.family.domain.FamilyRemoveSchedule;
+import hotspot.user.family.domain.FamilyApplyTarget;
 import hotspot.user.family.domain.FamilySubscription;
 import hotspot.user.family.service.port.FamilyApplyRepository;
-import hotspot.user.family.service.port.FamilyRemoveScheduleRepository;
+import hotspot.user.family.service.port.FamilyApplyTargetRepository;
 import hotspot.user.family.service.port.FamilySubscriptionRepository;
 import hotspot.user.member.domain.FamilyRole;
 import hotspot.user.subscription.domain.Subscription;
@@ -46,10 +44,10 @@ class RemoveFamilyMemberServiceImplTest {
     private FamilySubscriptionRepository familySubscriptionRepository;
 
     @Mock
-    private FamilyRemoveScheduleRepository familyRemoveScheduleRepository;
+    private FamilyApplyTargetRepository familyApplyTargetRepository;
 
     @Test
-    @DisplayName("성공: OWNER가 자신을 포함한 가족 구성원 삭제 신청을 하면 성공한다.")
+    @DisplayName("성공: 방장이 자신을 포함한 가족 구성원 삭제 신청을 하면 성공한다.")
     void removeFamilyMemberSuccess() {
         // given
         Long requesterMemberId = 1L;
@@ -57,23 +55,21 @@ class RemoveFamilyMemberServiceImplTest {
         Long requesterSubId = 100L;
         Long targetSubId = 200L;
 
-        // 방장 정보 설정
         FamilySubscription requesterFs = createFs(familyId, requesterSubId, FamilyRole.OWNER);
         given(familySubscriptionRepository.findByMemberId(requesterMemberId)).willReturn(Optional.of(requesterFs));
 
-        // 삭제 대상 리스트 (본인 포함)
         RemoveFamilyMemberRequest request = new RemoveFamilyMemberRequest(List.of(requesterSubId, targetSubId));
 
-        // 일괄 조회 모킹
         FamilySubscription targetFs = createFs(familyId, targetSubId, FamilyRole.CHILD);
         given(familySubscriptionRepository.findAllBySubIdIn(anyList())).willReturn(List.of(requesterFs, targetFs));
-        given(familyRemoveScheduleRepository.findAllByTargetSubIdInAndStatus(anyList(), eq(DeleteStatus.SCHEDULED)))
-                .willReturn(List.of()); // 중복 신청 없음
+
+        // 중복 신청 없음 모킹 (FamilyApplyTarget 테이블 조회)
+        given(familyApplyTargetRepository.findAllPendingByTargetSubIdIn(anyList())).willReturn(List.of());
 
         given(familyApplyRepository.save(any())).willReturn(FamilyApply.builder().id(1L).familyId(familyId).build());
-        given(familyRemoveScheduleRepository.saveAll(anyList())).willReturn(List.of(
-                FamilyRemoveSchedule.builder().targetSubId(requesterSubId).build(),
-                FamilyRemoveSchedule.builder().targetSubId(targetSubId).build()
+        given(familyApplyTargetRepository.saveAll(anyList())).willReturn(List.of(
+                FamilyApplyTarget.builder().targetSubId(requesterSubId).build(),
+                FamilyApplyTarget.builder().targetSubId(targetSubId).build()
         ));
 
         // when
@@ -88,7 +84,7 @@ class RemoveFamilyMemberServiceImplTest {
     @DisplayName("실패: 요청자가 OWNER가 아니면 예외가 발생한다.")
     void removeFamilyMemberFailNotOwner() {
         // given
-        FamilySubscription requesterFs = createFs(10L, 100L, FamilyRole.CHILD); // OWNER 아님
+        FamilySubscription requesterFs = createFs(10L, 100L, FamilyRole.CHILD);
         given(familySubscriptionRepository.findByMemberId(anyLong())).willReturn(Optional.of(requesterFs));
 
         RemoveFamilyMemberRequest request = new RemoveFamilyMemberRequest(List.of());
@@ -100,29 +96,24 @@ class RemoveFamilyMemberServiceImplTest {
     }
 
     @Test
-    @DisplayName("실패: 삭제 대상 중 다른 가족 구성원이 포함되어 있으면 예외가 발생한다.")
-    void removeFamilyMemberFailNotMyFamily() {
+    @DisplayName("실패: 삭제 대상 중 존재하지 않는 회선이 포함되어 있으면 예외가 발생한다.")
+    void removeFamilyMemberFailSubscriptionNotFound() {
         // given
         Long requesterMemberId = 1L;
-        Long myFamilyId = 10L;
         given(familySubscriptionRepository.findByMemberId(requesterMemberId))
-                .willReturn(Optional.of(createFs(myFamilyId, 100L, FamilyRole.OWNER)));
+                .willReturn(Optional.of(createFs(10L, 100L, FamilyRole.OWNER)));
 
-        Long otherFamilySubId = 999L;
-        RemoveFamilyMemberRequest request = new RemoveFamilyMemberRequest(List.of(otherFamilySubId));
-
-        // 다른 가족 소속인 구성원 모킹
-        FamilySubscription otherFs = createFs(20L, otherFamilySubId, FamilyRole.CHILD); // familyId가 20임
-        given(familySubscriptionRepository.findAllBySubIdIn(anyList())).willReturn(List.of(otherFs));
+        RemoveFamilyMemberRequest request = new RemoveFamilyMemberRequest(List.of(999L));
+        given(familySubscriptionRepository.findAllBySubIdIn(anyList())).willReturn(List.of()); // 아무도 못찾음
 
         // when & then
         assertThatThrownBy(() -> removeFamilyMemberService.removeFamilyMember(requesterMemberId, request))
                 .isInstanceOf(ApplicationException.class)
-                .hasMessage(FamilyErrorCode.NOT_FAMILY_MEMBER.getMessage());
+                .hasMessage(FamilyErrorCode.FAMILY_SUBSCRIPTION_NOT_FOUND.getMessage());
     }
 
     @Test
-    @DisplayName("실패: 이미 삭제 예정인 구성원을 다시 삭제 신청하면 예외가 발생한다.")
+    @DisplayName("실패: 이미 삭제 대기 중인(PENDING) 신청이 있으면 예외가 발생한다.")
     void removeFamilyMemberFailDuplicateApply() {
         // given
         Long requesterMemberId = 1L;
@@ -136,9 +127,9 @@ class RemoveFamilyMemberServiceImplTest {
         given(familySubscriptionRepository.findAllBySubIdIn(anyList()))
                 .willReturn(List.of(createFs(familyId, targetSubId, FamilyRole.CHILD)));
 
-        // 이미 스케줄이 존재함 모킹
-        given(familyRemoveScheduleRepository.findAllByTargetSubIdInAndStatus(anyList(), eq(DeleteStatus.SCHEDULED)))
-                .willReturn(List.of(FamilyRemoveSchedule.builder().targetSubId(targetSubId).build()));
+        // 이미 대기 중인 신청 존재 모킹
+        given(familyApplyTargetRepository.findAllPendingByTargetSubIdIn(anyList()))
+                .willReturn(List.of(FamilyApplyTarget.builder().targetSubId(targetSubId).build()));
 
         // when & then
         assertThatThrownBy(() -> removeFamilyMemberService.removeFamilyMember(requesterMemberId, request))

--- a/src/test/java/hotspot/user/plan/infrastructure/PlanRepositoryImplTest.java
+++ b/src/test/java/hotspot/user/plan/infrastructure/PlanRepositoryImplTest.java
@@ -36,7 +36,7 @@ class PlanRepositoryImplTest {
         PlanEntity entity = PlanEntity.builder()
                 .planId(planId)
                 .planName("LTE 기본 요금제")
-                .planDataAmount(10)
+                .planDataAmount(100L)
                 .dataPeriod(DataPeriod.MONTH)
                 .build();
 
@@ -49,7 +49,7 @@ class PlanRepositoryImplTest {
         assertThat(result).isPresent();
         assertThat(result.get().getId()).isEqualTo(planId);
         assertThat(result.get().getName()).isEqualTo("LTE 기본 요금제");
-        assertThat(result.get().getDataAmount()).isEqualTo(10);
+        assertThat(result.get().getDataAmount()).isEqualTo(100L);
         assertThat(result.get().getDataPeriod()).isEqualTo(DataPeriod.MONTH);
     }
 }

--- a/src/test/java/hotspot/user/plan/service/FindPlanServiceImplTest.java
+++ b/src/test/java/hotspot/user/plan/service/FindPlanServiceImplTest.java
@@ -40,7 +40,7 @@ class FindPlanServiceImplTest {
         Plan plan = Plan.builder()
                 .id(planId)
                 .name("베이직 요금제")
-                .dataAmount(10)
+                .dataAmount(100L)
                 .dataPeriod(DataPeriod.MONTH)
                 .build();
 
@@ -51,7 +51,7 @@ class FindPlanServiceImplTest {
 
         // then
         assertThat(result.name()).isEqualTo("베이직 요금제");
-        assertThat(result.dataAmount()).isEqualTo(10);
+        assertThat(result.dataAmount()).isEqualTo(100L);
         assertThat(result.dataPeriod()).isEqualTo(DataPeriod.MONTH);
     }
 

--- a/src/test/java/hotspot/user/subscription/service/FindSubscriptionServiceImplTest.java
+++ b/src/test/java/hotspot/user/subscription/service/FindSubscriptionServiceImplTest.java
@@ -48,7 +48,7 @@ class FindSubscriptionServiceImplTest {
         Plan plan = Plan.builder()
                 .id(1L)
                 .name("베이직")
-                .dataAmount(10)
+                .dataAmount(100L)
                 .dataPeriod(DataPeriod.MONTH)
                 .build();
 
@@ -100,7 +100,7 @@ class FindSubscriptionServiceImplTest {
         Plan plan = Plan.builder()
                 .id(1L)
                 .name("베이직")
-                .dataAmount(10)
+                .dataAmount(100L)
                 .dataPeriod(DataPeriod.MONTH).build();
 
         Member member = Member.builder()


### PR DESCRIPTION
## 🎫 지라 티켓

<!-- 지라 티켓을 작성해주세요 ex) HOTSPOT-123 -->
HOTSPOT-216

---

## 🔗 GitHub 이슈
<!-- 자동 close를 원하면 아래 형식으로 작성
예) Closes #12
-->
Closes #117 

---


## ✅ 작업 사항

<!-- 작업한 부분을 설명해주세요. -->

가족 구성원 삭제 신청 로직 변경
- 변경 전 : 가족 구성원 삭제 신청 시 familyApply, familyRemoveSchedule 테이블에 바로 적재함
- 변경 후 : familyApply, familyApplyTarget 테이블에 적재 후 관리자 쪽에서 familyRemoveSchedule 테이블에 적재함

<br/>

요금제 데이터 사용량 데이터 타입 변경
- 변경 전 : int
- 변경 후 : long

---

## 📋 체크리스트

<!-- PR 제출 전 확인해주세요. 해당 항목에 [x]로 체크해주세요. -->

- [x] 코드가 정상적으로 빌드됩니다.
- [x] 관련 테스트 코드를 작성했습니다.
- [x] 기존 테스트가 모두 통과합니다.
- [x] 코드 스타일(Spotless, Checkstyle)을 준수합니다.
- [x] Jira 티켓 상태를 In Review / Done으로 변경했습니다.

---

## ⌨ 기타
