### PR TITLE
[HOTSPOT-263] 로그아웃, 회원 탈퇴 시 accessToken 삭제되지 않는 버그 수정

### DIFF
--- a/src/main/java/hotspot/user/auth/controller/AuthController.java
+++ b/src/main/java/hotspot/user/auth/controller/AuthController.java
@@ -107,7 +107,7 @@ public class AuthController implements AuthApi {
 
         TokenRequest request = new TokenRequest(refreshToken);
         logoutService.logout(principal.getId(), request); //  memberId 전달
-        
+
         ResponseCookie accessCookie = CookieUtil.deleteCookie("accessToken");
         ResponseCookie refreshCookie = CookieUtil.deleteCookie("refreshToken");
 
@@ -129,7 +129,7 @@ public class AuthController implements AuthApi {
 
         TokenRequest request = new TokenRequest(refreshToken);
         withdrawService.withdraw(principal.getId(), request); //  memberId 전달
-        
+
         ResponseCookie accessCookie = CookieUtil.deleteCookie("accessToken");
         ResponseCookie refreshCookie = CookieUtil.deleteCookie("refreshToken");
 

--- a/src/main/java/hotspot/user/auth/controller/AuthController.java
+++ b/src/main/java/hotspot/user/auth/controller/AuthController.java
@@ -107,10 +107,13 @@ public class AuthController implements AuthApi {
 
         TokenRequest request = new TokenRequest(refreshToken);
         logoutService.logout(principal.getId(), request); //  memberId 전달
-        ResponseCookie cookie = CookieUtil.deleteCookie("refreshToken");
+        
+        ResponseCookie accessCookie = CookieUtil.deleteCookie("accessToken");
+        ResponseCookie refreshCookie = CookieUtil.deleteCookie("refreshToken");
 
         return ResponseEntity.ok()
-                .header(HttpHeaders.SET_COOKIE, cookie.toString())
+                .header(HttpHeaders.SET_COOKIE, accessCookie.toString())
+                .header(HttpHeaders.SET_COOKIE, refreshCookie.toString())
                 .body(ApiResponse.success());
     }
 
@@ -126,10 +129,13 @@ public class AuthController implements AuthApi {
 
         TokenRequest request = new TokenRequest(refreshToken);
         withdrawService.withdraw(principal.getId(), request); //  memberId 전달
-        ResponseCookie cookie = CookieUtil.deleteCookie("refreshToken");
+        
+        ResponseCookie accessCookie = CookieUtil.deleteCookie("accessToken");
+        ResponseCookie refreshCookie = CookieUtil.deleteCookie("refreshToken");
 
         return ResponseEntity.ok()
-                .header(HttpHeaders.SET_COOKIE, cookie.toString())
+                .header(HttpHeaders.SET_COOKIE, accessCookie.toString())
+                .header(HttpHeaders.SET_COOKIE, refreshCookie.toString())
                 .body(ApiResponse.success());
     }
 

--- a/src/test/java/hotspot/user/auth/controller/AuthControllerTest.java
+++ b/src/test/java/hotspot/user/auth/controller/AuthControllerTest.java
@@ -178,16 +178,20 @@ class AuthControllerTest {
     }
 
     @Test
-    @DisplayName("로그아웃(logout) 성공 시 RefreshToken 쿠키를 삭제해야 한다")
+    @DisplayName("로그아웃(logout) 성공 시 AccessToken과 RefreshToken 쿠키를 모두 삭제해야 한다")
     void logoutSuccess() throws Exception {
         Cookie requestCookie = new Cookie("refreshToken", REFRESH_TOKEN);
         doNothing().when(logoutService).logout(anyLong(), any(TokenRequest.class));
 
-        mockMvc.perform(post("/api/v1/auth/logout")
+        MvcResult result = mockMvc.perform(post("/api/v1/auth/logout")
                         .cookie(requestCookie))
                 .andDo(print())
                 .andExpect(status().isOk())
-                .andExpect(header().string(HttpHeaders.SET_COOKIE, Matchers.containsString("Max-Age=0")));
+                .andReturn();
+
+        List<String> cookies = result.getResponse().getHeaders(HttpHeaders.SET_COOKIE);
+        assertThat(cookies).anyMatch(c -> c.contains("accessToken=") && c.contains("Max-Age=0"));
+        assertThat(cookies).anyMatch(c -> c.contains("refreshToken=") && c.contains("Max-Age=0"));
     }
 
     @Test
@@ -196,6 +200,23 @@ class AuthControllerTest {
         mockMvc.perform(post("/api/v1/auth/logout"))
                 .andDo(print())
                 .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("회원탈퇴(withdraw) 성공 시 AccessToken과 RefreshToken 쿠키를 모두 삭제해야 한다")
+    void withdrawSuccess() throws Exception {
+        Cookie requestCookie = new Cookie("refreshToken", REFRESH_TOKEN);
+        doNothing().when(withdrawService).withdraw(anyLong(), any(TokenRequest.class));
+
+        MvcResult result = mockMvc.perform(post("/api/v1/auth/withdraw")
+                        .cookie(requestCookie))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andReturn();
+
+        List<String> cookies = result.getResponse().getHeaders(HttpHeaders.SET_COOKIE);
+        assertThat(cookies).anyMatch(c -> c.contains("accessToken=") && c.contains("Max-Age=0"));
+        assertThat(cookies).anyMatch(c -> c.contains("refreshToken=") && c.contains("Max-Age=0"));
     }
 
     @Test

--- a/src/test/java/hotspot/user/auth/controller/AuthControllerTest.java
+++ b/src/test/java/hotspot/user/auth/controller/AuthControllerTest.java
@@ -9,7 +9,6 @@ import static org.mockito.Mockito.doNothing;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -17,7 +16,6 @@ import java.util.List;
 
 import jakarta.servlet.http.Cookie;
 
-import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
## 🎫 지라 티켓

<!-- 지라 티켓을 작성해주세요 ex) HOTSPOT-123 -->
HOTSPOT-263

---

## 🔗 GitHub 이슈
<!-- 자동 close를 원하면 아래 형식으로 작성
예) Closes #12
-->
Closes #153

---


## ✅ 작업 사항

<!-- 작업한 부분을 설명해주세요. -->
로그아웃, 회원 탈퇴 시 accessToken 삭제되지 않는 버그 해결
- `AuthController`
- `AuthControllerTest`


---

## 📋 체크리스트

<!-- PR 제출 전 확인해주세요. 해당 항목에 [x]로 체크해주세요. -->

- [x] 코드가 정상적으로 빌드됩니다.
- [x] 관련 테스트 코드를 작성했습니다.
- [x] 기존 테스트가 모두 통과합니다.
- [x] 코드 스타일(Spotless, Checkstyle)을 준수합니다.
- [x] Jira 티켓 상태를 In Review / Done으로 변경했습니다.

---

## ⌨ 기타
