### PR TITLE
[HOTSPOT-233] SMS 실발송 벤더 API 연동

### DIFF
--- a/src/main/java/hotspot/user/common/exception/code/SmsErrorCode.java
+++ b/src/main/java/hotspot/user/common/exception/code/SmsErrorCode.java
@@ -48,6 +48,21 @@ public enum SmsErrorCode implements BaseErrorCode {
             "SMS_008",
             "SMS 리스너 처리 중 오류가 발생했습니다."
     ),
+    SMS_PROVIDER_CONFIG_INVALID(
+            HttpStatus.INTERNAL_SERVER_ERROR,
+            "SMS_009",
+            "SMS 제공자 설정값이 올바르지 않습니다."
+    ),
+    SMS_PROVIDER_AUTH_FAILED(
+            HttpStatus.INTERNAL_SERVER_ERROR,
+            "SMS_010",
+            "SMS 제공자 인증 헤더 생성에 실패했습니다."
+    ),
+    SMS_PROVIDER_REQUEST_FAILED(
+            HttpStatus.INTERNAL_SERVER_ERROR,
+            "SMS_011",
+            "SMS 제공자 요청 처리에 실패했습니다."
+    ),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/hotspot/user/dispatch/sms/config/SmsHttpClientConfig.java
+++ b/src/main/java/hotspot/user/dispatch/sms/config/SmsHttpClientConfig.java
@@ -1,0 +1,16 @@
+package hotspot.user.dispatch.sms.config;
+
+import java.net.http.HttpClient;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SmsHttpClientConfig {
+
+    // SMS 외부 API 호출에 사용할 기본 HttpClient 빈을 등록한다.
+    @Bean
+    public HttpClient smsHttpClient() {
+        return HttpClient.newHttpClient();
+    }
+}

--- a/src/main/java/hotspot/user/dispatch/sms/config/SmsProperties.java
+++ b/src/main/java/hotspot/user/dispatch/sms/config/SmsProperties.java
@@ -10,29 +10,28 @@ import lombok.Getter;
 public class SmsProperties {
 
     private final boolean enabled;
-    private final boolean enabled2;
-    private final boolean enabled3;
-    private final boolean enabled4;
-    private final boolean enabled5;
     private final String provider;
     private final String from;
+    private final String apiKey;
+    private final String apiSecret;
+    private final String apiBaseUrl;
+    private final String sendPath;
 
-    // SMS 동작 여부/제공자/발신번호 설정값을 초기화한다.
     public SmsProperties(
             @Value("${sms.enabled:false}") boolean enabled,
-            @Value("${sms.enabled2:false}") boolean enabled2,
-            @Value("${sms.enabled3:false}") boolean enabled3,
-            @Value("${sms.enabled4:false}") boolean enabled4,
-            @Value("${sms.enabled5:false}") boolean enabled5,
             @Value("${sms.provider:noop}") String provider,
-            @Value("${sms.from:}") String from
+            @Value("${sms.from:}") String from,
+            @Value("${sms.api-key:}") String apiKey,
+            @Value("${sms.api-secret:}") String apiSecret,
+            @Value("${sms.api-base-url:https://api.solapi.com}") String apiBaseUrl,
+            @Value("${sms.send-path:/messages/v4/send-many/detail}") String sendPath
     ) {
         this.enabled = enabled;
-        this.enabled2 = enabled2;
-        this.enabled3 = enabled3;
-        this.enabled4 = enabled4;
-        this.enabled5 = enabled5;
         this.provider = provider;
         this.from = from;
+        this.apiKey = apiKey;
+        this.apiSecret = apiSecret;
+        this.apiBaseUrl = apiBaseUrl;
+        this.sendPath = sendPath;
     }
 }

--- a/src/main/java/hotspot/user/dispatch/sms/infrastructure/NoopSmsSender.java
+++ b/src/main/java/hotspot/user/dispatch/sms/infrastructure/NoopSmsSender.java
@@ -1,14 +1,15 @@
 package hotspot.user.dispatch.sms.infrastructure;
 
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
 import hotspot.user.dispatch.sms.config.SmsProperties;
-import hotspot.user.dispatch.sms.port.SmsSenderPort;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Component
+@ConditionalOnProperty(prefix = "sms", name = "provider", havingValue = "noop", matchIfMissing = true)
 @RequiredArgsConstructor
 public class NoopSmsSender implements SmsSenderPort {
 

--- a/src/main/java/hotspot/user/dispatch/sms/infrastructure/SmsSenderPort.java
+++ b/src/main/java/hotspot/user/dispatch/sms/infrastructure/SmsSenderPort.java
@@ -1,4 +1,4 @@
-package hotspot.user.dispatch.sms.port;
+package hotspot.user.dispatch.sms.infrastructure;
 
 public interface SmsSenderPort {
 

--- a/src/main/java/hotspot/user/dispatch/sms/infrastructure/SolapiSmsSender.java
+++ b/src/main/java/hotspot/user/dispatch/sms/infrastructure/SolapiSmsSender.java
@@ -1,0 +1,96 @@
+package hotspot.user.dispatch.sms.infrastructure;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import hotspot.user.common.exception.ApplicationException;
+import hotspot.user.common.exception.code.SmsErrorCode;
+import hotspot.user.dispatch.sms.config.SmsProperties;
+import hotspot.user.dispatch.sms.support.SolapiAuthHeaderFactory;
+import hotspot.user.dispatch.sms.support.SolapiRequestFactory;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@ConditionalOnProperty(prefix = "sms", name = "provider", havingValue = "solapi")
+public class SolapiSmsSender implements SmsSenderPort {
+
+    private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(10);
+
+    private final SmsProperties smsProperties;
+    private final ObjectMapper objectMapper;
+    private final SolapiAuthHeaderFactory authHeaderFactory;
+    private final SolapiRequestFactory requestFactory;
+    private final HttpClient httpClient;
+
+    public SolapiSmsSender(
+            SmsProperties smsProperties,
+            ObjectMapper objectMapper,
+            SolapiAuthHeaderFactory authHeaderFactory,
+            SolapiRequestFactory requestFactory,
+            HttpClient httpClient
+    ) {
+        this.smsProperties = smsProperties;
+        this.objectMapper = objectMapper;
+        this.authHeaderFactory = authHeaderFactory;
+        this.requestFactory = requestFactory;
+        this.httpClient = httpClient;
+    }
+
+    @Override
+    // Solapi API를 호출해 실제 SMS 발송을 수행한다.
+    public void send(String to, String message) {
+        validateCredentials();
+        try {
+            String authorization = authHeaderFactory.create(smsProperties.getApiKey(), smsProperties.getApiSecret());
+
+            String payload = objectMapper.writeValueAsString(
+                    requestFactory.buildPayload(smsProperties.getFrom(), to, message)
+            );
+            String sendUrl = requestFactory.buildSendUrl(smsProperties.getApiBaseUrl(), smsProperties.getSendPath());
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(sendUrl))
+                    .timeout(REQUEST_TIMEOUT)
+                    .header("Content-Type", "application/json")
+                    .header("Authorization", authorization)
+                    .POST(HttpRequest.BodyPublishers.ofString(payload))
+                    .build();
+
+            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+            if (response.statusCode() < 200 || response.statusCode() >= 300) {
+                throw new ApplicationException(SmsErrorCode.SMS_PROVIDER_REQUEST_FAILED);
+            }
+
+        } catch (ApplicationException ex) {
+            throw ex;
+        } catch (Exception ex) {
+            throw new ApplicationException(SmsErrorCode.SMS_PROVIDER_REQUEST_FAILED, ex);
+        }
+    }
+
+    // Solapi 인증/발신 설정 필수값이 존재하는지 검증한다.
+    private void validateCredentials() {
+        if (isBlank(smsProperties.getApiKey())) {
+            throw new ApplicationException(SmsErrorCode.SMS_PROVIDER_CONFIG_INVALID);
+        }
+        if (isBlank(smsProperties.getApiSecret())) {
+            throw new ApplicationException(SmsErrorCode.SMS_PROVIDER_CONFIG_INVALID);
+        }
+        if (isBlank(smsProperties.getFrom())) {
+            throw new ApplicationException(SmsErrorCode.SMS_PROVIDER_CONFIG_INVALID);
+        }
+    }
+
+    // 문자열이 null 또는 공백인지 반환한다.
+    private static boolean isBlank(String value) {
+        return value == null || value.isBlank();
+    }
+}

--- a/src/main/java/hotspot/user/dispatch/sms/infrastructure/SolapiSmsSender.java
+++ b/src/main/java/hotspot/user/dispatch/sms/infrastructure/SolapiSmsSender.java
@@ -69,9 +69,10 @@ public class SolapiSmsSender implements SmsSenderPort {
                 throw new ApplicationException(SmsErrorCode.SMS_PROVIDER_REQUEST_FAILED);
             }
 
-        } catch (ApplicationException ex) {
-            throw ex;
         } catch (Exception ex) {
+            if (ex instanceof ApplicationException) {
+                throw (ApplicationException) ex;
+            }
             throw new ApplicationException(SmsErrorCode.SMS_PROVIDER_REQUEST_FAILED, ex);
         }
     }

--- a/src/main/java/hotspot/user/dispatch/sms/listener/SmsPushService.java
+++ b/src/main/java/hotspot/user/dispatch/sms/listener/SmsPushService.java
@@ -6,7 +6,7 @@ import org.springframework.stereotype.Component;
 import hotspot.user.common.exception.ApplicationException;
 import hotspot.user.common.exception.code.SmsErrorCode;
 import hotspot.user.dispatch.sms.config.SmsProperties;
-import hotspot.user.dispatch.sms.infrastructure.SmsDispatchQueuePublisher;
+import hotspot.user.dispatch.sms.service.SmsDispatchQueuePublisher;
 import hotspot.user.kafka.dto.UserAlertNotificationsPersistedEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -23,22 +23,6 @@ public class SmsPushService {
     // 저장된 알림 이벤트를 받아 SMS 디스패치 큐에 적재한다.
     public void onNotificationsPersisted(UserAlertNotificationsPersistedEvent event) {
         if (!smsProperties.isEnabled()) {
-            return;
-        }
-
-        if (!smsProperties.isEnabled2()) {
-            return;
-        }
-
-        if (!smsProperties.isEnabled3()) {
-            return;
-        }
-
-        if (!smsProperties.isEnabled4()) {
-            return;
-        }
-
-        if (!smsProperties.isEnabled5()) {
             return;
         }
 

--- a/src/main/java/hotspot/user/dispatch/sms/service/SmsDispatchQueuePublisher.java
+++ b/src/main/java/hotspot/user/dispatch/sms/service/SmsDispatchQueuePublisher.java
@@ -1,4 +1,4 @@
-package hotspot.user.dispatch.sms.infrastructure;
+package hotspot.user.dispatch.sms.service;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.kafka.core.KafkaTemplate;

--- a/src/main/java/hotspot/user/dispatch/sms/service/SmsDispatchService.java
+++ b/src/main/java/hotspot/user/dispatch/sms/service/SmsDispatchService.java
@@ -5,7 +5,7 @@ import org.springframework.stereotype.Service;
 import hotspot.user.common.exception.ApplicationException;
 import hotspot.user.common.exception.code.SmsErrorCode;
 import hotspot.user.dispatch.sms.domain.SmsRecipientResolution;
-import hotspot.user.dispatch.sms.port.SmsSenderPort;
+import hotspot.user.dispatch.sms.infrastructure.SmsSenderPort;
 import hotspot.user.kafka.domain.NotificationType;
 import hotspot.user.notification.domain.Notification;
 import hotspot.user.notification.domain.NotificationCategory;

--- a/src/main/java/hotspot/user/dispatch/sms/support/SolapiAuthHeaderFactory.java
+++ b/src/main/java/hotspot/user/dispatch/sms/support/SolapiAuthHeaderFactory.java
@@ -1,0 +1,55 @@
+package hotspot.user.dispatch.sms.support;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.UUID;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+
+import org.springframework.stereotype.Component;
+
+import hotspot.user.common.exception.ApplicationException;
+import hotspot.user.common.exception.code.SmsErrorCode;
+
+@Component
+public class SolapiAuthHeaderFactory {
+
+    // Solapi HMAC 인증 헤더를 생성한다.
+    public String create(String apiKey, String apiSecret) {
+        String date = Instant.now().truncatedTo(ChronoUnit.SECONDS).toString();
+        String salt = UUID.randomUUID().toString().replace("-", "");
+        return create(apiKey, apiSecret, date, salt);
+    }
+
+    // Solapi HMAC 인증 헤더를 지정한 date/salt로 생성한다.
+    String create(String apiKey, String apiSecret, String date, String salt) {
+        String signature = hmacSha256Hex(apiSecret, date + salt);
+        return "HMAC-SHA256 apiKey=" + apiKey
+                + ", date=" + date
+                + ", salt=" + salt
+                + ", signature=" + signature;
+    }
+
+    // HMAC-SHA256 서명을 hex 문자열로 생성한다.
+    private String hmacSha256Hex(String secret, String value) {
+        try {
+            Mac mac = Mac.getInstance("HmacSHA256");
+            mac.init(new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), "HmacSHA256"));
+            byte[] raw = mac.doFinal(value.getBytes(StandardCharsets.UTF_8));
+            return toHex(raw);
+        } catch (Exception ex) {
+            throw new ApplicationException(SmsErrorCode.SMS_PROVIDER_AUTH_FAILED, ex);
+        }
+    }
+
+    // byte 배열을 소문자 hex 문자열로 변환한다.
+    private String toHex(byte[] bytes) {
+        StringBuilder builder = new StringBuilder(bytes.length * 2);
+        for (byte b : bytes) {
+            builder.append(String.format("%02x", b));
+        }
+        return builder.toString();
+    }
+}

--- a/src/main/java/hotspot/user/dispatch/sms/support/SolapiRequestFactory.java
+++ b/src/main/java/hotspot/user/dispatch/sms/support/SolapiRequestFactory.java
@@ -1,0 +1,38 @@
+package hotspot.user.dispatch.sms.support;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class SolapiRequestFactory {
+
+    // Solapi SMS 발송 엔드포인트 URL을 생성한다.
+    public String buildSendUrl(String baseUrl, String sendPath) {
+        if (baseUrl.endsWith("/") && sendPath.startsWith("/")) {
+            return baseUrl.substring(0, baseUrl.length() - 1) + sendPath;
+        }
+        if (!baseUrl.endsWith("/") && !sendPath.startsWith("/")) {
+            return baseUrl + "/" + sendPath;
+        }
+        return baseUrl + sendPath;
+    }
+
+    // Solapi send-many/detail 요청 바디를 구성한다.
+    public Map<String, Object> buildPayload(String from, String to, String message) {
+        Map<String, String> msg = new LinkedHashMap<>();
+        msg.put("to", digitsOnly(to));
+        msg.put("from", digitsOnly(from));
+        msg.put("text", message);
+
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("message", msg);
+        return payload;
+    }
+
+    // 전화번호 문자열에서 숫자만 추출한다.
+    private String digitsOnly(String value) {
+        return value == null ? "" : value.replaceAll("\\D", "");
+    }
+}

--- a/src/main/resources/sms.yml
+++ b/src/main/resources/sms.yml
@@ -1,8 +1,8 @@
 sms:
-  enabled: false
-  enabled2: false
-  enabled3: false
-  enabled4: false
-  enabled5: false
-  provider: noop
+  enabled: true
+  provider: solapi
   from: ${SMS_FROM_NUMBER:}
+  api-key: ${SOLAPI_API_KEY:}
+  api-secret: ${SOLAPI_API_SECRET:}
+  api-base-url: ${SOLAPI_API_BASE_URL:https://api.solapi.com}
+  send-path: ${SOLAPI_SEND_PATH:/messages/v4/send-many/detail}

--- a/src/test/java/hotspot/user/dispatch/sms/config/SmsPropertiesTest.java
+++ b/src/test/java/hotspot/user/dispatch/sms/config/SmsPropertiesTest.java
@@ -10,14 +10,17 @@ class SmsPropertiesTest {
     @Test
     @DisplayName("keeps configured sms properties")
     void propertiesValues() {
-        SmsProperties properties = new SmsProperties(true, false, false, false, false, "noop", "01012345678");
+        SmsProperties properties = new SmsProperties(
+                true, "noop", "01012345678",
+                "api-key", "api-secret", "https://api.solapi.com", "/messages/v4/send-many/detail"
+        );
 
         assertThat(properties.isEnabled()).isTrue();
-        assertThat(properties.isEnabled2()).isFalse();
-        assertThat(properties.isEnabled3()).isFalse();
-        assertThat(properties.isEnabled4()).isFalse();
-        assertThat(properties.isEnabled5()).isFalse();
         assertThat(properties.getProvider()).isEqualTo("noop");
         assertThat(properties.getFrom()).isEqualTo("01012345678");
+        assertThat(properties.getApiKey()).isEqualTo("api-key");
+        assertThat(properties.getApiSecret()).isEqualTo("api-secret");
+        assertThat(properties.getApiBaseUrl()).isEqualTo("https://api.solapi.com");
+        assertThat(properties.getSendPath()).isEqualTo("/messages/v4/send-many/detail");
     }
 }

--- a/src/test/java/hotspot/user/dispatch/sms/infrastructure/NoopSmsSenderTest.java
+++ b/src/test/java/hotspot/user/dispatch/sms/infrastructure/NoopSmsSenderTest.java
@@ -11,7 +11,10 @@ class NoopSmsSenderTest {
     @DisplayName("send does not throw")
     void sendNoop() {
         NoopSmsSender sender = new NoopSmsSender(
-                new SmsProperties(true, false, false, false, false, "noop", "01012345678")
+                new SmsProperties(
+                        true, "noop", "01012345678",
+                        "api-key", "api-secret", "https://api.solapi.com", "/messages/v4/send-many/detail"
+                )
         );
 
         sender.send("01012345678", "hello");

--- a/src/test/java/hotspot/user/dispatch/sms/infrastructure/SmsDispatchQueuePublisherTest.java
+++ b/src/test/java/hotspot/user/dispatch/sms/infrastructure/SmsDispatchQueuePublisherTest.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import hotspot.user.common.exception.ApplicationException;
 import hotspot.user.common.exception.code.SmsErrorCode;
+import hotspot.user.dispatch.sms.service.SmsDispatchQueuePublisher;
 import hotspot.user.notification.domain.Notification;
 
 @ExtendWith(MockitoExtension.class)

--- a/src/test/java/hotspot/user/dispatch/sms/infrastructure/SolapiAuthHeaderFactoryTest.java
+++ b/src/test/java/hotspot/user/dispatch/sms/infrastructure/SolapiAuthHeaderFactoryTest.java
@@ -1,0 +1,38 @@
+package hotspot.user.dispatch.sms.infrastructure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import hotspot.user.common.exception.ApplicationException;
+import hotspot.user.common.exception.code.SmsErrorCode;
+import hotspot.user.dispatch.sms.support.SolapiAuthHeaderFactory;
+
+class SolapiAuthHeaderFactoryTest {
+
+    private final SolapiAuthHeaderFactory factory = new SolapiAuthHeaderFactory();
+
+    @Test
+    @DisplayName("creates hmac authorization header with required fields")
+    void createHeader() {
+        String header = factory.create("test-api-key", "test-api-secret");
+
+        assertThat(header).startsWith("HMAC-SHA256 apiKey=test-api-key");
+        assertThat(header).contains(", date=");
+        assertThat(header).contains(", salt=");
+        assertThat(header).contains(", signature=");
+    }
+
+    @Test
+    @DisplayName("throws common sms auth error when secret is invalid")
+    void createHeaderFails() {
+        assertThatThrownBy(() -> factory.create("test-api-key", null))
+                .isInstanceOf(ApplicationException.class)
+                .satisfies(ex -> {
+                    ApplicationException appEx = (ApplicationException) ex;
+                    assertThat(appEx.getCode()).isEqualTo(SmsErrorCode.SMS_PROVIDER_AUTH_FAILED);
+                });
+    }
+}

--- a/src/test/java/hotspot/user/dispatch/sms/infrastructure/SolapiRequestFactoryTest.java
+++ b/src/test/java/hotspot/user/dispatch/sms/infrastructure/SolapiRequestFactoryTest.java
@@ -1,0 +1,39 @@
+package hotspot.user.dispatch.sms.infrastructure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import hotspot.user.dispatch.sms.support.SolapiRequestFactory;
+
+class SolapiRequestFactoryTest {
+
+    private final SolapiRequestFactory factory = new SolapiRequestFactory();
+
+    @Test
+    @DisplayName("builds send url safely for slash combinations")
+    void buildSendUrl() {
+        assertThat(factory.buildSendUrl("https://api.solapi.com", "/messages/v4/send-many/detail"))
+                .isEqualTo("https://api.solapi.com/messages/v4/send-many/detail");
+        assertThat(factory.buildSendUrl("https://api.solapi.com/", "/messages/v4/send-many/detail"))
+                .isEqualTo("https://api.solapi.com/messages/v4/send-many/detail");
+        assertThat(factory.buildSendUrl("https://api.solapi.com", "messages/v4/send-many/detail"))
+                .isEqualTo("https://api.solapi.com/messages/v4/send-many/detail");
+    }
+
+    @Test
+    @DisplayName("builds payload with digits-only phone numbers")
+    void buildPayload() {
+        Map<String, Object> payload = factory.buildPayload("010-1111-2222", "010-3333-4444", "hello");
+
+        assertThat(payload).containsKey("message");
+        @SuppressWarnings("unchecked")
+        Map<String, String> message = (Map<String, String>) payload.get("message");
+        assertThat(message.get("from")).isEqualTo("01011112222");
+        assertThat(message.get("to")).isEqualTo("01033334444");
+        assertThat(message.get("text")).isEqualTo("hello");
+    }
+}

--- a/src/test/java/hotspot/user/dispatch/sms/infrastructure/SolapiSmsSenderTest.java
+++ b/src/test/java/hotspot/user/dispatch/sms/infrastructure/SolapiSmsSenderTest.java
@@ -1,0 +1,134 @@
+package hotspot.user.dispatch.sms.infrastructure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import hotspot.user.common.exception.ApplicationException;
+import hotspot.user.common.exception.code.SmsErrorCode;
+import hotspot.user.dispatch.sms.config.SmsProperties;
+import hotspot.user.dispatch.sms.support.SolapiAuthHeaderFactory;
+import hotspot.user.dispatch.sms.support.SolapiRequestFactory;
+
+@ExtendWith(MockitoExtension.class)
+class SolapiSmsSenderTest {
+
+    @Mock
+    private ObjectMapper objectMapper;
+
+    @Mock
+    private HttpClient httpClient;
+
+    @Mock
+    private HttpResponse<String> response;
+
+    @Mock
+    private SolapiAuthHeaderFactory authHeaderFactory;
+
+    @Mock
+    private SolapiRequestFactory requestFactory;
+
+    @Test
+    @DisplayName("calls solapi endpoint with hmac authorization when sending sms")
+    void sendSuccess() throws Exception {
+        SmsProperties properties = solapiProperties();
+        SolapiSmsSender sender = new SolapiSmsSender(
+                properties,
+                objectMapper,
+                authHeaderFactory,
+                requestFactory,
+                httpClient
+        );
+        given(authHeaderFactory.create("test-api-key", "test-api-secret")).willReturn("auth-header");
+        given(requestFactory.buildSendUrl("https://api.solapi.com", "/messages/v4/send-many/detail"))
+                .willReturn("https://api.solapi.com/messages/v4/send-many/detail");
+        given(requestFactory.buildPayload("01012345678", "010-1234-5678", "test-message"))
+                .willReturn(java.util.Map.of("message", java.util.Map.of()));
+        given(objectMapper.writeValueAsString(any())).willReturn("{\"message\":{}}");
+        given(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class))).willReturn(response);
+        given(response.statusCode()).willReturn(200);
+
+        sender.send("010-1234-5678", "test-message");
+
+        ArgumentCaptor<HttpRequest> requestCaptor = ArgumentCaptor.forClass(HttpRequest.class);
+        then(httpClient).should().send(requestCaptor.capture(), any(HttpResponse.BodyHandler.class));
+        HttpRequest request = requestCaptor.getValue();
+
+        assertThat(request.uri().toString()).isEqualTo("https://api.solapi.com/messages/v4/send-many/detail");
+        assertThat(request.headers().firstValue("Authorization")).isPresent();
+        assertThat(request.headers().firstValue("Authorization").orElse("")).isEqualTo("auth-header");
+    }
+
+    @Test
+    @DisplayName("throws when solapi response is non-success")
+    void sendFailsWhenNonSuccessResponse() throws Exception {
+        SmsProperties properties = solapiProperties();
+        SolapiSmsSender sender = new SolapiSmsSender(
+                properties,
+                objectMapper,
+                authHeaderFactory,
+                requestFactory,
+                httpClient
+        );
+        given(authHeaderFactory.create("test-api-key", "test-api-secret")).willReturn("auth-header");
+        given(requestFactory.buildSendUrl("https://api.solapi.com", "/messages/v4/send-many/detail"))
+                .willReturn("https://api.solapi.com/messages/v4/send-many/detail");
+        given(requestFactory.buildPayload("01012345678", "01012345678", "test-message"))
+                .willReturn(java.util.Map.of("message", java.util.Map.of()));
+        given(objectMapper.writeValueAsString(any())).willReturn("{\"message\":{}}");
+        given(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class))).willReturn(response);
+        given(response.statusCode()).willReturn(400);
+
+        assertThatThrownBy(() -> sender.send("01012345678", "test-message"))
+                .isInstanceOf(ApplicationException.class)
+                .satisfies(ex -> {
+                    ApplicationException appEx = (ApplicationException) ex;
+                    assertThat(appEx.getCode()).isEqualTo(SmsErrorCode.SMS_PROVIDER_REQUEST_FAILED);
+                });
+    }
+
+    @Test
+    @DisplayName("throws when required solapi credential is missing")
+    void sendFailsWhenCredentialMissing() {
+        SmsProperties properties = new SmsProperties(
+                true, "solapi", "01012345678",
+                "", "test-api-secret", "https://api.solapi.com", "/messages/v4/send-many/detail"
+        );
+        SolapiSmsSender sender = new SolapiSmsSender(
+                properties,
+                objectMapper,
+                authHeaderFactory,
+                requestFactory,
+                httpClient
+        );
+
+        assertThatThrownBy(() -> sender.send("01012345678", "test-message"))
+                .isInstanceOf(ApplicationException.class)
+                .satisfies(ex -> {
+                    ApplicationException appEx = (ApplicationException) ex;
+                    assertThat(appEx.getCode()).isEqualTo(SmsErrorCode.SMS_PROVIDER_CONFIG_INVALID);
+                });
+    }
+
+    private SmsProperties solapiProperties() {
+        return new SmsProperties(
+                true, "solapi", "01012345678",
+                "test-api-key", "test-api-secret", "https://api.solapi.com", "/messages/v4/send-many/detail"
+        );
+    }
+}

--- a/src/test/java/hotspot/user/dispatch/sms/listener/SmsPushServiceTest.java
+++ b/src/test/java/hotspot/user/dispatch/sms/listener/SmsPushServiceTest.java
@@ -20,7 +20,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import hotspot.user.common.exception.ApplicationException;
 import hotspot.user.common.exception.code.SmsErrorCode;
 import hotspot.user.dispatch.sms.config.SmsProperties;
-import hotspot.user.dispatch.sms.infrastructure.SmsDispatchQueuePublisher;
+import hotspot.user.dispatch.sms.service.SmsDispatchQueuePublisher;
 import hotspot.user.kafka.dto.UserAlertEvent;
 import hotspot.user.kafka.dto.UserAlertNotificationsPersistedEvent;
 import hotspot.user.notification.domain.Notification;
@@ -40,7 +40,7 @@ class SmsPushServiceTest {
     @Test
     @DisplayName("enqueues notifications when sms is enabled")
     void dispatchesWhenEnabled() {
-        mockAllEnabled();
+        mockEnabled();
         Notification notification = notification(1L, "IMMEDIATE_BLOCK_APPLIED");
         UserAlertNotificationsPersistedEvent event = new UserAlertNotificationsPersistedEvent(
                 sourceEvent(),
@@ -70,7 +70,7 @@ class SmsPushServiceTest {
     @Test
     @DisplayName("throws listener error when enqueue fails")
     void throwsWhenEnqueueFails() {
-        mockAllEnabled();
+        mockEnabled();
         Notification first = notification(1L, "IMMEDIATE_BLOCK_APPLIED");
         UserAlertNotificationsPersistedEvent event = new UserAlertNotificationsPersistedEvent(
                 sourceEvent(),
@@ -88,12 +88,8 @@ class SmsPushServiceTest {
         then(smsDispatchQueuePublisher).should().enqueue(first);
     }
 
-    private void mockAllEnabled() {
+    private void mockEnabled() {
         given(smsProperties.isEnabled()).willReturn(true);
-        given(smsProperties.isEnabled2()).willReturn(true);
-        given(smsProperties.isEnabled3()).willReturn(true);
-        given(smsProperties.isEnabled4()).willReturn(true);
-        given(smsProperties.isEnabled5()).willReturn(true);
     }
 
     private UserAlertEvent sourceEvent() {

--- a/src/test/java/hotspot/user/dispatch/sms/service/SmsDispatchServiceTest.java
+++ b/src/test/java/hotspot/user/dispatch/sms/service/SmsDispatchServiceTest.java
@@ -18,7 +18,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import hotspot.user.common.exception.ApplicationException;
 import hotspot.user.common.exception.code.SmsErrorCode;
 import hotspot.user.dispatch.sms.domain.SmsRecipientResolution;
-import hotspot.user.dispatch.sms.port.SmsSenderPort;
+import hotspot.user.dispatch.sms.infrastructure.SmsSenderPort;
 import hotspot.user.notification.domain.Notification;
 import hotspot.user.notification.domain.NotificationAllow;
 import hotspot.user.notification.domain.NotificationCategory;

--- a/src/test/java/hotspot/user/dispatch/sms/service/SmsMessageBuilderTest.java
+++ b/src/test/java/hotspot/user/dispatch/sms/service/SmsMessageBuilderTest.java
@@ -16,7 +16,10 @@ class SmsMessageBuilderTest {
     @DisplayName("builds sms message with from and notification content")
     void buildMessage() {
         SmsMessageBuilder builder = new SmsMessageBuilder(
-                new SmsProperties(true, false, false, false, false, "noop", "HOTSPOT")
+                new SmsProperties(
+                        true, "noop", "HOTSPOT",
+                        "api-key", "api-secret", "https://api.solapi.com", "/messages/v4/send-many/detail"
+                )
         );
         Notification notification = Notification.builder()
                 .id(1L)


### PR DESCRIPTION
## 🎫 지라 티켓

<!-- 지라 티켓을 작성해주세요 ex) HOTSPOT-123 -->
HOTSPOT-233

---

## 🔗 GitHub 이슈
<!-- 자동 close를 원하면 아래 형식으로 작성
예) Closes #12
-->
Closes #137 

---


## ✅ 작업 사항

<!-- 작업한 부분을 설명해주세요. -->
- Solapi SMS API 연동
- 설정 속성 추가 및 정리 
  - Solapi API 키
  - 시크릿 
  - 기본 URL 및 발송 경로

- SMS 발송 시스템 리팩토링
- 공통 오류 코드 추가

-  실발송 테스트

---

## 📋 체크리스트

<!-- PR 제출 전 확인해주세요. 해당 항목에 [x]로 체크해주세요. -->

- [x] 코드가 정상적으로 빌드됩니다.
- [x] 관련 테스트 코드를 작성했습니다.
- [x] 기존 테스트가 모두 통과합니다.
- [x] 코드 스타일(Spotless, Checkstyle)을 준수합니다.
- [x] Jira 티켓 상태를 In Review / Done으로 변경했습니다.

---

## ⌨ 기타
