### PR TITLE
[HOTSPOT-262] 다중 소셜 로그인 시 목록 조회 실패 버그 수정

### DIFF
--- a/src/main/java/hotspot/user/auth/service/GetMemberInfoServiceImpl.java
+++ b/src/main/java/hotspot/user/auth/service/GetMemberInfoServiceImpl.java
@@ -42,7 +42,7 @@ public class GetMemberInfoServiceImpl implements GetMemberInfoService {
                 .orElseThrow(() -> new ApplicationException(MemberErrorCode.MEMBER_NOT_FOUND));
 
         // 2. 소셜 계정 정보 조회 (이메일 확인용)
-        SocialAccount socialAccount = socialAccountRepository.findByMemberId(memberId)
+        SocialAccount socialAccount = socialAccountRepository.findByMemberIdAndEmail(memberId, email)
                 .orElseThrow(() -> new ApplicationException(MemberErrorCode.MEMBER_NOT_FOUND));
 
         // 3. 회선 정보 조회

--- a/src/main/java/hotspot/user/auth/service/OnboardingServiceImpl.java
+++ b/src/main/java/hotspot/user/auth/service/OnboardingServiceImpl.java
@@ -47,7 +47,7 @@ public class OnboardingServiceImpl implements OnboardingService {
         // 1. 데이터 조회 및 회선 검증
         Subscription subscription = validateAndGetSubscription(request.phoneNumber());
         Member pendingMember = findPendingMember(memberId);
-        SocialAccount socialAccount = findSocialAccount(pendingMember.getId());
+        SocialAccount socialAccount = findSocialAccount(pendingMember.getId(), email);
 
         // 2. 신규 승인 또는 기존 회원 통합 처리
         Member finalMember = handleMemberIntegration(subscription, pendingMember, socialAccount, request.birthDate());
@@ -87,8 +87,8 @@ public class OnboardingServiceImpl implements OnboardingService {
     }
 
     // 멤버와 연결된 소셜 계정 정보를 조회
-    private SocialAccount findSocialAccount(Long memberId) {
-        return socialAccountRepository.findByMemberId(memberId)
+    private SocialAccount findSocialAccount(Long memberId, String email) {
+        return socialAccountRepository.findByMemberIdAndEmail(memberId, email)
                 .orElseThrow(() -> new ApplicationException(MemberErrorCode.MEMBER_NOT_FOUND));
     }
 

--- a/src/main/java/hotspot/user/family/infrastructure/FamilyJpaRepository.java
+++ b/src/main/java/hotspot/user/family/infrastructure/FamilyJpaRepository.java
@@ -17,7 +17,7 @@ public interface FamilyJpaRepository extends JpaRepository<FamilyEntity, Long> {
     @Query("""
            SELECT DISTINCT new hotspot.user.family.infrastructure.entity.FamilyDetailInfoDto(
                f, m, (
-                   SELECT MAX(sa.email) FROM SocialAccountEntity sa 
+                   SELECT MAX(sa.email) FROM SocialAccountEntity sa
                    WHERE sa.member = m AND sa.isDeleted = false
                ), s.phoneEnc, s.subId, fs.familyRole
            )

--- a/src/main/java/hotspot/user/family/infrastructure/FamilyJpaRepository.java
+++ b/src/main/java/hotspot/user/family/infrastructure/FamilyJpaRepository.java
@@ -17,9 +17,9 @@ public interface FamilyJpaRepository extends JpaRepository<FamilyEntity, Long> {
         @Query("""
                SELECT DISTINCT new hotspot.user.family.infrastructure.entity.FamilyDetailInfoDto(
                    f, m, (
-                       SELECT sa.email FROM SocialAccountEntity sa 
+                       SELECT sa.email FROM SocialAccountEntity sa
                        WHERE sa.id = (
-                           SELECT MAX(sa2.id) FROM SocialAccountEntity sa2 
+                           SELECT MAX(sa2.id) FROM SocialAccountEntity sa2
                            WHERE sa2.member = m AND sa2.isDeleted = false
                        )
                    ), s.phoneEnc, s.subId, fs.familyRole

--- a/src/main/java/hotspot/user/family/infrastructure/FamilyJpaRepository.java
+++ b/src/main/java/hotspot/user/family/infrastructure/FamilyJpaRepository.java
@@ -16,7 +16,10 @@ public interface FamilyJpaRepository extends JpaRepository<FamilyEntity, Long> {
 
     @Query("""
            SELECT DISTINCT new hotspot.user.family.infrastructure.entity.FamilyDetailInfoDto(
-               f, m, (SELECT MAX(sa.email) FROM SocialAccountEntity sa WHERE sa.member = m AND sa.isDeleted = false), s.phoneEnc, s.subId, fs.familyRole
+               f, m, (
+                   SELECT MAX(sa.email) FROM SocialAccountEntity sa 
+                   WHERE sa.member = m AND sa.isDeleted = false
+               ), s.phoneEnc, s.subId, fs.familyRole
            )
            FROM FamilySubscriptionEntity fs
            JOIN fs.family f

--- a/src/main/java/hotspot/user/family/infrastructure/FamilyJpaRepository.java
+++ b/src/main/java/hotspot/user/family/infrastructure/FamilyJpaRepository.java
@@ -14,19 +14,21 @@ import hotspot.user.family.infrastructure.entity.FamilyEntity;
  */
 public interface FamilyJpaRepository extends JpaRepository<FamilyEntity, Long> {
 
-    @Query("""
-           SELECT DISTINCT new hotspot.user.family.infrastructure.entity.FamilyDetailInfoDto(
-               f, m, (
-                   SELECT MAX(sa.email) FROM SocialAccountEntity sa
-                   WHERE sa.member = m AND sa.isDeleted = false
-               ), s.phoneEnc, s.subId, fs.familyRole
-           )
-           FROM FamilySubscriptionEntity fs
-           JOIN fs.family f
-           JOIN fs.subscription s
-           JOIN s.member m
-           WHERE f.familyId = :familyId
-           """)
-    List<FamilyDetailInfoDto> findFamilyDetailQueryResult(
-            @Param("familyId") Long familyId);
+        @Query("""
+               SELECT DISTINCT new hotspot.user.family.infrastructure.entity.FamilyDetailInfoDto(
+                   f, m, (
+                       SELECT sa.email FROM SocialAccountEntity sa 
+                       WHERE sa.id = (
+                           SELECT MAX(sa2.id) FROM SocialAccountEntity sa2 
+                           WHERE sa2.member = m AND sa2.isDeleted = false
+                       )
+                   ), s.phoneEnc, s.subId, fs.familyRole
+               )
+               FROM FamilySubscriptionEntity fs
+               JOIN fs.family f
+               JOIN fs.subscription s
+               JOIN s.member m
+               WHERE f.familyId = :familyId
+               """)
+        List<FamilyDetailInfoDto> findFamilyDetailQueryResult(            @Param("familyId") Long familyId);
 }

--- a/src/main/java/hotspot/user/family/infrastructure/FamilyJpaRepository.java
+++ b/src/main/java/hotspot/user/family/infrastructure/FamilyJpaRepository.java
@@ -16,13 +16,12 @@ public interface FamilyJpaRepository extends JpaRepository<FamilyEntity, Long> {
 
     @Query("""
            SELECT DISTINCT new hotspot.user.family.infrastructure.entity.FamilyDetailInfoDto(
-               f, m, sa.email, s.phoneEnc, s.subId, fs.familyRole
+               f, m, (SELECT MAX(sa.email) FROM SocialAccountEntity sa WHERE sa.member = m AND sa.isDeleted = false), s.phoneEnc, s.subId, fs.familyRole
            )
-           FROM FamilyEntity f
-           LEFT JOIN FamilySubscriptionEntity fs ON fs.family = f
-           LEFT JOIN SubscriptionEntity s ON fs.subscription = s
-           LEFT JOIN MemberEntity m ON s.member = m
-           LEFT JOIN SocialAccountEntity sa ON sa.member = m
+           FROM FamilySubscriptionEntity fs
+           JOIN fs.family f
+           JOIN fs.subscription s
+           JOIN s.member m
            WHERE f.familyId = :familyId
            """)
     List<FamilyDetailInfoDto> findFamilyDetailQueryResult(

--- a/src/main/java/hotspot/user/member/infrastructure/SocialAccountJpaRepository.java
+++ b/src/main/java/hotspot/user/member/infrastructure/SocialAccountJpaRepository.java
@@ -19,6 +19,8 @@ public interface SocialAccountJpaRepository extends JpaRepository<SocialAccountE
 
     Optional<SocialAccountEntity> findByMemberId(Long memberId);
 
+    Optional<SocialAccountEntity> findByMemberIdAndEmail(Long memberId, String email);
+
     // Soft Delete
     @Modifying
     @Query("UPDATE SocialAccountEntity sa SET sa.isDeleted = true WHERE sa.member.id = :memberId")

--- a/src/main/java/hotspot/user/member/infrastructure/SocialAccountJpaRepository.java
+++ b/src/main/java/hotspot/user/member/infrastructure/SocialAccountJpaRepository.java
@@ -19,7 +19,10 @@ public interface SocialAccountJpaRepository extends JpaRepository<SocialAccountE
 
     Optional<SocialAccountEntity> findByMemberId(Long memberId);
 
-    Optional<SocialAccountEntity> findByMemberIdAndEmail(Long memberId, String email);
+    Optional<SocialAccountEntity> findFirstByMemberIdAndEmailAndIsDeletedFalseOrderByIdDesc(
+            @Param("memberId") Long memberId,
+            @Param("email") String email
+    );
 
     // Soft Delete
     @Modifying

--- a/src/main/java/hotspot/user/member/infrastructure/SocialAccountRepositoryImpl.java
+++ b/src/main/java/hotspot/user/member/infrastructure/SocialAccountRepositoryImpl.java
@@ -35,6 +35,12 @@ public class SocialAccountRepositoryImpl implements SocialAccountRepository {
     }
 
     @Override
+    public Optional<SocialAccount> findByMemberIdAndEmail(Long memberId, String email) {
+        return socialAccountJpaRepository.findByMemberIdAndEmail(memberId, email)
+                .map(SocialAccountEntity::entityToDomain);
+    }
+
+    @Override
     public Optional<SocialAccount> findByEmail(String email) {
         return socialAccountJpaRepository.findByEmail(email)
                 .map(SocialAccountEntity::entityToDomain);

--- a/src/main/java/hotspot/user/member/infrastructure/SocialAccountRepositoryImpl.java
+++ b/src/main/java/hotspot/user/member/infrastructure/SocialAccountRepositoryImpl.java
@@ -36,7 +36,7 @@ public class SocialAccountRepositoryImpl implements SocialAccountRepository {
 
     @Override
     public Optional<SocialAccount> findByMemberIdAndEmail(Long memberId, String email) {
-        return socialAccountJpaRepository.findByMemberIdAndEmail(memberId, email)
+        return socialAccountJpaRepository.findFirstByMemberIdAndEmailAndIsDeletedFalseOrderByIdDesc(memberId, email)
                 .map(SocialAccountEntity::entityToDomain);
     }
 

--- a/src/main/java/hotspot/user/member/service/port/SocialAccountRepository.java
+++ b/src/main/java/hotspot/user/member/service/port/SocialAccountRepository.java
@@ -8,6 +8,7 @@ public interface SocialAccountRepository {
     SocialAccount save(SocialAccount socialAccount);
     Optional<SocialAccount> findByMemberId(Long memberId);
     Optional<SocialAccount> findByEmail(String email);
+    Optional<SocialAccount> findByMemberIdAndEmail(Long memberId, String email);
     void delete(SocialAccount socialAccount);
     void deleteByMemberId(Long memberId);
 }

--- a/src/test/java/hotspot/user/auth/service/GetMemberInfoServiceImplTest.java
+++ b/src/test/java/hotspot/user/auth/service/GetMemberInfoServiceImplTest.java
@@ -64,7 +64,7 @@ class GetMemberInfoServiceImplTest {
                 .build();
 
         given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
-        given(socialAccountRepository.findByMemberId(memberId)).willReturn(Optional.of(socialAccount));
+        given(socialAccountRepository.findByMemberIdAndEmail(memberId, email)).willReturn(Optional.of(socialAccount));
         given(subscriptionRepository.findByMemberId(memberId)).willReturn(Optional.of(subscription));
         given(familySubscriptionRepository.findBySubId(100L)).willReturn(Optional.of(familySub));
         given(phoneDecryptor.decrypt("enc-phone")).willReturn(phoneNumber);
@@ -93,7 +93,7 @@ class GetMemberInfoServiceImplTest {
         Subscription subscription = Subscription.builder().id(100L).phoneEnc("enc-phone").build();
 
         given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
-        given(socialAccountRepository.findByMemberId(memberId)).willReturn(Optional.of(socialAccount));
+        given(socialAccountRepository.findByMemberIdAndEmail(memberId, email)).willReturn(Optional.of(socialAccount));
         given(subscriptionRepository.findByMemberId(memberId)).willReturn(Optional.of(subscription));
         given(familySubscriptionRepository.findBySubId(100L)).willReturn(Optional.empty());
         given(phoneDecryptor.decrypt("enc-phone")).willReturn(phoneNumber);
@@ -128,7 +128,8 @@ class GetMemberInfoServiceImplTest {
         SocialAccount socialAccount = SocialAccount.builder().memberId(memberId).build();
 
         given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
-        given(socialAccountRepository.findByMemberId(memberId)).willReturn(Optional.of(socialAccount));
+        given(socialAccountRepository.findByMemberIdAndEmail(memberId, "test@email.com"))
+                .willReturn(Optional.of(socialAccount));
         given(subscriptionRepository.findByMemberId(memberId)).willReturn(Optional.empty());
 
         // when & then

--- a/src/test/java/hotspot/user/auth/service/OnboardingServiceImplTest.java
+++ b/src/test/java/hotspot/user/auth/service/OnboardingServiceImplTest.java
@@ -81,7 +81,8 @@ class OnboardingServiceImplTest {
         given(phoneHashIndexer.toHash(phoneNumber)).willReturn(phoneHash);
         given(subscriptionRepository.findByPhoneHash(phoneHash)).willReturn(Optional.of(subscription));
         given(memberRepository.findById(memberId)).willReturn(Optional.of(pendingMember));
-        given(socialAccountRepository.findByMemberId(memberId)).willReturn(Optional.of(socialAccount));
+        given(socialAccountRepository.findByMemberIdAndEmail(memberId, email))
+                .willReturn(Optional.of(socialAccount));
         given(familySubscriptionRepository.findBySubId(100L)).willReturn(Optional.of(familySubscription));
         given(phoneDecryptor.decrypt("enc-phone")).willReturn(phoneNumber);
 
@@ -127,7 +128,8 @@ class OnboardingServiceImplTest {
         given(phoneHashIndexer.toHash(phoneNumber)).willReturn(phoneHash);
         given(subscriptionRepository.findByPhoneHash(phoneHash)).willReturn(Optional.of(subscription));
         given(memberRepository.findById(pendingMemberId)).willReturn(Optional.of(pendingMember));
-        given(socialAccountRepository.findByMemberId(pendingMemberId)).willReturn(Optional.of(socialAccount));
+        given(socialAccountRepository.findByMemberIdAndEmail(pendingMemberId, email))
+                .willReturn(Optional.of(socialAccount));
         given(familySubscriptionRepository.findBySubId(100L)).willReturn(Optional.of(familySubscription));
         given(phoneDecryptor.decrypt("enc-phone")).willReturn(phoneNumber);
 
@@ -181,7 +183,8 @@ class OnboardingServiceImplTest {
         given(phoneHashIndexer.toHash(phoneNumber)).willReturn(phoneHash);
         given(subscriptionRepository.findByPhoneHash(phoneHash)).willReturn(Optional.of(subscription));
         given(memberRepository.findById(memberId)).willReturn(Optional.of(pendingMember));
-        given(socialAccountRepository.findByMemberId(memberId)).willReturn(Optional.of(socialAccount));
+        given(socialAccountRepository.findByMemberIdAndEmail(memberId, email))
+                .willReturn(Optional.of(socialAccount));
         given(familySubscriptionRepository.findBySubId(100L)).willReturn(Optional.empty());
         given(phoneDecryptor.decrypt("enc-phone")).willReturn(phoneNumber);
 

--- a/src/test/java/hotspot/user/member/infrastructure/SocialAccountRepositoryImplTest.java
+++ b/src/test/java/hotspot/user/member/infrastructure/SocialAccountRepositoryImplTest.java
@@ -81,6 +81,32 @@ class SocialAccountRepositoryImplTest {
     }
 
     @Test
+    @DisplayName("memberId와 이메일로 소셜 계정 조회 성공")
+    void findByMemberIdAndEmailSuccess() {
+        // given
+        Long memberId = 1L;
+        String email = "test@test.com";
+        MemberEntity memberEntity = MemberEntity.builder().id(memberId).build();
+        SocialAccountEntity entity = SocialAccountEntity.builder()
+                .id(10L)
+                .member(memberEntity)
+                .email(email)
+                .socialId("social123")
+                .provider(Provider.GOOGLE)
+                .build();
+
+        given(socialAccountJpaRepository.findFirstByMemberIdAndEmailAndIsDeletedFalseOrderByIdDesc(memberId, email))
+                .willReturn(Optional.of(entity));
+
+        // when
+        Optional<SocialAccount> result = socialAccountRepository.findByMemberIdAndEmail(memberId, email);
+
+        // then
+        assertThat(result).isPresent();
+        assertThat(result.get().getEmail()).isEqualTo(email);
+    }
+
+    @Test
     @DisplayName("이메일로 소셜 계정 조회 성공")
     void findByEmailSuccess() {
         // given


### PR DESCRIPTION
## 🎫 지라 티켓

<!-- 지라 티켓을 작성해주세요 ex) HOTSPOT-123 -->
HOTSPOT-262

---

## 🔗 GitHub 이슈
<!-- 자동 close를 원하면 아래 형식으로 작성
예) Closes #12
-->
Closes #148 

---


## ✅ 작업 사항

<!-- 작업한 부분을 설명해주세요. -->

특정 사용자가 동일한 이메일로 여러 소셜 계정을 연동했을 때, 내 정보 조회(`/api/v1/auth/info`, `/api/v1/families/me`) 및 가족 구성원 조회 시 발생하는 `NonUniqueResultException` 에러 해결 및 조인 쿼리를 최적화

---

소셜 계정 조회 로직 개선 (에러 해결)
   * 중복 데이터 대응: SocialAccountJpaRepository에 findFirst...ByMemberIdAndEmail...OrderByIdDesc 도입.
       * 동일한 memberId와 email을 가진 계정이 여러 개 존재하더라도, SQL LIMIT 1 최적화를 통해 가장 최신 계정 하나만 조회하도록 보장해 `NonUniqueResultException` 차단
   * 조회 조건 강화: GetMemberInfoService 및 OnboardingService에서 회원 ID뿐만 아니라 현재 로그인한 이메일을 함께 조건으로 사용하여 정확한 계정 정보를 찾도록 수정


---

## 📋 체크리스트

<!-- PR 제출 전 확인해주세요. 해당 항목에 [x]로 체크해주세요. -->

- [x] 코드가 정상적으로 빌드됩니다.
- [x] 관련 테스트 코드를 작성했습니다.
- [x] 기존 테스트가 모두 통과합니다.
- [x] 코드 스타일(Spotless, Checkstyle)을 준수합니다.
- [x] Jira 티켓 상태를 In Review / Done으로 변경했습니다.

---

## ⌨ 기타
