### PR TITLE
[HOTSPOT-197] 가족 구성원 전체 정보 조회 API 로직 수정

### DIFF
--- a/src/main/java/hotspot/user/family/controller/response/FamilyInfoResponse.java
+++ b/src/main/java/hotspot/user/family/controller/response/FamilyInfoResponse.java
@@ -2,7 +2,6 @@ package hotspot.user.family.controller.response;
 
 import java.util.List;
 
-import hotspot.user.member.controller.response.MemberResponse;
 import lombok.Builder;
 
 /**
@@ -12,6 +11,6 @@ import lombok.Builder;
 public record FamilyInfoResponse(
         Long familyId,
         int familyNum,
-        List<MemberResponse> memberInfoList
+        List<FamilyMemberInfoResponse> memberInfoList
 ) {
 }

--- a/src/main/java/hotspot/user/family/controller/response/FamilyMemberInfoResponse.java
+++ b/src/main/java/hotspot/user/family/controller/response/FamilyMemberInfoResponse.java
@@ -1,0 +1,28 @@
+package hotspot.user.family.controller.response;
+
+import hotspot.user.member.domain.FamilyRole;
+import hotspot.user.member.domain.Status;
+import lombok.Builder;
+
+/**
+ * 가족 정보 조회 시 구성원 세부 정보
+ * @param id
+ * @param name
+ * @param email
+ * @param phone
+ * @param familyRole
+ * @param familyId
+ * @param subId
+ * @param status
+ */
+@Builder
+public record FamilyMemberInfoResponse(
+        Long id,
+        String name,
+        String phone,
+        FamilyRole familyRole,
+        Long familyId,
+        Long subId,
+        Status status
+) {
+}

--- a/src/main/java/hotspot/user/family/controller/response/FamilyMemberInfoResponse.java
+++ b/src/main/java/hotspot/user/family/controller/response/FamilyMemberInfoResponse.java
@@ -8,7 +8,6 @@ import lombok.Builder;
  * 가족 정보 조회 시 구성원 세부 정보
  * @param id
  * @param name
- * @param email
  * @param phone
  * @param familyRole
  * @param familyId

--- a/src/main/java/hotspot/user/family/domain/mapper/FamilyMapper.java
+++ b/src/main/java/hotspot/user/family/domain/mapper/FamilyMapper.java
@@ -3,13 +3,13 @@ package hotspot.user.family.domain.mapper;
 import java.util.List;
 
 import hotspot.user.family.controller.response.FamilyInfoResponse;
+import hotspot.user.family.controller.response.FamilyMemberInfoResponse;
 import hotspot.user.family.controller.response.FamilyResponse;
 import hotspot.user.family.controller.response.MemberPriorityResponse;
 import hotspot.user.family.controller.response.UpdateFamilyPriorityResponse;
 import hotspot.user.family.domain.Family;
 import hotspot.user.family.domain.FamilyDetailInfo;
 import hotspot.user.family.domain.FamilySubscription;
-import hotspot.user.member.controller.response.MemberResponse;
 
 /**
  * request Dto -> 도메인
@@ -48,7 +48,7 @@ public class FamilyMapper {
 
     public static FamilyInfoResponse toFamilyInfoResponse(
             FamilyDetailInfo detailInfo,
-            List<MemberResponse> memberInfoList) {
+            List<FamilyMemberInfoResponse> memberInfoList) {
         return FamilyInfoResponse.builder()
                 .familyId(detailInfo.getFamilyId())
                 .familyNum(detailInfo.getFamilyNum())

--- a/src/main/java/hotspot/user/family/service/FindFamilyInfoServiceImpl.java
+++ b/src/main/java/hotspot/user/family/service/FindFamilyInfoServiceImpl.java
@@ -10,11 +10,11 @@ import hotspot.user.common.exception.ApplicationException;
 import hotspot.user.common.exception.code.FamilyErrorCode;
 import hotspot.user.family.controller.port.FindFamilyInfoService;
 import hotspot.user.family.controller.response.FamilyInfoResponse;
+import hotspot.user.family.controller.response.FamilyMemberInfoResponse;
 import hotspot.user.family.domain.FamilyDetailInfo;
 import hotspot.user.family.domain.mapper.FamilyMapper;
 import hotspot.user.family.service.port.FamilyRepository;
-import hotspot.user.member.controller.response.MemberResponse;
-import hotspot.user.member.domain.mapper.MemberMapper;
+import hotspot.user.member.domain.mapper.FamilyMemberInfoMapper;
 import lombok.RequiredArgsConstructor;
 
 /**
@@ -36,10 +36,10 @@ public class FindFamilyInfoServiceImpl implements FindFamilyInfoService {
                 .orElseThrow(() -> new ApplicationException(FamilyErrorCode.FAMILY_NOT_FOUND));
 
         // 서비스 계층에서 리스트 내 각 멤버의 정보를 복호화하여 매핑
-        List<MemberResponse> memberInfoList = detailInfo.getMemberDetailInfoList().stream()
+        List<FamilyMemberInfoResponse> memberInfoList = detailInfo.getMemberDetailInfoList().stream()
                 .map(info -> {
                     String decryptedPhone = phoneDecryptor.decrypt(info.getPhone());
-                    return MemberMapper.toMemberResponse(info, decryptedPhone);
+                    return FamilyMemberInfoMapper.toFamilyMemberInfoResponse(info, decryptedPhone);
                 })
                 .toList();
 

--- a/src/main/java/hotspot/user/member/domain/mapper/FamilyMemberInfoMapper.java
+++ b/src/main/java/hotspot/user/member/domain/mapper/FamilyMemberInfoMapper.java
@@ -1,7 +1,6 @@
 package hotspot.user.member.domain.mapper;
 
 import hotspot.user.family.controller.response.FamilyMemberInfoResponse;
-
 import hotspot.user.member.domain.MemberDetailInfo;
 
 /**

--- a/src/main/java/hotspot/user/member/domain/mapper/FamilyMemberInfoMapper.java
+++ b/src/main/java/hotspot/user/member/domain/mapper/FamilyMemberInfoMapper.java
@@ -1,0 +1,26 @@
+package hotspot.user.member.domain.mapper;
+
+import hotspot.user.family.controller.response.FamilyMemberInfoResponse;
+
+import hotspot.user.member.domain.MemberDetailInfo;
+
+/**
+ * FamilyMemberInfo 도메인과 DTO 간의 변환을 담당하는 매퍼
+ */
+public class FamilyMemberInfoMapper {
+
+
+    // Domain -> Response
+    public static FamilyMemberInfoResponse toFamilyMemberInfoResponse(MemberDetailInfo info, String decryptedPhone) {
+        return FamilyMemberInfoResponse.builder()
+             .id(info.getMember().getId())
+             .name(info.getMember().getName())
+             .phone(decryptedPhone)
+             .familyRole(info.getRole())
+             .familyId(info.getFamilyId())
+             .subId(info.getSubId())
+             .status(info.getMember().getStatus())
+             .build();
+    }
+
+}

--- a/src/test/java/hotspot/user/family/controller/FamilyControllerTest.java
+++ b/src/test/java/hotspot/user/family/controller/FamilyControllerTest.java
@@ -24,7 +24,7 @@ import hotspot.user.common.security.jwt.JwtFilter;
 import hotspot.user.common.security.jwt.JwtProvider;
 import hotspot.user.family.controller.port.FindFamilyInfoService;
 import hotspot.user.family.controller.response.FamilyInfoResponse;
-import hotspot.user.member.controller.response.MemberResponse;
+import hotspot.user.family.controller.response.FamilyMemberInfoResponse;
 import hotspot.user.member.domain.FamilyRole;
 import hotspot.user.member.domain.Status;
 
@@ -65,26 +65,24 @@ class FamilyControllerTest {
     }
 
     @Test
-    @DisplayName("성공: 가족 정보 조회 API 호출 시 200 OK와 가족 구성원 정보를 반환한다")
+    @DisplayName("성공: 가족 정보 조회 API 호출 시 200 OK와 가족 구성원 정보를 반환한다 (이메일 제외)")
     void getFamilyInfoSuccess() throws Exception {
         // given
         Long familyId = 100L;
         setAuthentication(familyId);
 
-        MemberResponse member1 = MemberResponse.builder()
+        FamilyMemberInfoResponse member1 = FamilyMemberInfoResponse.builder()
                 .id(1L)
                 .name("홍길동")
-                .email("test@test.com")
                 .familyRole(FamilyRole.OWNER)
                 .familyId(familyId)
                 .subId(10L)
                 .status(Status.APPROVED)
                 .build();
 
-        MemberResponse member2 = MemberResponse.builder()
+        FamilyMemberInfoResponse member2 = FamilyMemberInfoResponse.builder()
                 .id(2L)
                 .name("김철수")
-                .email("chulsoo@test.com")
                 .familyRole(FamilyRole.CHILD)
                 .familyId(familyId)
                 .subId(11L)

--- a/src/test/java/hotspot/user/family/service/FindFamilyInfoServiceImplTest.java
+++ b/src/test/java/hotspot/user/family/service/FindFamilyInfoServiceImplTest.java
@@ -38,7 +38,7 @@ class FindFamilyInfoServiceImplTest {
     private FindFamilyInfoServiceImpl findFamilyInfoService;
 
     @Test
-    @DisplayName("성공: 가족 ID로 가족 및 구성원 전체 정보를 조회한다")
+    @DisplayName("성공: 가족 ID로 가족 및 구성원 전체 정보를 조회한다 (이메일 제외)")
     void findFamilyInfoByIdSuccess() {
         // given
         Long familyId = 1L;
@@ -56,7 +56,7 @@ class FindFamilyInfoServiceImplTest {
                 .build();
 
         given(familyRepository.findInfoById(familyId)).willReturn(Optional.of(detailInfo));
-        given(phoneDecryptor.decrypt(anyString())).willReturn("010-1234-5678"); //  추가
+        given(phoneDecryptor.decrypt(anyString())).willReturn("010-1234-5678");
 
         // when
         FamilyInfoResponse response = findFamilyInfoService.findFamilyInfoById(familyId);
@@ -65,8 +65,8 @@ class FindFamilyInfoServiceImplTest {
         assertThat(response.familyId()).isEqualTo(familyId);
         assertThat(response.familyNum()).isEqualTo(1);
         assertThat(response.memberInfoList()).hasSize(1);
-        assertThat(response.memberInfoList().get(0).email()).isEqualTo("test@test.com");
         assertThat(response.memberInfoList().get(0).phone()).isEqualTo("010-1234-5678");
+        // 이메일 검증은 더 이상 수행하지 않음 (FamilyMemberInfoResponse에는 필드 없음)
     }
 
     @Test


### PR DESCRIPTION
## 🎫 지라 티켓

<!-- 지라 티켓을 작성해주세요 ex) HOTSPOT-123 -->
HOTSPOT-197

---

## 🔗 GitHub 이슈
<!-- 자동 close를 원하면 아래 형식으로 작성
예) Closes #12
-->
Closes #99

---


## ✅ 작업 사항

<!-- 작업한 부분을 설명해주세요. -->

가족 구성원 전체 정보를 조회할 때는 email을 응답에서 제외한다.
- 이유
  - 정보 조회 시 (이름, 전화번호, 가족 내 역할)만 응답에 포함
  - email은 회선과는 관련 없는 정보라서 자연스럽지 않아서 삭제함

---

## 📋 체크리스트

<!-- PR 제출 전 확인해주세요. 해당 항목에 [x]로 체크해주세요. -->

- [x] 코드가 정상적으로 빌드됩니다.
- [x] 관련 테스트 코드를 작성했습니다.
- [x] 기존 테스트가 모두 통과합니다.
- [x] 코드 스타일(Spotless, Checkstyle)을 준수합니다.
- [x] Jira 티켓 상태를 In Review / Done으로 변경했습니다.

---

## ⌨ 기타
