### PR TITLE
[HOTSPOT-262] 다중 소셜 로그인 내 정보 조회 버그 수정

### DIFF
--- a/src/main/java/hotspot/user/member/infrastructure/MemberJpaRepository.java
+++ b/src/main/java/hotspot/user/member/infrastructure/MemberJpaRepository.java
@@ -18,21 +18,38 @@ public interface MemberJpaRepository extends JpaRepository<MemberEntity, Long> {
     // MemberDetailInfoDto로 바로 변환해야함 But, Builder는 JPQL에서 불가능
     // [To-Do] 1:N 관계(다중 회선) 발생 시 중복 행 문제 해결 필요
     // - Subscription: 현재는 1:1로 가정하나, 다중 회선 확장 시 최신/대표 회선 필터링 조건 추가 필요
-            @Query("""
-                   SELECT new hotspot.user.member.infrastructure.entity.MemberDetailInfoDto(
-                       m, :email, s.phoneEnc, s.subId, fs.familyRole, fs.family.familyId
-                   )
-                   FROM MemberEntity m
-                   LEFT JOIN SubscriptionEntity s ON s.member = m
-                        AND s.subId = (SELECT MAX(s2.subId) FROM SubscriptionEntity s2 WHERE s2.member = m)
-                   LEFT JOIN FamilySubscriptionEntity fs ON fs.subscription = s
-                   WHERE m.id = :memberId
-                     AND m.isDeleted = false
-                     AND (:email IS NULL OR EXISTS (
-                         SELECT 1 FROM SocialAccountEntity sa
-                         WHERE sa.member = m AND sa.email = :email
-                     ))
-                   """)
-            Optional<MemberDetailInfoDto> findDetailQueryResult(@Param("memberId") Long memberId,
-                                                                @Param("email") String email);
-        }
+    // [보안 강화] 이메일 소유권까지 엄격하게 검증하여 조회 (외부 API용)
+    @Query("""
+           SELECT new hotspot.user.member.infrastructure.entity.MemberDetailInfoDto(
+               m, :email, s.phoneEnc, s.subId, fs.familyRole, fs.family.familyId
+           )
+           FROM MemberEntity m
+           LEFT JOIN SubscriptionEntity s ON s.member = m
+                AND s.isDeleted = false
+                AND s.subId = (SELECT MAX(s2.subId) FROM SubscriptionEntity s2 WHERE s2.member = m AND s2.isDeleted = false)
+           LEFT JOIN FamilySubscriptionEntity fs ON fs.subscription = s
+           WHERE m.id = :memberId
+             AND m.isDeleted = false
+             AND EXISTS (
+                 SELECT 1 FROM SocialAccountEntity sa
+                 WHERE sa.member = m AND sa.email = :email AND sa.isDeleted = false
+             )
+           """)
+    Optional<MemberDetailInfoDto> findDetailByIdAndEmail(@Param("memberId") Long memberId, @Param("email") String email);
+
+    // [내부 전용] 이메일 검증 없이 ID만으로 상세 정보 조회 (이미 권한이 검증된 내부 로직용)
+    @Query("""
+           SELECT new hotspot.user.member.infrastructure.entity.MemberDetailInfoDto(
+               m, null, s.phoneEnc, s.subId, fs.familyRole, fs.family.familyId
+           )
+           FROM MemberEntity m
+           LEFT JOIN SubscriptionEntity s ON s.member = m
+                AND s.isDeleted = false
+                AND s.subId = (SELECT MAX(s2.subId) FROM SubscriptionEntity s2 WHERE s2.member = m AND s2.isDeleted = false)
+           LEFT JOIN FamilySubscriptionEntity fs ON fs.subscription = s
+           WHERE m.id = :memberId
+             AND m.isDeleted = false
+           """)
+    Optional<MemberDetailInfoDto> findDetailById(@Param("memberId") Long memberId);
+}
+                

--- a/src/main/java/hotspot/user/member/infrastructure/MemberJpaRepository.java
+++ b/src/main/java/hotspot/user/member/infrastructure/MemberJpaRepository.java
@@ -26,7 +26,11 @@ public interface MemberJpaRepository extends JpaRepository<MemberEntity, Long> {
            FROM MemberEntity m
            LEFT JOIN SubscriptionEntity s ON s.member = m
                 AND s.isDeleted = false
-                AND s.subId = (SELECT MAX(s2.subId) FROM SubscriptionEntity s2 WHERE s2.member = m AND s2.isDeleted = false)
+                AND s.subId = (
+                    SELECT MAX(s2.subId)
+                    FROM SubscriptionEntity s2
+                    WHERE s2.member = m AND s2.isDeleted = false
+                )
            LEFT JOIN FamilySubscriptionEntity fs ON fs.subscription = s
            WHERE m.id = :memberId
              AND m.isDeleted = false
@@ -35,7 +39,10 @@ public interface MemberJpaRepository extends JpaRepository<MemberEntity, Long> {
                  WHERE sa.member = m AND sa.email = :email AND sa.isDeleted = false
              )
            """)
-    Optional<MemberDetailInfoDto> findDetailByIdAndEmail(@Param("memberId") Long memberId, @Param("email") String email);
+    Optional<MemberDetailInfoDto> findDetailByIdAndEmail(
+            @Param("memberId") Long memberId,
+            @Param("email") String email
+    );
 
     // [내부 전용] 이메일 검증 없이 ID만으로 상세 정보 조회 (이미 권한이 검증된 내부 로직용)
     @Query("""
@@ -45,11 +52,14 @@ public interface MemberJpaRepository extends JpaRepository<MemberEntity, Long> {
            FROM MemberEntity m
            LEFT JOIN SubscriptionEntity s ON s.member = m
                 AND s.isDeleted = false
-                AND s.subId = (SELECT MAX(s2.subId) FROM SubscriptionEntity s2 WHERE s2.member = m AND s2.isDeleted = false)
+                AND s.subId = (
+                    SELECT MAX(s2.subId)
+                    FROM SubscriptionEntity s2
+                    WHERE s2.member = m AND s2.isDeleted = false
+                )
            LEFT JOIN FamilySubscriptionEntity fs ON fs.subscription = s
            WHERE m.id = :memberId
              AND m.isDeleted = false
            """)
     Optional<MemberDetailInfoDto> findDetailById(@Param("memberId") Long memberId);
 }
-                

--- a/src/main/java/hotspot/user/member/infrastructure/MemberJpaRepository.java
+++ b/src/main/java/hotspot/user/member/infrastructure/MemberJpaRepository.java
@@ -24,6 +24,7 @@ public interface MemberJpaRepository extends JpaRepository<MemberEntity, Long> {
            )
            FROM MemberEntity m
            LEFT JOIN SubscriptionEntity s ON s.member = m
+                AND s.subId = (SELECT MAX(s2.subId) FROM SubscriptionEntity s2 WHERE s2.member = m)
            LEFT JOIN FamilySubscriptionEntity fs ON fs.subscription = s
            WHERE m.id = :memberId
              AND EXISTS (

--- a/src/main/java/hotspot/user/member/infrastructure/MemberJpaRepository.java
+++ b/src/main/java/hotspot/user/member/infrastructure/MemberJpaRepository.java
@@ -23,7 +23,7 @@ public interface MemberJpaRepository extends JpaRepository<MemberEntity, Long> {
                        m, :email, s.phoneEnc, s.subId, fs.familyRole, fs.family.familyId
                    )
                    FROM MemberEntity m
-                   LEFT JOIN SubscriptionEntity s ON s.member = m 
+                   LEFT JOIN SubscriptionEntity s ON s.member = m
                         AND s.subId = (SELECT MAX(s2.subId) FROM SubscriptionEntity s2 WHERE s2.member = m)
                    LEFT JOIN FamilySubscriptionEntity fs ON fs.subscription = s
                    WHERE m.id = :memberId
@@ -33,6 +33,6 @@ public interface MemberJpaRepository extends JpaRepository<MemberEntity, Long> {
                          WHERE sa.member = m AND sa.email = :email
                      ))
                    """)
-            Optional<MemberDetailInfoDto> findDetailQueryResult(@Param("memberId") Long memberId, @Param("email") String email);
+            Optional<MemberDetailInfoDto> findDetailQueryResult(@Param("memberId") Long memberId,
+                                                                @Param("email") String email);
         }
-        

--- a/src/main/java/hotspot/user/member/infrastructure/MemberJpaRepository.java
+++ b/src/main/java/hotspot/user/member/infrastructure/MemberJpaRepository.java
@@ -18,19 +18,21 @@ public interface MemberJpaRepository extends JpaRepository<MemberEntity, Long> {
     // MemberDetailInfoDto로 바로 변환해야함 But, Builder는 JPQL에서 불가능
     // [To-Do] 1:N 관계(다중 회선) 발생 시 중복 행 문제 해결 필요
     // - Subscription: 현재는 1:1로 가정하나, 다중 회선 확장 시 최신/대표 회선 필터링 조건 추가 필요
-    @Query("""
-           SELECT new hotspot.user.member.infrastructure.entity.MemberDetailInfoDto(
-               m, :email, s.phoneEnc, s.subId, fs.familyRole, fs.family.familyId
-           )
-           FROM MemberEntity m
-           LEFT JOIN SubscriptionEntity s ON s.member = m
-                AND s.subId = (SELECT MAX(s2.subId) FROM SubscriptionEntity s2 WHERE s2.member = m)
-           LEFT JOIN FamilySubscriptionEntity fs ON fs.subscription = s
-           WHERE m.id = :memberId
-             AND EXISTS (
-                 SELECT 1 FROM SocialAccountEntity sa
-                 WHERE sa.member = m AND sa.email = :email
-             )
-           """)
-    Optional<MemberDetailInfoDto> findDetailQueryResult(@Param("memberId") Long memberId, @Param("email") String email);
-}
+            @Query("""
+                   SELECT new hotspot.user.member.infrastructure.entity.MemberDetailInfoDto(
+                       m, :email, s.phoneEnc, s.subId, fs.familyRole, fs.family.familyId
+                   )
+                   FROM MemberEntity m
+                   LEFT JOIN SubscriptionEntity s ON s.member = m 
+                        AND s.subId = (SELECT MAX(s2.subId) FROM SubscriptionEntity s2 WHERE s2.member = m)
+                   LEFT JOIN FamilySubscriptionEntity fs ON fs.subscription = s
+                   WHERE m.id = :memberId
+                     AND m.isDeleted = false
+                     AND (:email IS NULL OR EXISTS (
+                         SELECT 1 FROM SocialAccountEntity sa
+                         WHERE sa.member = m AND sa.email = :email
+                     ))
+                   """)
+            Optional<MemberDetailInfoDto> findDetailQueryResult(@Param("memberId") Long memberId, @Param("email") String email);
+        }
+        

--- a/src/main/java/hotspot/user/member/infrastructure/MemberRepositoryImpl.java
+++ b/src/main/java/hotspot/user/member/infrastructure/MemberRepositoryImpl.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Repository;
 
 import hotspot.user.member.domain.Member;
 import hotspot.user.member.domain.MemberDetailInfo;
+import hotspot.user.member.infrastructure.entity.MemberDetailInfoDto;
 import hotspot.user.member.infrastructure.entity.MemberEntity;
 import hotspot.user.member.service.port.MemberRepository;
 import lombok.RequiredArgsConstructor;
@@ -31,17 +32,25 @@ public class MemberRepositoryImpl implements MemberRepository {
 
     @Override
     public Optional<MemberDetailInfo> findDetailByIdAndEmail(Long id, String email) {
-        // 쿼리 결과를 DTO로 받고, 안전하게 도메인 객체(MemberDetailInfo)로 변환
-        return memberJpaRepository.findDetailQueryResult(id, email)
-                .map(dto -> MemberDetailInfo.builder()
-                        .member(dto.memberEntity().entityToDomain())
-                        .email(dto.email())
-                        .phone(dto.phone())
-                        .subId(dto.subId())
-                        .role(dto.role())
-                        .familyId(dto.familyId())
-                        .build()
-                );
+        return memberJpaRepository.findDetailByIdAndEmail(id, email)
+                .map(this::mapToDomain);
+    }
+
+    @Override
+    public Optional<MemberDetailInfo> findDetailById(Long id) {
+        return memberJpaRepository.findDetailById(id)
+                .map(this::mapToDomain);
+    }
+
+    private MemberDetailInfo mapToDomain(MemberDetailInfoDto dto) {
+        return MemberDetailInfo.builder()
+                .member(dto.memberEntity().entityToDomain())
+                .email(dto.email())
+                .phone(dto.phone())
+                .subId(dto.subId())
+                .role(dto.role())
+                .familyId(dto.familyId())
+                .build();
     }
 
     @Override

--- a/src/main/java/hotspot/user/member/service/port/MemberRepository.java
+++ b/src/main/java/hotspot/user/member/service/port/MemberRepository.java
@@ -8,8 +8,8 @@ import hotspot.user.member.domain.MemberDetailInfo;
 public interface MemberRepository {
     Member save(Member member);
     Optional<Member> findById(Long id);
-    Optional<MemberDetailInfo> findDetailByIdAndEmail(Long id, String email); // 소셜 계정 여러 개인걸 감안해서 email도 전달
-     // 멤버 상세 정보 조회할 떄 JOIN으로 가져오기
+    Optional<MemberDetailInfo> findDetailByIdAndEmail(Long id, String email);
+    Optional<MemberDetailInfo> findDetailById(Long id);
     void delete(Member member);
     void deleteById(Long id);
 }

--- a/src/main/java/hotspot/user/policy/infrastructure/entity/PolicySubEntity.java
+++ b/src/main/java/hotspot/user/policy/infrastructure/entity/PolicySubEntity.java
@@ -64,8 +64,8 @@ public class PolicySubEntity extends BaseEntity {
     public PolicySub entityToDomain() {
         return PolicySub.builder()
                 .id(this.policySubId)
-                .subId(this.subId)
-                .blockPolicyId(this.blockPolicyId)
+                .subId(this.subscription.getSubId())
+                .blockPolicyId(this.blockPolicy.getBlockPolicyId())
                 .isActive(this.isActive)
                 .createdTime(this.getCreatedTime())
                 .modifiedTime(this.getModifiedTime())

--- a/src/main/java/hotspot/user/policy/service/CreateBlockPolicyServiceImpl.java
+++ b/src/main/java/hotspot/user/policy/service/CreateBlockPolicyServiceImpl.java
@@ -51,7 +51,7 @@ public class CreateBlockPolicyServiceImpl implements CreateBlockPolicyService {
     }
 
     private void validateOwnerAuthority(Long memberId, Long requesterFamilyId) {
-        MemberDetailInfo memberDetail = memberRepository.findDetailByIdAndEmail(memberId, null)
+        MemberDetailInfo memberDetail = memberRepository.findDetailById(memberId)
                 .orElseThrow(() -> new ApplicationException(MemberErrorCode.MEMBER_NOT_FOUND));
 
         if (!Objects.equals(memberDetail.getFamilyId(), requesterFamilyId)) {

--- a/src/main/java/hotspot/user/policy/service/DeleteFamilyBlockPolicyServiceImpl.java
+++ b/src/main/java/hotspot/user/policy/service/DeleteFamilyBlockPolicyServiceImpl.java
@@ -47,7 +47,7 @@ public class DeleteFamilyBlockPolicyServiceImpl implements DeleteFamilyBlockPoli
 
     // 요청자가 OWNER인지 권한 검증
     private void validateOwnerAuthority(Long memberId, Long requesterFamilyId) {
-        MemberDetailInfo memberDetail = memberRepository.findDetailByIdAndEmail(memberId, null)
+        MemberDetailInfo memberDetail = memberRepository.findDetailById(memberId)
                 .orElseThrow(() -> new ApplicationException(MemberErrorCode.MEMBER_NOT_FOUND));
 
         if (!Objects.equals(memberDetail.getFamilyId(), requesterFamilyId)) {

--- a/src/main/java/hotspot/user/policy/service/FindSingleBlockPolicyServiceImpl.java
+++ b/src/main/java/hotspot/user/policy/service/FindSingleBlockPolicyServiceImpl.java
@@ -49,7 +49,7 @@ public class FindSingleBlockPolicyServiceImpl implements FindSingleBlockPolicySe
     }
 
     private void validateOwnerAuthority(Long memberId, Long requesterFamilyId) {
-        MemberDetailInfo memberDetail = memberRepository.findDetailByIdAndEmail(memberId, null)
+        MemberDetailInfo memberDetail = memberRepository.findDetailById(memberId)
                 .orElseThrow(() -> new ApplicationException(MemberErrorCode.MEMBER_NOT_FOUND));
 
         if (!Objects.equals(memberDetail.getFamilyId(), requesterFamilyId)) {

--- a/src/main/java/hotspot/user/policy/service/UpdateBlockPolicyServiceImpl.java
+++ b/src/main/java/hotspot/user/policy/service/UpdateBlockPolicyServiceImpl.java
@@ -73,7 +73,7 @@ public class UpdateBlockPolicyServiceImpl implements UpdateBlockPolicyService {
     }
 
     private void validateOwnerAuthority(Long memberId, Long requesterFamilyId) {
-        MemberDetailInfo memberDetail = memberRepository.findDetailByIdAndEmail(memberId, null)
+        MemberDetailInfo memberDetail = memberRepository.findDetailById(memberId)
                 .orElseThrow(() -> new ApplicationException(MemberErrorCode.MEMBER_NOT_FOUND));
 
         if (!Objects.equals(memberDetail.getFamilyId(), requesterFamilyId)) {

--- a/src/main/java/hotspot/user/policy/service/UpdateFamilyBlockPolicyStatusServiceImpl.java
+++ b/src/main/java/hotspot/user/policy/service/UpdateFamilyBlockPolicyStatusServiceImpl.java
@@ -88,7 +88,7 @@ public class UpdateFamilyBlockPolicyStatusServiceImpl implements UpdateFamilyBlo
 
     private void validateOwnerAuthority(Long memberId, Long requesterFamilyId) {
         // MemberDetailInfo를 통해 역할(Role)과 소속 가족(FamilyId)을 한 번에 확인
-        MemberDetailInfo memberDetail = memberRepository.findDetailByIdAndEmail(memberId, null)
+        MemberDetailInfo memberDetail = memberRepository.findDetailById(memberId)
                 .orElseThrow(() -> new ApplicationException(MemberErrorCode.MEMBER_NOT_FOUND));
 
         if (!Objects.equals(memberDetail.getFamilyId(), requesterFamilyId)) {

--- a/src/test/java/hotspot/user/member/infrastructure/MemberRepositoryImplTest.java
+++ b/src/test/java/hotspot/user/member/infrastructure/MemberRepositoryImplTest.java
@@ -82,7 +82,7 @@ class MemberRepositoryImplTest {
                 .familyId(100L)
                 .build();
 
-        given(memberJpaRepository.findDetailQueryResult(memberId, email)).willReturn(Optional.of(dto));
+        given(memberJpaRepository.findDetailByIdAndEmail(memberId, email)).willReturn(Optional.of(dto));
 
         // when
         Optional<MemberDetailInfo> result = memberRepository.findDetailByIdAndEmail(memberId, email);
@@ -104,7 +104,7 @@ class MemberRepositoryImplTest {
         // given
         Long memberId = 999L;
         String email = "notfound@email.com";
-        given(memberJpaRepository.findDetailQueryResult(memberId, email)).willReturn(Optional.empty());
+        given(memberJpaRepository.findDetailByIdAndEmail(memberId, email)).willReturn(Optional.empty());
 
         // when
         Optional<MemberDetailInfo> result = memberRepository.findDetailByIdAndEmail(memberId, email);

--- a/src/test/java/hotspot/user/policy/service/CreateBlockPolicyServiceImplTest.java
+++ b/src/test/java/hotspot/user/policy/service/CreateBlockPolicyServiceImplTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
@@ -58,7 +57,7 @@ class CreateBlockPolicyServiceImplTest {
                 .familyId(FAMILY_ID)
                 .role(FamilyRole.OWNER)
                 .build();
-        given(memberRepository.findDetailByIdAndEmail(anyLong(), isNull()))
+        given(memberRepository.findDetailById(anyLong()))
                 .willReturn(Optional.of(memberDetail));
 
         BlockPolicy savedPolicy = BlockPolicy.builder()
@@ -93,7 +92,7 @@ class CreateBlockPolicyServiceImplTest {
                 .familyId(FAMILY_ID)
                 .role(FamilyRole.OWNER)
                 .build();
-        given(memberRepository.findDetailByIdAndEmail(anyLong(), isNull()))
+        given(memberRepository.findDetailById(anyLong()))
                 .willReturn(Optional.of(memberDetail));
 
         // when & then

--- a/src/test/java/hotspot/user/policy/service/DeleteFamilyBlockPolicyServiceImplTest.java
+++ b/src/test/java/hotspot/user/policy/service/DeleteFamilyBlockPolicyServiceImplTest.java
@@ -2,7 +2,6 @@ package hotspot.user.policy.service;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
@@ -56,7 +55,7 @@ class DeleteFamilyBlockPolicyServiceImplTest {
                 .role(FamilyRole.OWNER)
                 .build();
 
-        given(memberRepository.findDetailByIdAndEmail(anyLong(), isNull()))
+        given(memberRepository.findDetailById(anyLong()))
                 .willReturn(Optional.of(memberDetail));
 
         BlockPolicy policy1 = BlockPolicy.builder().id(10L).familyId(FAMILY_ID).build();
@@ -81,7 +80,7 @@ class DeleteFamilyBlockPolicyServiceImplTest {
                 .role(FamilyRole.PARENT)
                 .build();
 
-        given(memberRepository.findDetailByIdAndEmail(anyLong(), isNull()))
+        given(memberRepository.findDetailById(anyLong()))
                 .willReturn(Optional.of(memberDetail));
 
         // when & then
@@ -100,7 +99,7 @@ class DeleteFamilyBlockPolicyServiceImplTest {
                 .role(FamilyRole.OWNER)
                 .build();
 
-        given(memberRepository.findDetailByIdAndEmail(anyLong(), isNull()))
+        given(memberRepository.findDetailById(anyLong()))
                 .willReturn(Optional.of(memberDetail));
 
         // 10L은 존재하지만 999L은 DB에 없음
@@ -123,7 +122,7 @@ class DeleteFamilyBlockPolicyServiceImplTest {
                 .role(FamilyRole.OWNER)
                 .build();
 
-        given(memberRepository.findDetailByIdAndEmail(anyLong(), isNull()))
+        given(memberRepository.findDetailById(anyLong()))
                 .willReturn(Optional.of(memberDetail));
 
         BlockPolicy policy1 = BlockPolicy.builder().id(10L).familyId(FAMILY_ID).build();
@@ -140,7 +139,7 @@ class DeleteFamilyBlockPolicyServiceImplTest {
     @DisplayName("실패: 회원을 찾을 수 없으면 예외가 발생한다")
     void deleteFailMemberNotFound() {
         // given
-        given(memberRepository.findDetailByIdAndEmail(anyLong(), isNull()))
+        given(memberRepository.findDetailById(anyLong()))
                 .willReturn(Optional.empty());
 
         // when & then
@@ -158,7 +157,7 @@ class DeleteFamilyBlockPolicyServiceImplTest {
                 .role(FamilyRole.OWNER)
                 .build();
 
-        given(memberRepository.findDetailByIdAndEmail(anyLong(), isNull()))
+        given(memberRepository.findDetailById(anyLong()))
                 .willReturn(Optional.of(memberDetail));
 
         // when & then

--- a/src/test/java/hotspot/user/policy/service/FindSingleBlockPolicyServiceImplTest.java
+++ b/src/test/java/hotspot/user/policy/service/FindSingleBlockPolicyServiceImplTest.java
@@ -3,7 +3,6 @@ package hotspot.user.policy.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
@@ -49,7 +48,7 @@ class FindSingleBlockPolicyServiceImplTest {
                 .familyId(FAMILY_ID)
                 .role(FamilyRole.OWNER)
                 .build();
-        given(memberRepository.findDetailByIdAndEmail(anyLong(), isNull()))
+        given(memberRepository.findDetailById(anyLong()))
                 .willReturn(Optional.of(memberDetail));
 
         BlockPolicy policy = BlockPolicy.builder()
@@ -77,7 +76,7 @@ class FindSingleBlockPolicyServiceImplTest {
                 .familyId(FAMILY_ID)
                 .role(FamilyRole.OWNER)
                 .build();
-        given(memberRepository.findDetailByIdAndEmail(anyLong(), isNull()))
+        given(memberRepository.findDetailById(anyLong()))
                 .willReturn(Optional.of(memberDetail));
 
         BlockPolicy policy = BlockPolicy.builder()
@@ -104,7 +103,7 @@ class FindSingleBlockPolicyServiceImplTest {
                 .familyId(FAMILY_ID)
                 .role(FamilyRole.OWNER)
                 .build();
-        given(memberRepository.findDetailByIdAndEmail(anyLong(), isNull()))
+        given(memberRepository.findDetailById(anyLong()))
                 .willReturn(Optional.of(memberDetail));
 
         BlockPolicy policy = BlockPolicy.builder()

--- a/src/test/java/hotspot/user/policy/service/UpdateBlockPolicyServiceImplTest.java
+++ b/src/test/java/hotspot/user/policy/service/UpdateBlockPolicyServiceImplTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
@@ -71,7 +70,7 @@ class UpdateBlockPolicyServiceImplTest {
                 .role(FamilyRole.OWNER)
                 .build();
 
-        given(memberRepository.findDetailByIdAndEmail(anyLong(), isNull()))
+        given(memberRepository.findDetailById(anyLong()))
                 .willReturn(Optional.of(memberDetail));
 
         BlockPolicy existingPolicy = BlockPolicy.builder()
@@ -116,7 +115,7 @@ class UpdateBlockPolicyServiceImplTest {
                 .role(FamilyRole.OWNER)
                 .build();
 
-        given(memberRepository.findDetailByIdAndEmail(anyLong(), isNull()))
+        given(memberRepository.findDetailById(anyLong()))
                 .willReturn(Optional.of(memberDetail));
 
         BlockPolicy existingPolicy = BlockPolicy.builder()
@@ -152,7 +151,7 @@ class UpdateBlockPolicyServiceImplTest {
                 .role(FamilyRole.OWNER)
                 .build();
 
-        given(memberRepository.findDetailByIdAndEmail(anyLong(), isNull()))
+        given(memberRepository.findDetailById(anyLong()))
                 .willReturn(Optional.of(memberDetail));
 
         BlockPolicy adminPolicy = BlockPolicy.builder()
@@ -181,7 +180,7 @@ class UpdateBlockPolicyServiceImplTest {
                 .role(FamilyRole.OWNER)
                 .build();
 
-        given(memberRepository.findDetailByIdAndEmail(anyLong(), isNull()))
+        given(memberRepository.findDetailById(anyLong()))
                 .willReturn(Optional.of(memberDetail));
 
         BlockPolicy foreignPolicy = BlockPolicy.builder()
@@ -216,7 +215,7 @@ class UpdateBlockPolicyServiceImplTest {
                 .role(FamilyRole.OWNER)
                 .build();
 
-        given(memberRepository.findDetailByIdAndEmail(anyLong(), isNull()))
+        given(memberRepository.findDetailById(anyLong()))
                 .willReturn(Optional.of(memberDetail));
 
         BlockPolicy existingPolicy = BlockPolicy.builder()
@@ -247,7 +246,7 @@ class UpdateBlockPolicyServiceImplTest {
         BlockPolicyRequest request =
                 new BlockPolicyRequest("이름", PolicyType.ONCE, null, "설명", true);
 
-        given(memberRepository.findDetailByIdAndEmail(anyLong(), isNull()))
+        given(memberRepository.findDetailById(anyLong()))
                 .willReturn(Optional.empty());
 
         assertThatThrownBy(() ->
@@ -267,7 +266,7 @@ class UpdateBlockPolicyServiceImplTest {
                 .familyId(200L)
                 .build();
 
-        given(memberRepository.findDetailByIdAndEmail(anyLong(), isNull()))
+        given(memberRepository.findDetailById(anyLong()))
                 .willReturn(Optional.of(memberDetail));
 
         assertThatThrownBy(() ->
@@ -288,7 +287,7 @@ class UpdateBlockPolicyServiceImplTest {
                 .role(FamilyRole.PARENT)
                 .build();
 
-        given(memberRepository.findDetailByIdAndEmail(anyLong(), isNull()))
+        given(memberRepository.findDetailById(anyLong()))
                 .willReturn(Optional.of(memberDetail));
 
         assertThatThrownBy(() ->

--- a/src/test/java/hotspot/user/policy/service/UpdateFamilyBlockPolicyStatusServiceImplTest.java
+++ b/src/test/java/hotspot/user/policy/service/UpdateFamilyBlockPolicyStatusServiceImplTest.java
@@ -62,7 +62,7 @@ class UpdateFamilyBlockPolicyStatusServiceImplTest {
                 .familyId(FAMILY_ID)
                 .role(FamilyRole.OWNER)
                 .build();
-        given(memberRepository.findDetailByIdAndEmail(MEMBER_ID, null)).willReturn(Optional.of(memberDetail));
+        given(memberRepository.findDetailById(MEMBER_ID)).willReturn(Optional.of(memberDetail));
 
         // 3. 기존 가족 정책 Mock (1: 이미 활성, 2: 비활성, 3: 활성)
         BlockPolicy p1 = BlockPolicy.builder().id(1L).isActive(true).build();
@@ -96,7 +96,7 @@ class UpdateFamilyBlockPolicyStatusServiceImplTest {
                 .familyId(FAMILY_ID)
                 .role(FamilyRole.PARENT) // PARENT는 권한 없음
                 .build();
-        given(memberRepository.findDetailByIdAndEmail(MEMBER_ID, null)).willReturn(Optional.of(memberDetail));
+        given(memberRepository.findDetailById(MEMBER_ID)).willReturn(Optional.of(memberDetail));
 
         // when & then
         assertThatThrownBy(() -> service.updateFamilyBlockPolicyStatus(request, MEMBER_ID, FAMILY_ID))
@@ -114,7 +114,7 @@ class UpdateFamilyBlockPolicyStatusServiceImplTest {
                 .familyId(200L) // 다른 가족
                 .role(FamilyRole.OWNER)
                 .build();
-        given(memberRepository.findDetailByIdAndEmail(MEMBER_ID, null)).willReturn(Optional.of(memberDetail));
+        given(memberRepository.findDetailById(MEMBER_ID)).willReturn(Optional.of(memberDetail));
 
         // when & then
         assertThatThrownBy(() -> service.updateFamilyBlockPolicyStatus(request, MEMBER_ID, FAMILY_ID))
@@ -135,7 +135,7 @@ class UpdateFamilyBlockPolicyStatusServiceImplTest {
                 .familyId(FAMILY_ID)
                 .role(FamilyRole.OWNER)
                 .build();
-        given(memberRepository.findDetailByIdAndEmail(MEMBER_ID, null)).willReturn(Optional.of(memberDetail));
+        given(memberRepository.findDetailById(MEMBER_ID)).willReturn(Optional.of(memberDetail));
 
         // 우리 가족 정책은 1, 2번뿐
         BlockPolicy p1 = BlockPolicy.builder().id(1L).isActive(true).build();
@@ -160,7 +160,7 @@ class UpdateFamilyBlockPolicyStatusServiceImplTest {
                 .familyId(FAMILY_ID)
                 .role(FamilyRole.OWNER)
                 .build();
-        given(memberRepository.findDetailByIdAndEmail(MEMBER_ID, null)).willReturn(Optional.of(memberDetail));
+        given(memberRepository.findDetailById(MEMBER_ID)).willReturn(Optional.of(memberDetail));
 
         // 이미 1번은 켜져있고, 2번은 꺼져있음 -> 요청(1번만 켜기)과 동일함
         BlockPolicy p1 = BlockPolicy.builder().id(1L).isActive(true).build();


### PR DESCRIPTION
## 🎫 지라 티켓

<!-- 지라 티켓을 작성해주세요 ex) HOTSPOT-123 -->
HOTSPOT-262

---

## 🔗 GitHub 이슈
<!-- 자동 close를 원하면 아래 형식으로 작성
예) Closes #12
-->
#148 

---


## ✅ 작업 사항

<!-- 작업한 부분을 설명해주세요. -->
JPA 대신 JPQL 사용한 쿼리는 `@SQLDelete` 작동하지 않아서 생겼던 문제
- 명시적으로 `Where isDeleted = false` JPQL 쿼리에 추가

`findByIdAndEmail`, `findById` 로직 분리

---

## 📋 체크리스트

<!-- PR 제출 전 확인해주세요. 해당 항목에 [x]로 체크해주세요. -->

- [x] 코드가 정상적으로 빌드됩니다.
- [x] 관련 테스트 코드를 작성했습니다.
- [x] 기존 테스트가 모두 통과합니다.
- [x] 코드 스타일(Spotless, Checkstyle)을 준수합니다.
- [x] Jira 티켓 상태를 In Review / Done으로 변경했습니다.

---

## ⌨ 기타
