### PR TITLE
[HOTSPOT-221] 개인 데이터 사용량 조회 로직 수정

### DIFF
--- a/src/main/java/hotspot/user/usage/subscriptionUsage/controller/response/SubscriptionUsageResponse.java
+++ b/src/main/java/hotspot/user/usage/subscriptionUsage/controller/response/SubscriptionUsageResponse.java
@@ -6,6 +6,7 @@ import java.util.List;
 public record SubscriptionUsageResponse(
         Long subId,
         LocalDateTime currentTime,
+        String planName, // 요금제 이름
         Double subDataAmount,
         Double subDataUsageAmount,
         Double subDataRemainAmount,

--- a/src/main/java/hotspot/user/usage/subscriptionUsage/domain/mapper/SubscriptionUsageMapper.java
+++ b/src/main/java/hotspot/user/usage/subscriptionUsage/domain/mapper/SubscriptionUsageMapper.java
@@ -11,6 +11,7 @@ public class SubscriptionUsageMapper {
 
     public static SubscriptionUsageResponse toSubscriptionUsageResponse(
             SubscriptionUsage usage,
+            String planName,
             Map<Long, String> giftIdToUserName,
             LocalDateTime now
     ) {
@@ -40,6 +41,7 @@ public class SubscriptionUsageMapper {
         return new SubscriptionUsageResponse(
                 usage.subId(),
                 now,
+                planName, // 요금제 이름
                 // 개인 요금제
                 usage.limitGb(),
                 usage.usedGb(),

--- a/src/main/java/hotspot/user/usage/subscriptionUsage/service/FindSubscriptionUsageServiceImpl.java
+++ b/src/main/java/hotspot/user/usage/subscriptionUsage/service/FindSubscriptionUsageServiceImpl.java
@@ -54,11 +54,13 @@ public class FindSubscriptionUsageServiceImpl implements FindSubscriptionUsageSe
                 presentDataRepository.findGiftGiverNames(giftIds);
 
         LocalDateTime now = LocalDateTime.now(clock);
+        String planName = subscription.getPlan().getName(); // 요금제 이름
 
         // Mapper에 전달
         return SubscriptionUsageMapper
                 .toSubscriptionUsageResponse(
                         usage,
+                        planName, // 요금제 이름
                         giftIdToUserName,
                         now
                 );

--- a/src/test/java/hotspot/user/usage/subscriptionUsage/controller/SubscriptionUsageControllerTest.java
+++ b/src/test/java/hotspot/user/usage/subscriptionUsage/controller/SubscriptionUsageControllerTest.java
@@ -55,6 +55,7 @@ class SubscriptionUsageControllerTest {
                 new SubscriptionUsageResponse(
                         1L,
                         now,
+                        "요금제명",
                         24.0,
                         0.0,
                         24.0,


### PR DESCRIPTION
## 🎫 지라 티켓

<!-- 지라 티켓을 작성해주세요 ex) HOTSPOT-123 -->
HOTSPOT-221

---

## 🔗 GitHub 이슈
<!-- 자동 close를 원하면 아래 형식으로 작성
예) Closes #12
-->
Closes #123

---


## ✅ 작업 사항

<!-- 작업한 부분을 설명해주세요. -->

개인 데이터 사용량 조회 시 가입된 요금제 이름 같이 응답으로 리턴하도록 로직 수정

---

## 📋 체크리스트

<!-- PR 제출 전 확인해주세요. 해당 항목에 [x]로 체크해주세요. -->

- [x] 코드가 정상적으로 빌드됩니다.
- [x] 관련 테스트 코드를 작성했습니다.
- [x] 기존 테스트가 모두 통과합니다.
- [x] 코드 스타일(Spotless, Checkstyle)을 준수합니다.
- [x] Jira 티켓 상태를 In Review / Done으로 변경했습니다.

---

## ⌨ 기타
