### PR TITLE
[HOTSPOT-262] 다중 소셜 로그인 시 내 정보 조회 안되는 버그 해결

### DIFF
--- a/src/main/java/hotspot/user/member/infrastructure/MemberJpaRepository.java
+++ b/src/main/java/hotspot/user/member/infrastructure/MemberJpaRepository.java
@@ -20,10 +20,9 @@ public interface MemberJpaRepository extends JpaRepository<MemberEntity, Long> {
     // - Subscription: 현재는 1:1로 가정하나, 다중 회선 확장 시 최신/대표 회선 필터링 조건 추가 필요
     @Query("""
            SELECT DISTINCT new hotspot.user.member.infrastructure.entity.MemberDetailInfoDto(
-               m, sa.email, s.phoneEnc, s.subId, fs.familyRole, fs.family.familyId
+               m, :email, s.phoneEnc, s.subId, fs.familyRole, fs.family.familyId
            )
            FROM MemberEntity m
-           JOIN SocialAccountEntity sa ON sa.member = m AND sa.email = :email
            LEFT JOIN SubscriptionEntity s ON s.member = m
            LEFT JOIN FamilySubscriptionEntity fs ON fs.subscription = s
            WHERE m.id = :memberId

--- a/src/main/java/hotspot/user/member/infrastructure/MemberJpaRepository.java
+++ b/src/main/java/hotspot/user/member/infrastructure/MemberJpaRepository.java
@@ -23,7 +23,7 @@ public interface MemberJpaRepository extends JpaRepository<MemberEntity, Long> {
                m, sa.email, s.phoneEnc, s.subId, fs.familyRole, fs.family.familyId
            )
            FROM MemberEntity m
-           LEFT JOIN SocialAccountEntity sa ON sa.member = m AND sa.email = :email
+           JOIN SocialAccountEntity sa ON sa.member = m AND sa.email = :email
            LEFT JOIN SubscriptionEntity s ON s.member = m
            LEFT JOIN FamilySubscriptionEntity fs ON fs.subscription = s
            WHERE m.id = :memberId


### PR DESCRIPTION
## 🎫 지라 티켓

<!-- 지라 티켓을 작성해주세요 ex) HOTSPOT-123 -->
HOTSPOT-262

---

## 🔗 GitHub 이슈
<!-- 자동 close를 원하면 아래 형식으로 작성
예) Closes #12
-->
Closes #148

---


## ✅ 작업 사항

<!-- 작업한 부분을 설명해주세요. -->

다중 소셜 로그인 정보 조회 시 Not Unique Error 해결
- email은 accessToken에 담겨져있기 때문에 검증이 끝나서 DB조회하지 않고 그대로 전달함

---

## 📋 체크리스트

<!-- PR 제출 전 확인해주세요. 해당 항목에 [x]로 체크해주세요. -->

- [x] 코드가 정상적으로 빌드됩니다.
- [x] 관련 테스트 코드를 작성했습니다.
- [x] 기존 테스트가 모두 통과합니다.
- [x] 코드 스타일(Spotless, Checkstyle)을 준수합니다.
- [x] Jira 티켓 상태를 In Review / Done으로 변경했습니다.

---

## ⌨ 기타
