### PR TITLE
[HOTSPOT-219] SMS 알림 발송 파이프라인 구현

### DIFF
--- a/src/main/java/hotspot/user/common/config/KafkaConsumerConfig.java
+++ b/src/main/java/hotspot/user/common/config/KafkaConsumerConfig.java
@@ -11,6 +11,7 @@ import org.springframework.kafka.listener.ContainerProperties;
 import org.springframework.kafka.listener.DefaultErrorHandler;
 import org.springframework.util.backoff.ExponentialBackOff;
 
+import hotspot.user.dispatch.sms.dto.SmsDispatchCommand;
 import hotspot.user.kafka.dto.UserAlertEvent;
 
 @Configuration
@@ -23,9 +24,14 @@ public class KafkaConsumerConfig {
     private static final long BACKOFF_MAX_ELAPSED_MS = 60_000L;
 
     private final String userAlertConsumerGroup;
+    private final String smsDispatchConsumerGroup;
 
-    public KafkaConsumerConfig(@Value("${app.consumer-groups.user-alert}") String userAlertConsumerGroup) {
+    public KafkaConsumerConfig(
+            @Value("${app.consumer-groups.user-alert}") String userAlertConsumerGroup,
+            @Value("${app.consumer-groups.sms-dispatch}") String smsDispatchConsumerGroup
+    ) {
         this.userAlertConsumerGroup = userAlertConsumerGroup;
+        this.smsDispatchConsumerGroup = smsDispatchConsumerGroup;
     }
 
     @Bean
@@ -45,9 +51,35 @@ public class KafkaConsumerConfig {
     public ConcurrentKafkaListenerContainerFactory<String, UserAlertEvent> userAlertKafkaListenerContainerFactory(
             ConsumerFactory<String, UserAlertEvent> userAlertEventConsumerFactory
     ) {
-        ConcurrentKafkaListenerContainerFactory<String, UserAlertEvent> factory =
+        return buildListenerFactory(userAlertEventConsumerFactory);
+    }
+
+    @Bean
+    public ConsumerFactory<String, SmsDispatchCommand> smsDispatchCommandConsumerFactory(
+            KafkaProperties kafkaProperties,
+            SslBundles sslBundles
+    ) {
+        return KafkaConsumerFactorySupport.createConsumerFactory(
+                kafkaProperties,
+                sslBundles,
+                SmsDispatchCommand.class,
+                smsDispatchConsumerGroup
+        );
+    }
+
+    @Bean(name = "smsDispatchKafkaListenerContainerFactory")
+    public ConcurrentKafkaListenerContainerFactory<String, SmsDispatchCommand> smsDispatchKafkaListenerContainerFactory(
+            ConsumerFactory<String, SmsDispatchCommand> smsDispatchCommandConsumerFactory
+    ) {
+        return buildListenerFactory(smsDispatchCommandConsumerFactory);
+    }
+
+    private <T> ConcurrentKafkaListenerContainerFactory<String, T> buildListenerFactory(
+            ConsumerFactory<String, T> consumerFactory
+    ) {
+        ConcurrentKafkaListenerContainerFactory<String, T> factory =
                 new ConcurrentKafkaListenerContainerFactory<>();
-        factory.setConsumerFactory(userAlertEventConsumerFactory);
+        factory.setConsumerFactory(consumerFactory);
         factory.setConcurrency(CONCURRENCY);
         factory.getContainerProperties().setAckMode(ContainerProperties.AckMode.MANUAL);
 

--- a/src/main/java/hotspot/user/dispatch/sms/config/SmsProperties.java
+++ b/src/main/java/hotspot/user/dispatch/sms/config/SmsProperties.java
@@ -1,0 +1,38 @@
+package hotspot.user.dispatch.sms.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import lombok.Getter;
+
+@Getter
+@Component
+public class SmsProperties {
+
+    private final boolean enabled;
+    private final boolean enabled2;
+    private final boolean enabled3;
+    private final boolean enabled4;
+    private final boolean enabled5;
+    private final String provider;
+    private final String from;
+
+    // SMS 동작 여부/제공자/발신번호 설정값을 초기화한다.
+    public SmsProperties(
+            @Value("${sms.enabled:false}") boolean enabled,
+            @Value("${sms.enabled2:false}") boolean enabled2,
+            @Value("${sms.enabled3:false}") boolean enabled3,
+            @Value("${sms.enabled4:false}") boolean enabled4,
+            @Value("${sms.enabled5:false}") boolean enabled5,
+            @Value("${sms.provider:noop}") String provider,
+            @Value("${sms.from:}") String from
+    ) {
+        this.enabled = enabled;
+        this.enabled2 = enabled2;
+        this.enabled3 = enabled3;
+        this.enabled4 = enabled4;
+        this.enabled5 = enabled5;
+        this.provider = provider;
+        this.from = from;
+    }
+}

--- a/src/main/java/hotspot/user/dispatch/sms/domain/SmsRecipientResolution.java
+++ b/src/main/java/hotspot/user/dispatch/sms/domain/SmsRecipientResolution.java
@@ -1,0 +1,26 @@
+package hotspot.user.dispatch.sms.domain;
+
+public record SmsRecipientResolution(
+        SmsRecipientResolutionStatus status,
+        String phoneNumber
+) {
+    // 수신자 전화번호를 정상적으로 찾은 상태를 생성한다.
+    public static SmsRecipientResolution found(String phoneNumber) {
+        return new SmsRecipientResolution(SmsRecipientResolutionStatus.FOUND, phoneNumber);
+    }
+
+    // 구독 정보가 없어 수신자를 찾지 못한 상태를 생성한다.
+    public static SmsRecipientResolution subscriptionNotFound() {
+        return new SmsRecipientResolution(SmsRecipientResolutionStatus.SUBSCRIPTION_NOT_FOUND, null);
+    }
+
+    // 수신자 전화번호가 비어 있는 상태를 생성한다.
+    public static SmsRecipientResolution phoneMissing() {
+        return new SmsRecipientResolution(SmsRecipientResolutionStatus.PHONE_MISSING, null);
+    }
+
+    // 전화번호 복호화에 실패한 상태를 생성한다.
+    public static SmsRecipientResolution decryptFailed() {
+        return new SmsRecipientResolution(SmsRecipientResolutionStatus.DECRYPT_FAILED, null);
+    }
+}

--- a/src/main/java/hotspot/user/dispatch/sms/domain/SmsRecipientResolutionStatus.java
+++ b/src/main/java/hotspot/user/dispatch/sms/domain/SmsRecipientResolutionStatus.java
@@ -1,0 +1,8 @@
+package hotspot.user.dispatch.sms.domain;
+
+public enum SmsRecipientResolutionStatus {
+    FOUND,
+    SUBSCRIPTION_NOT_FOUND,
+    PHONE_MISSING,
+    DECRYPT_FAILED
+}

--- a/src/main/java/hotspot/user/dispatch/sms/dto/SmsDispatchCommand.java
+++ b/src/main/java/hotspot/user/dispatch/sms/dto/SmsDispatchCommand.java
@@ -1,0 +1,42 @@
+package hotspot.user.dispatch.sms.dto;
+
+import java.time.LocalDateTime;
+
+import hotspot.user.notification.domain.Notification;
+
+public record SmsDispatchCommand(
+        Long notificationId,
+        Long subId,
+        String eventId,
+        String notificationType,
+        String title,
+        String content,
+        LocalDateTime createdTime
+) {
+    // Notification 도메인 객체를 큐 전송용 커맨드로 변환한다.
+    public static SmsDispatchCommand from(Notification notification) {
+        return new SmsDispatchCommand(
+                notification.getId(),
+                notification.getSubId(),
+                notification.getEventId(),
+                notification.getNotificationType(),
+                notification.getTitle(),
+                notification.getContent(),
+                notification.getCreatedTime()
+        );
+    }
+
+    // 큐에서 받은 커맨드를 SMS 발송용 Notification 객체로 복원한다.
+    public Notification toNotification() {
+        return Notification.builder()
+                .id(notificationId)
+                .subId(subId)
+                .eventId(eventId)
+                .notificationType(notificationType)
+                .title(title)
+                .content(content)
+                .isRead(false)
+                .createdTime(createdTime)
+                .build();
+    }
+}

--- a/src/main/java/hotspot/user/dispatch/sms/infrastructure/NoopSmsSender.java
+++ b/src/main/java/hotspot/user/dispatch/sms/infrastructure/NoopSmsSender.java
@@ -1,0 +1,28 @@
+package hotspot.user.dispatch.sms.infrastructure;
+
+import org.springframework.stereotype.Component;
+
+import hotspot.user.dispatch.sms.config.SmsProperties;
+import hotspot.user.dispatch.sms.port.SmsSenderPort;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class NoopSmsSender implements SmsSenderPort {
+
+    private final SmsProperties smsProperties;
+
+    @Override
+    // 실제 발송 대신 로그만 남기는 NOOP 발송을 수행한다.
+    public void send(String to, String message) {
+        log.info(
+                "NOOP SMS send. provider={}, from={}, to={}, message={}",
+                smsProperties.getProvider(),
+                smsProperties.getFrom(),
+                to,
+                message
+        );
+    }
+}

--- a/src/main/java/hotspot/user/dispatch/sms/infrastructure/SmsDispatchQueuePublisher.java
+++ b/src/main/java/hotspot/user/dispatch/sms/infrastructure/SmsDispatchQueuePublisher.java
@@ -1,0 +1,39 @@
+package hotspot.user.dispatch.sms.infrastructure;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import hotspot.user.common.exception.ApplicationException;
+import hotspot.user.common.exception.code.SmsErrorCode;
+import hotspot.user.dispatch.sms.dto.SmsDispatchCommand;
+import hotspot.user.notification.domain.Notification;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class SmsDispatchQueuePublisher {
+
+    private final KafkaTemplate<String, String> kafkaTemplate;
+    private final ObjectMapper objectMapper;
+
+    @Value("${app.topics.sms-dispatch}")
+    private String smsDispatchTopic;
+
+    // 알림 정보를 SMS 디스패치 Kafka 토픽에 전송한다.
+    public void enqueue(Notification notification) {
+        try {
+            SmsDispatchCommand command = SmsDispatchCommand.from(notification);
+            String payload = objectMapper.writeValueAsString(command);
+            String key = notification.getSubId() + ":" + notification.getId();
+            kafkaTemplate.send(smsDispatchTopic, key, payload);
+        } catch (JsonProcessingException ex) {
+            throw new ApplicationException(SmsErrorCode.SMS_LISTENER_FAILED, ex);
+        } catch (Exception ex) {
+            throw new ApplicationException(SmsErrorCode.SMS_LISTENER_FAILED, ex);
+        }
+    }
+}

--- a/src/main/java/hotspot/user/dispatch/sms/infrastructure/SmsDispatchQueuePublisher.java
+++ b/src/main/java/hotspot/user/dispatch/sms/infrastructure/SmsDispatchQueuePublisher.java
@@ -4,7 +4,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Component;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import hotspot.user.common.exception.ApplicationException;
@@ -30,8 +29,6 @@ public class SmsDispatchQueuePublisher {
             String payload = objectMapper.writeValueAsString(command);
             String key = notification.getSubId() + ":" + notification.getId();
             kafkaTemplate.send(smsDispatchTopic, key, payload);
-        } catch (JsonProcessingException ex) {
-            throw new ApplicationException(SmsErrorCode.SMS_LISTENER_FAILED, ex);
         } catch (Exception ex) {
             throw new ApplicationException(SmsErrorCode.SMS_LISTENER_FAILED, ex);
         }

--- a/src/main/java/hotspot/user/dispatch/sms/listener/SmsDispatchConsumer.java
+++ b/src/main/java/hotspot/user/dispatch/sms/listener/SmsDispatchConsumer.java
@@ -1,0 +1,61 @@
+package hotspot.user.dispatch.sms.listener;
+
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Component;
+
+import hotspot.user.common.exception.ApplicationException;
+import hotspot.user.common.exception.code.BaseErrorCode;
+import hotspot.user.common.exception.code.SmsErrorCode;
+import hotspot.user.dispatch.sms.dto.SmsDispatchCommand;
+import hotspot.user.dispatch.sms.service.SmsDispatchService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SmsDispatchConsumer {
+
+    private final SmsDispatchService smsDispatchService;
+
+    @KafkaListener(
+            topics = "${app.topics.sms-dispatch}",
+            containerFactory = "smsDispatchKafkaListenerContainerFactory"
+    )
+    // SMS 디스패치 커맨드를 소비해 실제 발송 서비스를 호출한다.
+    public void consume(SmsDispatchCommand command, Acknowledgment acknowledgment) {
+        try {
+            smsDispatchService.dispatch(command.toNotification());
+            acknowledgment.acknowledge();
+        } catch (ApplicationException ex) {
+            SmsErrorCode errorCode = resolveErrorCode(ex);
+            if (isRetryable(errorCode)) {
+                throw ex;
+            }
+
+            log.warn(
+                    "Skip SMS dispatch consume. notificationId={}, subId={}, errorCode={}, reason={}",
+                    command.notificationId(),
+                    command.subId(),
+                    errorCode.getCustomCode(),
+                    ex.getMessage()
+            );
+            acknowledgment.acknowledge();
+        }
+    }
+
+    // 예외 코드에서 SMS 에러 코드를 추출하고 기본값을 보정한다.
+    private SmsErrorCode resolveErrorCode(ApplicationException ex) {
+        BaseErrorCode errorCode = ex.getCode();
+        if (errorCode instanceof SmsErrorCode smsErrorCode) {
+            return smsErrorCode;
+        }
+        return SmsErrorCode.SMS_DISPATCH_FAILED;
+    }
+
+    // 재시도 대상 에러인지 판별한다.
+    private boolean isRetryable(SmsErrorCode errorCode) {
+        return errorCode == SmsErrorCode.SMS_DISPATCH_FAILED;
+    }
+}

--- a/src/main/java/hotspot/user/dispatch/sms/listener/SmsPushService.java
+++ b/src/main/java/hotspot/user/dispatch/sms/listener/SmsPushService.java
@@ -1,0 +1,60 @@
+package hotspot.user.dispatch.sms.listener;
+
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+import hotspot.user.common.exception.ApplicationException;
+import hotspot.user.common.exception.code.SmsErrorCode;
+import hotspot.user.dispatch.sms.config.SmsProperties;
+import hotspot.user.dispatch.sms.infrastructure.SmsDispatchQueuePublisher;
+import hotspot.user.kafka.dto.UserAlertNotificationsPersistedEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SmsPushService {
+
+    private final SmsProperties smsProperties;
+    private final SmsDispatchQueuePublisher smsDispatchQueuePublisher;
+
+    @EventListener
+    // 저장된 알림 이벤트를 받아 SMS 디스패치 큐에 적재한다.
+    public void onNotificationsPersisted(UserAlertNotificationsPersistedEvent event) {
+        if (!smsProperties.isEnabled()) {
+            return;
+        }
+
+        if (!smsProperties.isEnabled2()) {
+            return;
+        }
+
+        if (!smsProperties.isEnabled3()) {
+            return;
+        }
+
+        if (!smsProperties.isEnabled4()) {
+            return;
+        }
+
+        if (!smsProperties.isEnabled5()) {
+            return;
+        }
+
+        for (var notification : event.persistedNotifications()) {
+            try {
+                smsDispatchQueuePublisher.enqueue(notification);
+            } catch (Exception ex) {
+                log.error(
+                        "Failed to enqueue SMS dispatch. notificationId={}, subId={}, reason={}",
+                        notification.getId(),
+                        notification.getSubId(),
+                        ex.getMessage(),
+                        ex
+                );
+                throw new ApplicationException(SmsErrorCode.SMS_LISTENER_FAILED, ex);
+            }
+        }
+    }
+}

--- a/src/main/java/hotspot/user/dispatch/sms/port/SmsSenderPort.java
+++ b/src/main/java/hotspot/user/dispatch/sms/port/SmsSenderPort.java
@@ -1,0 +1,7 @@
+package hotspot.user.dispatch.sms.port;
+
+public interface SmsSenderPort {
+
+    // 수신번호와 메시지 본문으로 SMS 발송을 수행한다.
+    void send(String to, String message);
+}

--- a/src/main/java/hotspot/user/dispatch/sms/service/SmsDispatchService.java
+++ b/src/main/java/hotspot/user/dispatch/sms/service/SmsDispatchService.java
@@ -1,0 +1,90 @@
+package hotspot.user.dispatch.sms.service;
+
+import org.springframework.stereotype.Service;
+
+import hotspot.user.common.exception.ApplicationException;
+import hotspot.user.common.exception.code.SmsErrorCode;
+import hotspot.user.dispatch.sms.domain.SmsRecipientResolution;
+import hotspot.user.dispatch.sms.port.SmsSenderPort;
+import hotspot.user.kafka.domain.NotificationType;
+import hotspot.user.notification.domain.Notification;
+import hotspot.user.notification.domain.NotificationCategory;
+import hotspot.user.notification.service.port.NotificationAllowRepository;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class SmsDispatchService {
+
+    private final SmsSenderPort smsSenderPort;
+    private final SmsRecipientResolver smsRecipientResolver;
+    private final SmsMessageBuilder smsMessageBuilder;
+    private final NotificationAllowRepository notificationAllowRepository;
+
+    // 알림 정보를 검증하고 수신자/메시지를 구성해 SMS를 발송한다.
+    public void dispatch(Notification notification) {
+        try {
+            NotificationType notificationType = parseNotificationType(notification);
+            validateSmsTargetType(notificationType);
+            validateDataAllow(notification, notificationType);
+
+            SmsRecipientResolution resolution = smsRecipientResolver.resolve(notification.getSubId());
+            String phoneNumber = resolvePhoneNumber(resolution);
+
+            smsSenderPort.send(phoneNumber, smsMessageBuilder.build(notification));
+        } catch (ApplicationException ex) {
+            throw ex;
+        } catch (Exception ex) {
+            throw new ApplicationException(SmsErrorCode.SMS_DISPATCH_FAILED, ex);
+        }
+    }
+
+    // DATA 카테고리 알림인지 확인해 수신 허용 검증 필요 여부를 반환한다.
+    private boolean requiresDataAllowValidation(NotificationType notificationType) {
+        return notificationType.category() == NotificationCategory.DATA;
+    }
+
+    // 구독자의 카테고리별 알림 허용 여부를 조회한다.
+    private boolean isAllowed(Long subId, NotificationCategory category) {
+        return notificationAllowRepository.findBySubIdAndCategory(subId, category)
+                .map(notificationAllow -> Boolean.TRUE.equals(notificationAllow.getNotificationAllow()))
+                .orElse(false);
+    }
+
+    // 알림 타입 문자열을 NotificationType으로 파싱한다.
+    private NotificationType parseNotificationType(Notification notification) {
+        try {
+            return NotificationType.from(notification.getNotificationType());
+        } catch (RuntimeException ex) {
+            throw new ApplicationException(SmsErrorCode.UNSUPPORTED_SMS_NOTIFICATION_TYPE, ex);
+        }
+    }
+
+    // SMS 발송 대상 타입인지 검증한다.
+    private void validateSmsTargetType(NotificationType notificationType) {
+        if (!NotificationType.isSmsAllowed(notificationType)) {
+            throw new ApplicationException(SmsErrorCode.SMS_NOTIFICATION_TYPE_NOT_TARGET);
+        }
+    }
+
+    // DATA 카테고리 알림의 수신 허용 상태를 검증한다.
+    private void validateDataAllow(Notification notification, NotificationType notificationType) {
+        if (requiresDataAllowValidation(notificationType)
+                && !isAllowed(notification.getSubId(), NotificationCategory.DATA)) {
+            throw new ApplicationException(SmsErrorCode.SMS_NOTIFICATION_ALLOW_DISABLED);
+        }
+    }
+
+    // 수신자 해석 결과를 실제 전화번호 또는 도메인 예외로 변환한다.
+    private String resolvePhoneNumber(SmsRecipientResolution resolution) {
+        return switch (resolution.status()) {
+            case FOUND -> resolution.phoneNumber();
+            case SUBSCRIPTION_NOT_FOUND ->
+                    throw new ApplicationException(SmsErrorCode.SMS_RECIPIENT_SUBSCRIPTION_NOT_FOUND);
+            case PHONE_MISSING ->
+                    throw new ApplicationException(SmsErrorCode.SMS_RECIPIENT_PHONE_MISSING);
+            case DECRYPT_FAILED ->
+                    throw new ApplicationException(SmsErrorCode.SMS_RECIPIENT_DECRYPT_FAILED);
+        };
+    }
+}

--- a/src/main/java/hotspot/user/dispatch/sms/service/SmsMessageBuilder.java
+++ b/src/main/java/hotspot/user/dispatch/sms/service/SmsMessageBuilder.java
@@ -1,0 +1,19 @@
+package hotspot.user.dispatch.sms.service;
+
+import org.springframework.stereotype.Component;
+
+import hotspot.user.dispatch.sms.config.SmsProperties;
+import hotspot.user.notification.domain.Notification;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class SmsMessageBuilder {
+
+    private final SmsProperties smsProperties;
+
+    // 발신번호 접두어를 포함한 SMS 본문 문자열을 생성한다.
+    public String build(Notification notification) {
+        return "[" + smsProperties.getFrom() + "] " + notification.getTitle() + " - " + notification.getContent();
+    }
+}

--- a/src/main/java/hotspot/user/dispatch/sms/service/SmsRecipientResolver.java
+++ b/src/main/java/hotspot/user/dispatch/sms/service/SmsRecipientResolver.java
@@ -1,0 +1,36 @@
+package hotspot.user.dispatch.sms.service;
+
+import org.springframework.stereotype.Component;
+
+import hotspot.user.common.crpyto.PhoneDecryptor;
+import hotspot.user.dispatch.sms.domain.SmsRecipientResolution;
+import hotspot.user.subscription.domain.Subscription;
+import hotspot.user.subscription.service.port.SubscriptionRepository;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class SmsRecipientResolver {
+
+    private final SubscriptionRepository subscriptionRepository;
+    private final PhoneDecryptor phoneDecryptor;
+
+    // 구독자 ID로 SMS 수신 전화번호를 조회하고 복호화 결과를 상태로 반환한다.
+    public SmsRecipientResolution resolve(Long subId) {
+        Subscription subscription = subscriptionRepository.findById(subId).orElse(null);
+        if (subscription == null) {
+            return SmsRecipientResolution.subscriptionNotFound();
+        }
+
+        String phoneEnc = subscription.getPhoneEnc();
+        if (phoneEnc == null || phoneEnc.isBlank()) {
+            return SmsRecipientResolution.phoneMissing();
+        }
+
+        try {
+            return SmsRecipientResolution.found(phoneDecryptor.decrypt(phoneEnc));
+        } catch (RuntimeException ex) {
+            return SmsRecipientResolution.decryptFailed();
+        }
+    }
+}

--- a/src/main/java/hotspot/user/dispatch/sms/service/SmsRecipientResolver.java
+++ b/src/main/java/hotspot/user/dispatch/sms/service/SmsRecipientResolver.java
@@ -17,11 +17,13 @@ public class SmsRecipientResolver {
 
     // 구독자 ID로 SMS 수신 전화번호를 조회하고 복호화 결과를 상태로 반환한다.
     public SmsRecipientResolution resolve(Long subId) {
-        Subscription subscription = subscriptionRepository.findById(subId).orElse(null);
-        if (subscription == null) {
-            return SmsRecipientResolution.subscriptionNotFound();
-        }
+        return subscriptionRepository.findById(subId)
+                .map(this::resolvePhoneNumber)
+                .orElseGet(SmsRecipientResolution::subscriptionNotFound);
+    }
 
+    // 구독 정보에서 전화번호 존재 여부와 복호화 성공 여부를 해석한다.
+    private SmsRecipientResolution resolvePhoneNumber(Subscription subscription) {
         String phoneEnc = subscription.getPhoneEnc();
         if (phoneEnc == null || phoneEnc.isBlank()) {
             return SmsRecipientResolution.phoneMissing();

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -28,6 +28,7 @@ spring:
       - classpath:jwt.yml
       - classpath:crypto.yml
       - classpath:s3.yml
+      - classpath:sms.yml
 
   web:
     resources:

--- a/src/main/resources/kafka.yml
+++ b/src/main/resources/kafka.yml
@@ -25,6 +25,8 @@ spring:
 app:
   topics:
     user-alert-events: user-alert-events
+    sms-dispatch: sms-dispatch
 
   consumer-groups:
     user-alert: user-alert-consumer-group
+    sms-dispatch: sms-dispatch-consumer-group

--- a/src/main/resources/sms.yml
+++ b/src/main/resources/sms.yml
@@ -1,0 +1,8 @@
+sms:
+  enabled: false
+  enabled2: false
+  enabled3: false
+  enabled4: false
+  enabled5: false
+  provider: noop
+  from: ${SMS_FROM_NUMBER:}

--- a/src/test/java/hotspot/user/common/config/KafkaConsumerConfigTest.java
+++ b/src/test/java/hotspot/user/common/config/KafkaConsumerConfigTest.java
@@ -18,6 +18,7 @@ import org.springframework.kafka.core.ConsumerFactory;
 import org.springframework.kafka.listener.ContainerProperties;
 import org.springframework.kafka.support.serializer.JsonDeserializer;
 
+import hotspot.user.dispatch.sms.dto.SmsDispatchCommand;
 import hotspot.user.kafka.dto.UserAlertEvent;
 
 class KafkaConsumerConfigTest {
@@ -67,7 +68,10 @@ class KafkaConsumerConfigTest {
     @DisplayName("Builds consumer factory and listener factory with manual ack and error handler")
     void shouldBuildKafkaConsumerAndListenerFactory() {
         // given
-        KafkaConsumerConfig kafkaConsumerConfig = new KafkaConsumerConfig("user-alert-consumer-group");
+        KafkaConsumerConfig kafkaConsumerConfig = new KafkaConsumerConfig(
+                "user-alert-consumer-group",
+                "sms-dispatch-consumer-group"
+        );
 
         KafkaProperties kafkaProperties = new KafkaProperties();
         kafkaProperties.setBootstrapServers(List.of("localhost:9092"));
@@ -79,13 +83,21 @@ class KafkaConsumerConfigTest {
                 kafkaConsumerConfig.userAlertEventConsumerFactory(kafkaProperties, sslBundles);
         ConcurrentKafkaListenerContainerFactory<String, UserAlertEvent> listenerFactory =
                 kafkaConsumerConfig.userAlertKafkaListenerContainerFactory(consumerFactory);
+        ConsumerFactory<String, SmsDispatchCommand> smsConsumerFactory =
+                kafkaConsumerConfig.smsDispatchCommandConsumerFactory(kafkaProperties, sslBundles);
+        ConcurrentKafkaListenerContainerFactory<String, SmsDispatchCommand> smsListenerFactory =
+                kafkaConsumerConfig.smsDispatchKafkaListenerContainerFactory(smsConsumerFactory);
 
         Map<String, Object> props = consumerFactory.getConfigurationProperties();
+        Map<String, Object> smsProps = smsConsumerFactory.getConfigurationProperties();
 
         // then
         assertThat(props.get(ConsumerConfig.GROUP_ID_CONFIG)).isEqualTo("user-alert-consumer-group");
+        assertThat(smsProps.get(ConsumerConfig.GROUP_ID_CONFIG)).isEqualTo("sms-dispatch-consumer-group");
         assertThat(props.get(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG)).isEqualTo(false);
         assertThat(listenerFactory.getContainerProperties().getAckMode()).isEqualTo(ContainerProperties.AckMode.MANUAL);
+        assertThat(smsListenerFactory.getContainerProperties().getAckMode()).isEqualTo(ContainerProperties.AckMode.MANUAL);
         assertThat(listenerFactory).isNotNull();
+        assertThat(smsListenerFactory).isNotNull();
     }
 }

--- a/src/test/java/hotspot/user/common/config/KafkaConsumerConfigTest.java
+++ b/src/test/java/hotspot/user/common/config/KafkaConsumerConfigTest.java
@@ -95,8 +95,10 @@ class KafkaConsumerConfigTest {
         assertThat(props.get(ConsumerConfig.GROUP_ID_CONFIG)).isEqualTo("user-alert-consumer-group");
         assertThat(smsProps.get(ConsumerConfig.GROUP_ID_CONFIG)).isEqualTo("sms-dispatch-consumer-group");
         assertThat(props.get(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG)).isEqualTo(false);
-        assertThat(listenerFactory.getContainerProperties().getAckMode()).isEqualTo(ContainerProperties.AckMode.MANUAL);
-        assertThat(smsListenerFactory.getContainerProperties().getAckMode()).isEqualTo(ContainerProperties.AckMode.MANUAL);
+        assertThat(listenerFactory.getContainerProperties().getAckMode())
+                .isEqualTo(ContainerProperties.AckMode.MANUAL);
+        assertThat(smsListenerFactory.getContainerProperties().getAckMode())
+                .isEqualTo(ContainerProperties.AckMode.MANUAL);
         assertThat(listenerFactory).isNotNull();
         assertThat(smsListenerFactory).isNotNull();
     }

--- a/src/test/java/hotspot/user/dispatch/sms/config/SmsPropertiesTest.java
+++ b/src/test/java/hotspot/user/dispatch/sms/config/SmsPropertiesTest.java
@@ -1,0 +1,23 @@
+package hotspot.user.dispatch.sms.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class SmsPropertiesTest {
+
+    @Test
+    @DisplayName("keeps configured sms properties")
+    void propertiesValues() {
+        SmsProperties properties = new SmsProperties(true, false, false, false, false, "noop", "01012345678");
+
+        assertThat(properties.isEnabled()).isTrue();
+        assertThat(properties.isEnabled2()).isFalse();
+        assertThat(properties.isEnabled3()).isFalse();
+        assertThat(properties.isEnabled4()).isFalse();
+        assertThat(properties.isEnabled5()).isFalse();
+        assertThat(properties.getProvider()).isEqualTo("noop");
+        assertThat(properties.getFrom()).isEqualTo("01012345678");
+    }
+}

--- a/src/test/java/hotspot/user/dispatch/sms/infrastructure/NoopSmsSenderTest.java
+++ b/src/test/java/hotspot/user/dispatch/sms/infrastructure/NoopSmsSenderTest.java
@@ -1,0 +1,19 @@
+package hotspot.user.dispatch.sms.infrastructure;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import hotspot.user.dispatch.sms.config.SmsProperties;
+
+class NoopSmsSenderTest {
+
+    @Test
+    @DisplayName("send does not throw")
+    void sendNoop() {
+        NoopSmsSender sender = new NoopSmsSender(
+                new SmsProperties(true, false, false, false, false, "noop", "01012345678")
+        );
+
+        sender.send("01012345678", "hello");
+    }
+}

--- a/src/test/java/hotspot/user/dispatch/sms/infrastructure/SmsDispatchQueuePublisherTest.java
+++ b/src/test/java/hotspot/user/dispatch/sms/infrastructure/SmsDispatchQueuePublisherTest.java
@@ -1,0 +1,84 @@
+package hotspot.user.dispatch.sms.infrastructure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import hotspot.user.common.exception.ApplicationException;
+import hotspot.user.common.exception.code.SmsErrorCode;
+import hotspot.user.notification.domain.Notification;
+
+@ExtendWith(MockitoExtension.class)
+class SmsDispatchQueuePublisherTest {
+
+    @Mock
+    private KafkaTemplate<String, String> kafkaTemplate;
+
+    @Mock
+    private ObjectMapper objectMapper;
+
+    @InjectMocks
+    private SmsDispatchQueuePublisher publisher;
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(publisher, "smsDispatchTopic", "sms-dispatch");
+    }
+
+    @Test
+    @DisplayName("enqueues sms dispatch command payload to kafka topic")
+    void enqueueSuccess() throws Exception {
+        Notification notification = notification();
+        given(objectMapper.writeValueAsString(org.mockito.ArgumentMatchers.any()))
+                .willReturn("{\"notificationId\":1}");
+
+        publisher.enqueue(notification);
+
+        then(kafkaTemplate).should().send("sms-dispatch", "1:1", "{\"notificationId\":1}");
+    }
+
+    @Test
+    @DisplayName("wraps exception with SMS_LISTENER_FAILED when enqueue fails")
+    void enqueueFailure() throws Exception {
+        Notification notification = notification();
+        given(objectMapper.writeValueAsString(org.mockito.ArgumentMatchers.any()))
+                .willThrow(new RuntimeException("serialize failed"));
+
+        assertThatThrownBy(() -> publisher.enqueue(notification))
+                .isInstanceOf(ApplicationException.class)
+                .satisfies(ex -> {
+                    ApplicationException appEx = (ApplicationException) ex;
+                    assertThat(appEx.getCode()).isEqualTo(SmsErrorCode.SMS_LISTENER_FAILED);
+                });
+
+        then(kafkaTemplate).shouldHaveNoInteractions();
+    }
+
+    private Notification notification() {
+        return Notification.builder()
+                .id(1L)
+                .subId(1L)
+                .eventId("evt-1")
+                .notificationType("SINGLE_USAGE_THRESHOLD_30")
+                .title("title")
+                .content("content")
+                .isRead(false)
+                .createdTime(LocalDateTime.of(2026, 2, 23, 10, 15, 30))
+                .build();
+    }
+}

--- a/src/test/java/hotspot/user/dispatch/sms/listener/SmsDispatchConsumerTest.java
+++ b/src/test/java/hotspot/user/dispatch/sms/listener/SmsDispatchConsumerTest.java
@@ -1,0 +1,86 @@
+package hotspot.user.dispatch.sms.listener;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.never;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.support.Acknowledgment;
+
+import hotspot.user.common.exception.ApplicationException;
+import hotspot.user.common.exception.code.SmsErrorCode;
+import hotspot.user.dispatch.sms.dto.SmsDispatchCommand;
+import hotspot.user.dispatch.sms.service.SmsDispatchService;
+import hotspot.user.notification.domain.Notification;
+
+@ExtendWith(MockitoExtension.class)
+class SmsDispatchConsumerTest {
+
+    @Mock
+    private SmsDispatchService smsDispatchService;
+
+    @Mock
+    private Acknowledgment acknowledgment;
+
+    @InjectMocks
+    private SmsDispatchConsumer smsDispatchConsumer;
+
+    @Test
+    @DisplayName("acks when SMS dispatch succeeds")
+    void ackWhenDispatchSucceeds() {
+        SmsDispatchCommand command = command(1L, 100L);
+
+        smsDispatchConsumer.consume(command, acknowledgment);
+
+        then(smsDispatchService).should().dispatch(any(Notification.class));
+        then(acknowledgment).should().acknowledge();
+    }
+
+    @Test
+    @DisplayName("acks and skips when non-retryable application exception occurs")
+    void ackWhenNonRetryableErrorOccurs() {
+        SmsDispatchCommand command = command(1L, 100L);
+        willThrow(new ApplicationException(SmsErrorCode.SMS_NOTIFICATION_ALLOW_DISABLED))
+                .given(smsDispatchService)
+                .dispatch(any(Notification.class));
+
+        smsDispatchConsumer.consume(command, acknowledgment);
+
+        then(acknowledgment).should().acknowledge();
+    }
+
+    @Test
+    @DisplayName("throws to retry when retryable application exception occurs")
+    void throwsWhenRetryableErrorOccurs() {
+        SmsDispatchCommand command = command(1L, 100L);
+        willThrow(new ApplicationException(SmsErrorCode.SMS_DISPATCH_FAILED))
+                .given(smsDispatchService)
+                .dispatch(any(Notification.class));
+
+        assertThatThrownBy(() -> smsDispatchConsumer.consume(command, acknowledgment))
+                .isInstanceOf(ApplicationException.class);
+
+        then(acknowledgment).should(never()).acknowledge();
+    }
+
+    private SmsDispatchCommand command(Long notificationId, Long subId) {
+        return new SmsDispatchCommand(
+                notificationId,
+                subId,
+                "event-1",
+                "SINGLE_USAGE_THRESHOLD_30",
+                "title",
+                "content",
+                LocalDateTime.of(2026, 2, 23, 10, 15, 30)
+        );
+    }
+}

--- a/src/test/java/hotspot/user/dispatch/sms/listener/SmsPushServiceTest.java
+++ b/src/test/java/hotspot/user/dispatch/sms/listener/SmsPushServiceTest.java
@@ -1,0 +1,121 @@
+package hotspot.user.dispatch.sms.listener;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import hotspot.user.common.exception.ApplicationException;
+import hotspot.user.common.exception.code.SmsErrorCode;
+import hotspot.user.dispatch.sms.config.SmsProperties;
+import hotspot.user.dispatch.sms.infrastructure.SmsDispatchQueuePublisher;
+import hotspot.user.kafka.dto.UserAlertEvent;
+import hotspot.user.kafka.dto.UserAlertNotificationsPersistedEvent;
+import hotspot.user.notification.domain.Notification;
+
+@ExtendWith(MockitoExtension.class)
+class SmsPushServiceTest {
+
+    @Mock
+    private SmsDispatchQueuePublisher smsDispatchQueuePublisher;
+
+    @Mock
+    private SmsProperties smsProperties;
+
+    @InjectMocks
+    private SmsPushService smsPushService;
+
+    @Test
+    @DisplayName("enqueues notifications when sms is enabled")
+    void dispatchesWhenEnabled() {
+        given(smsProperties.isEnabled()).willReturn(true);
+        Notification notification = notification(1L, "IMMEDIATE_BLOCK_APPLIED");
+        UserAlertNotificationsPersistedEvent event = new UserAlertNotificationsPersistedEvent(
+                sourceEvent(),
+                List.of(notification)
+        );
+
+        smsPushService.onNotificationsPersisted(event);
+
+        then(smsDispatchQueuePublisher).should().enqueue(notification);
+    }
+
+    @Test
+    @DisplayName("does not enqueue notifications when sms is disabled")
+    void doesNotDispatchWhenDisabled() {
+        given(smsProperties.isEnabled()).willReturn(false);
+        Notification notification = notification(1L, "IMMEDIATE_BLOCK_APPLIED");
+        UserAlertNotificationsPersistedEvent event = new UserAlertNotificationsPersistedEvent(
+                sourceEvent(),
+                List.of(notification)
+        );
+
+        smsPushService.onNotificationsPersisted(event);
+
+        then(smsDispatchQueuePublisher).should(never()).enqueue(notification);
+    }
+
+    @Test
+    @DisplayName("throws listener error when enqueue fails")
+    void throwsWhenEnqueueFails() {
+        given(smsProperties.isEnabled()).willReturn(true);
+        Notification first = notification(1L, "IMMEDIATE_BLOCK_APPLIED");
+        UserAlertNotificationsPersistedEvent event = new UserAlertNotificationsPersistedEvent(
+                sourceEvent(),
+                List.of(first)
+        );
+        doThrow(new RuntimeException("unexpected")).when(smsDispatchQueuePublisher).enqueue(first);
+
+        assertThatThrownBy(() -> smsPushService.onNotificationsPersisted(event))
+                .isInstanceOf(ApplicationException.class)
+                .satisfies(ex -> {
+                    ApplicationException appEx = (ApplicationException) ex;
+                    assertThat(appEx.getCode()).isEqualTo(SmsErrorCode.SMS_LISTENER_FAILED);
+                });
+
+        then(smsDispatchQueuePublisher).should().enqueue(first);
+    }
+
+    private UserAlertEvent sourceEvent() {
+        return new UserAlertEvent(
+                "alert-1",
+                "USAGE_THRESHOLD",
+                "PLAN_REMAINING",
+                1L,
+                null,
+                "30",
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                LocalDateTime.of(2026, 2, 23, 10, 15, 30)
+        );
+    }
+
+    private Notification notification(Long subId, String type) {
+        return Notification.builder()
+                .id(1L)
+                .subId(subId)
+                .eventId("evt-1")
+                .notificationType(type)
+                .title("title-1")
+                .content("content-1")
+                .isRead(false)
+                .createdTime(LocalDateTime.of(2026, 2, 23, 10, 15, 30))
+                .build();
+    }
+}

--- a/src/test/java/hotspot/user/dispatch/sms/listener/SmsPushServiceTest.java
+++ b/src/test/java/hotspot/user/dispatch/sms/listener/SmsPushServiceTest.java
@@ -40,7 +40,7 @@ class SmsPushServiceTest {
     @Test
     @DisplayName("enqueues notifications when sms is enabled")
     void dispatchesWhenEnabled() {
-        given(smsProperties.isEnabled()).willReturn(true);
+        mockAllEnabled();
         Notification notification = notification(1L, "IMMEDIATE_BLOCK_APPLIED");
         UserAlertNotificationsPersistedEvent event = new UserAlertNotificationsPersistedEvent(
                 sourceEvent(),
@@ -70,7 +70,7 @@ class SmsPushServiceTest {
     @Test
     @DisplayName("throws listener error when enqueue fails")
     void throwsWhenEnqueueFails() {
-        given(smsProperties.isEnabled()).willReturn(true);
+        mockAllEnabled();
         Notification first = notification(1L, "IMMEDIATE_BLOCK_APPLIED");
         UserAlertNotificationsPersistedEvent event = new UserAlertNotificationsPersistedEvent(
                 sourceEvent(),
@@ -86,6 +86,14 @@ class SmsPushServiceTest {
                 });
 
         then(smsDispatchQueuePublisher).should().enqueue(first);
+    }
+
+    private void mockAllEnabled() {
+        given(smsProperties.isEnabled()).willReturn(true);
+        given(smsProperties.isEnabled2()).willReturn(true);
+        given(smsProperties.isEnabled3()).willReturn(true);
+        given(smsProperties.isEnabled4()).willReturn(true);
+        given(smsProperties.isEnabled5()).willReturn(true);
     }
 
     private UserAlertEvent sourceEvent() {

--- a/src/test/java/hotspot/user/dispatch/sms/service/SmsDispatchServiceTest.java
+++ b/src/test/java/hotspot/user/dispatch/sms/service/SmsDispatchServiceTest.java
@@ -1,0 +1,190 @@
+package hotspot.user.dispatch.sms.service;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import hotspot.user.common.exception.ApplicationException;
+import hotspot.user.common.exception.code.SmsErrorCode;
+import hotspot.user.dispatch.sms.domain.SmsRecipientResolution;
+import hotspot.user.dispatch.sms.port.SmsSenderPort;
+import hotspot.user.notification.domain.Notification;
+import hotspot.user.notification.domain.NotificationAllow;
+import hotspot.user.notification.domain.NotificationCategory;
+import hotspot.user.notification.service.port.NotificationAllowRepository;
+
+@ExtendWith(MockitoExtension.class)
+class SmsDispatchServiceTest {
+
+    @Mock
+    private SmsSenderPort smsSenderPort;
+
+    @Mock
+    private SmsRecipientResolver smsRecipientResolver;
+
+    @Mock
+    private SmsMessageBuilder smsMessageBuilder;
+
+    @Mock
+    private NotificationAllowRepository notificationAllowRepository;
+
+    @InjectMocks
+    private SmsDispatchService smsDispatchService;
+
+    @Test
+    @DisplayName("sends sms for target type with resolved recipient")
+    void sendsSmsForTargetType() {
+        Notification notification = notification("SINGLE_USAGE_THRESHOLD_50");
+        given(notificationAllowRepository.findBySubIdAndCategory(1L, NotificationCategory.DATA))
+                .willReturn(Optional.of(NotificationAllow.builder()
+                        .subId(1L)
+                        .notificationCategory(NotificationCategory.DATA)
+                        .notificationAllow(true)
+                        .build()));
+        given(smsRecipientResolver.resolve(1L)).willReturn(SmsRecipientResolution.found("010-1234-5678"));
+        given(smsMessageBuilder.build(notification)).willReturn("[HOTSPOT] title-1 - content-1");
+
+        smsDispatchService.dispatch(notification);
+
+        then(smsSenderPort).should().send("010-1234-5678", "[HOTSPOT] title-1 - content-1");
+    }
+
+    @Test
+    @DisplayName("skips sms for non-target type")
+    void skipsForNonTargetType() {
+        Notification notification = notification("IMMEDIATE_BLOCK_APPLIED");
+
+        assertThatThrownBy(() -> smsDispatchService.dispatch(notification))
+                .isInstanceOf(ApplicationException.class)
+                .hasMessage(SmsErrorCode.SMS_NOTIFICATION_TYPE_NOT_TARGET.getMessage());
+
+        then(smsSenderPort).should(never()).send(org.mockito.ArgumentMatchers.anyString(),
+                org.mockito.ArgumentMatchers.anyString());
+    }
+
+    @Test
+    @DisplayName("skips sms when recipient resolution fails")
+    void skipsWhenResolverFails() {
+        Notification notification = notification("FAMILY_USAGE_THRESHOLD_10");
+        given(notificationAllowRepository.findBySubIdAndCategory(1L, NotificationCategory.DATA))
+                .willReturn(Optional.of(NotificationAllow.builder()
+                        .subId(1L)
+                        .notificationCategory(NotificationCategory.DATA)
+                        .notificationAllow(true)
+                        .build()));
+        given(smsRecipientResolver.resolve(1L)).willReturn(SmsRecipientResolution.decryptFailed());
+
+        assertThatThrownBy(() -> smsDispatchService.dispatch(notification))
+                .isInstanceOf(ApplicationException.class)
+                .hasMessage(SmsErrorCode.SMS_RECIPIENT_DECRYPT_FAILED.getMessage());
+
+        then(smsSenderPort).should(never()).send(org.mockito.ArgumentMatchers.anyString(),
+                org.mockito.ArgumentMatchers.anyString());
+    }
+
+    @Test
+    @DisplayName("skips data threshold sms when notification allow is disabled")
+    void skipsDataThresholdWhenAllowDisabled() {
+        Notification notification = notification("SINGLE_USAGE_THRESHOLD_30");
+        given(notificationAllowRepository.findBySubIdAndCategory(1L, NotificationCategory.DATA))
+                .willReturn(Optional.of(NotificationAllow.builder()
+                        .subId(1L)
+                        .notificationCategory(NotificationCategory.DATA)
+                        .notificationAllow(false)
+                        .build()));
+
+        assertThatThrownBy(() -> smsDispatchService.dispatch(notification))
+                .isInstanceOf(ApplicationException.class)
+                .hasMessage(SmsErrorCode.SMS_NOTIFICATION_ALLOW_DISABLED.getMessage());
+
+        then(smsRecipientResolver).should(never()).resolve(org.mockito.ArgumentMatchers.anyLong());
+        then(smsSenderPort).should(never()).send(org.mockito.ArgumentMatchers.anyString(),
+                org.mockito.ArgumentMatchers.anyString());
+    }
+
+    @Test
+    @DisplayName("sends family create sms regardless of data notification allow")
+    void sendsFamilyCreateWithoutDataAllowValidation() {
+        Notification notification = notification("FAMILY_CREATE_APPROVED");
+        given(smsRecipientResolver.resolve(1L)).willReturn(SmsRecipientResolution.found("010-1234-5678"));
+        given(smsMessageBuilder.build(notification)).willReturn("[HOTSPOT] title-1 - content-1");
+
+        smsDispatchService.dispatch(notification);
+
+        then(notificationAllowRepository).should(never())
+                .findBySubIdAndCategory(org.mockito.ArgumentMatchers.anyLong(), org.mockito.ArgumentMatchers.any());
+        then(smsSenderPort).should().send("010-1234-5678", "[HOTSPOT] title-1 - content-1");
+    }
+
+    @Test
+    @DisplayName("sends present usage sms when data notification allow is enabled")
+    void sendsPresentUsageWhenDataAllowEnabled() {
+        Notification notification = notification("PRESENT_USAGE_THRESHOLD_10");
+        given(notificationAllowRepository.findBySubIdAndCategory(1L, NotificationCategory.DATA))
+                .willReturn(Optional.of(NotificationAllow.builder()
+                        .subId(1L)
+                        .notificationCategory(NotificationCategory.DATA)
+                        .notificationAllow(true)
+                        .build()));
+        given(smsRecipientResolver.resolve(1L)).willReturn(SmsRecipientResolution.found("010-1234-5678"));
+        given(smsMessageBuilder.build(notification)).willReturn("[HOTSPOT] title-1 - content-1");
+
+        smsDispatchService.dispatch(notification);
+
+        then(smsSenderPort).should().send("010-1234-5678", "[HOTSPOT] title-1 - content-1");
+    }
+
+    @Test
+    @DisplayName("skips present usage sms when data notification allow is disabled")
+    void skipsPresentUsageWhenDataAllowDisabled() {
+        Notification notification = notification("PRESENT_USAGE_EXHAUSTED");
+        given(notificationAllowRepository.findBySubIdAndCategory(1L, NotificationCategory.DATA))
+                .willReturn(Optional.of(NotificationAllow.builder()
+                        .subId(1L)
+                        .notificationCategory(NotificationCategory.DATA)
+                        .notificationAllow(false)
+                        .build()));
+
+        assertThatThrownBy(() -> smsDispatchService.dispatch(notification))
+                .isInstanceOf(ApplicationException.class)
+                .hasMessage(SmsErrorCode.SMS_NOTIFICATION_ALLOW_DISABLED.getMessage());
+
+        then(smsRecipientResolver).should(never()).resolve(org.mockito.ArgumentMatchers.anyLong());
+        then(smsSenderPort).should(never()).send(org.mockito.ArgumentMatchers.anyString(),
+                org.mockito.ArgumentMatchers.anyString());
+    }
+
+    @Test
+    @DisplayName("throws when notification type is unsupported")
+    void throwsWhenUnsupportedNotificationType() {
+        Notification notification = notification("UNKNOWN_TYPE");
+
+        assertThatThrownBy(() -> smsDispatchService.dispatch(notification))
+                .isInstanceOf(ApplicationException.class)
+                .hasMessage(SmsErrorCode.UNSUPPORTED_SMS_NOTIFICATION_TYPE.getMessage());
+    }
+
+    private Notification notification(String type) {
+        return Notification.builder()
+                .id(1L)
+                .subId(1L)
+                .eventId("evt-1")
+                .notificationType(type)
+                .title("title-1")
+                .content("content-1")
+                .isRead(false)
+                .createdTime(LocalDateTime.of(2026, 2, 23, 10, 15, 30))
+                .build();
+    }
+}

--- a/src/test/java/hotspot/user/dispatch/sms/service/SmsMessageBuilderTest.java
+++ b/src/test/java/hotspot/user/dispatch/sms/service/SmsMessageBuilderTest.java
@@ -1,0 +1,36 @@
+package hotspot.user.dispatch.sms.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import hotspot.user.dispatch.sms.config.SmsProperties;
+import hotspot.user.notification.domain.Notification;
+
+class SmsMessageBuilderTest {
+
+    @Test
+    @DisplayName("builds sms message with from and notification content")
+    void buildMessage() {
+        SmsMessageBuilder builder = new SmsMessageBuilder(
+                new SmsProperties(true, false, false, false, false, "noop", "HOTSPOT")
+        );
+        Notification notification = Notification.builder()
+                .id(1L)
+                .subId(1L)
+                .eventId("evt-1")
+                .notificationType("SINGLE_USAGE_THRESHOLD_50")
+                .title("title")
+                .content("content")
+                .isRead(false)
+                .createdTime(LocalDateTime.of(2026, 2, 23, 10, 15, 30))
+                .build();
+
+        String message = builder.build(notification);
+
+        assertThat(message).isEqualTo("[HOTSPOT] title - content");
+    }
+}

--- a/src/test/java/hotspot/user/dispatch/sms/service/SmsRecipientResolverTest.java
+++ b/src/test/java/hotspot/user/dispatch/sms/service/SmsRecipientResolverTest.java
@@ -1,0 +1,76 @@
+package hotspot.user.dispatch.sms.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import hotspot.user.common.crpyto.PhoneDecryptor;
+import hotspot.user.dispatch.sms.domain.SmsRecipientResolution;
+import hotspot.user.dispatch.sms.domain.SmsRecipientResolutionStatus;
+import hotspot.user.subscription.domain.Subscription;
+import hotspot.user.subscription.service.port.SubscriptionRepository;
+
+@ExtendWith(MockitoExtension.class)
+class SmsRecipientResolverTest {
+
+    @Mock
+    private SubscriptionRepository subscriptionRepository;
+
+    @Mock
+    private PhoneDecryptor phoneDecryptor;
+
+    @InjectMocks
+    private SmsRecipientResolver smsRecipientResolver;
+
+    @Test
+    @DisplayName("returns subscription not found when sub does not exist")
+    void resolveSubscriptionNotFound() {
+        given(subscriptionRepository.findById(1L)).willReturn(java.util.Optional.empty());
+
+        SmsRecipientResolution resolution = smsRecipientResolver.resolve(1L);
+
+        assertThat(resolution.status()).isEqualTo(SmsRecipientResolutionStatus.SUBSCRIPTION_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("returns phone missing when encrypted phone is blank")
+    void resolvePhoneMissing() {
+        given(subscriptionRepository.findById(1L))
+                .willReturn(java.util.Optional.of(Subscription.builder().id(1L).phoneEnc(" ").build()));
+
+        SmsRecipientResolution resolution = smsRecipientResolver.resolve(1L);
+
+        assertThat(resolution.status()).isEqualTo(SmsRecipientResolutionStatus.PHONE_MISSING);
+    }
+
+    @Test
+    @DisplayName("returns decrypt failed when decryptor throws")
+    void resolveDecryptFailed() {
+        given(subscriptionRepository.findById(1L))
+                .willReturn(java.util.Optional.of(Subscription.builder().id(1L).phoneEnc("enc").build()));
+        given(phoneDecryptor.decrypt("enc")).willThrow(new IllegalStateException("decrypt fail"));
+
+        SmsRecipientResolution resolution = smsRecipientResolver.resolve(1L);
+
+        assertThat(resolution.status()).isEqualTo(SmsRecipientResolutionStatus.DECRYPT_FAILED);
+    }
+
+    @Test
+    @DisplayName("returns found when decrypt succeeds")
+    void resolveFound() {
+        given(subscriptionRepository.findById(1L))
+                .willReturn(java.util.Optional.of(Subscription.builder().id(1L).phoneEnc("enc").build()));
+        given(phoneDecryptor.decrypt("enc")).willReturn("010-1234-5678");
+
+        SmsRecipientResolution resolution = smsRecipientResolver.resolve(1L);
+
+        assertThat(resolution.status()).isEqualTo(SmsRecipientResolutionStatus.FOUND);
+        assertThat(resolution.phoneNumber()).isEqualTo("010-1234-5678");
+    }
+}


### PR DESCRIPTION
## 🎫 지라 티켓

<!-- 지라 티켓을 작성해주세요 ex) HOTSPOT-123 -->
HOTSPOT-219

---

## 🔗 GitHub 이슈
<!-- 자동 close를 원하면 아래 형식으로 작성
예) Closes #12
-->
Closes #121 

---


## ✅ 작업 사항

<!-- 작업한 부분을 설명해주세요. -->
- SMS 비동기 발송 파이프라인 구현
- Kafka 컨슈머 설정 확장
- SMS 관련 도메인 및 DTO 정의
- SMS 발송 서비스 및 인프라 구축
- 이벤트 기반 SMS 발송 트리거
- 설정 파일 업데이트
  - application.yml
  - kafka.yml
  - sms.yml
- 단위 테스트 추가
---

## 📋 체크리스트

<!-- PR 제출 전 확인해주세요. 해당 항목에 [x]로 체크해주세요. -->

- [x] 코드가 정상적으로 빌드됩니다.
- [x] 관련 테스트 코드를 작성했습니다.
- [x] 기존 테스트가 모두 통과합니다.
- [x] 코드 스타일(Spotless, Checkstyle)을 준수합니다.
- [x] Jira 티켓 상태를 In Review / Done으로 변경했습니다.

---

## ⌨ 기타

sms-dispatch 토픽 추가
