### PR TITLE
[HOTSPOT-278] 로그아웃 / 회원 탈퇴 시 실제 로그아웃 안되는 문제 해결

### DIFF
--- a/src/main/java/hotspot/user/common/config/SecurityConfig.java
+++ b/src/main/java/hotspot/user/common/config/SecurityConfig.java
@@ -7,6 +7,7 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.annotation.web.configurers.FormLoginConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.access.expression.WebExpressionAuthorizationManager;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
@@ -14,6 +15,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 import hotspot.user.common.security.jwt.JwtAccessDeniedHandler;
 import hotspot.user.common.security.jwt.JwtAuthenticationEntryPoint;
 import hotspot.user.common.security.jwt.JwtFilter;
+import hotspot.user.common.security.oauth.CustomOAuth2AuthorizationRequestResolver;
 import hotspot.user.common.security.oauth.CustomOidcUserService;
 import hotspot.user.common.security.oauth.OAuth2FailureHandler;
 import hotspot.user.common.security.oauth.OAuth2SuccessHandler;
@@ -40,6 +42,7 @@ public class SecurityConfig {
     private final CorsConfig corsConfig;
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
     private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
+    private final ClientRegistrationRepository clientRegistrationRepository;
 
 
     @Bean
@@ -62,7 +65,13 @@ public class SecurityConfig {
         // UsernamePasswordAuthenticationFilter : 이 클래스에서 폼 로그인 인증을 처리
         http.addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);
 
+        // OAuth2 로그인 설정
         http.oauth2Login(oauth -> oauth
+                // 인증 요청 시 커스텀 파라미터(prompt=login 등)를 추가하기 위한 리졸버 등록
+                .authorizationEndpoint(authorization -> authorization
+                        .authorizationRequestResolver(new CustomOAuth2AuthorizationRequestResolver(
+                                clientRegistrationRepository)))
+                // 사용자 정보 조회 시 OIDC 서비스 사용
                 .userInfoEndpoint(userInfo -> userInfo.oidcUserService(customOidcUserService))
                 .successHandler(oAuth2SuccessHandler)
                 .failureHandler(oAuth2FailureHandler));

--- a/src/main/java/hotspot/user/common/config/SecurityConfig.java
+++ b/src/main/java/hotspot/user/common/config/SecurityConfig.java
@@ -46,6 +46,11 @@ public class SecurityConfig {
 
 
     @Bean
+    public CustomOAuth2AuthorizationRequestResolver customOAuth2AuthorizationRequestResolver() {
+        return new CustomOAuth2AuthorizationRequestResolver(clientRegistrationRepository);
+    }
+
+    @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 
         http
@@ -69,8 +74,7 @@ public class SecurityConfig {
         http.oauth2Login(oauth -> oauth
                 // 인증 요청 시 커스텀 파라미터(prompt=login 등)를 추가하기 위한 리졸버 등록
                 .authorizationEndpoint(authorization -> authorization
-                        .authorizationRequestResolver(new CustomOAuth2AuthorizationRequestResolver(
-                                clientRegistrationRepository)))
+                        .authorizationRequestResolver(customOAuth2AuthorizationRequestResolver()))
                 // 사용자 정보 조회 시 OIDC 서비스 사용
                 .userInfoEndpoint(userInfo -> userInfo.oidcUserService(customOidcUserService))
                 .successHandler(oAuth2SuccessHandler)

--- a/src/main/java/hotspot/user/common/security/oauth/CustomOAuth2AuthorizationRequestResolver.java
+++ b/src/main/java/hotspot/user/common/security/oauth/CustomOAuth2AuthorizationRequestResolver.java
@@ -13,7 +13,7 @@ import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequ
 /**
  * OAuth2 로그인 시 소셜 서비스의 세션을 무시하고 로그인 창을 강제하기 위한 리졸버
  * 로그아웃
- * 
+ *
  * [파라미터 설정]
  * - 구글: prompt=select_account (항상 계정 선택창 노출)
  * - 카카오: prompt=login (기존 세션이 있어도 다시 로그인 창 노출)
@@ -50,7 +50,7 @@ public class CustomOAuth2AuthorizationRequestResolver implements OAuth2Authoriza
 
         // 기존 파라미터를 복사하여 새로운 맵 생성
         Map<String, Object> additionalParameters = new LinkedHashMap<>(authorizationRequest.getAdditionalParameters());
-        
+
         // 현재 요청 중인 소셜 서비스 식별 (google, kakao 등)
         String registrationId = (String) authorizationRequest.getAttribute("registration_id");
 

--- a/src/main/java/hotspot/user/common/security/oauth/CustomOAuth2AuthorizationRequestResolver.java
+++ b/src/main/java/hotspot/user/common/security/oauth/CustomOAuth2AuthorizationRequestResolver.java
@@ -1,0 +1,69 @@
+package hotspot.user.common.security.oauth;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.client.web.DefaultOAuth2AuthorizationRequestResolver;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestResolver;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+
+/**
+ * OAuth2 로그인 시 소셜 서비스의 세션을 무시하고 로그인 창을 강제하기 위한 리졸버
+ * 로그아웃
+ * 
+ * [파라미터 설정]
+ * - 구글: prompt=select_account (항상 계정 선택창 노출)
+ * - 카카오: prompt=login (기존 세션이 있어도 다시 로그인 창 노출)
+ */
+public class CustomOAuth2AuthorizationRequestResolver implements OAuth2AuthorizationRequestResolver {
+
+    private final OAuth2AuthorizationRequestResolver defaultResolver;
+
+    public CustomOAuth2AuthorizationRequestResolver(ClientRegistrationRepository clientRegistrationRepository) {
+        // 기본 리졸버를 생성하여 위임 구조로 구성 (엔드포인트는 기본값인 /oauth2/authorization 사용)
+        this.defaultResolver = new DefaultOAuth2AuthorizationRequestResolver(
+                clientRegistrationRepository, "/oauth2/authorization");
+    }
+
+    @Override
+    public OAuth2AuthorizationRequest resolve(HttpServletRequest request) {
+        OAuth2AuthorizationRequest authorizationRequest = defaultResolver.resolve(request);
+        return customizeAuthorizationRequest(authorizationRequest);
+    }
+
+    @Override
+    public OAuth2AuthorizationRequest resolve(HttpServletRequest request, String clientRegistrationId) {
+        OAuth2AuthorizationRequest authorizationRequest = defaultResolver.resolve(request, clientRegistrationId);
+        return customizeAuthorizationRequest(authorizationRequest);
+    }
+
+    /**
+     * 기존 인증 요청에 소셜 서비스별 커스텀 파라미터를 추가함.
+     */
+    private OAuth2AuthorizationRequest customizeAuthorizationRequest(OAuth2AuthorizationRequest authorizationRequest) {
+        if (authorizationRequest == null) {
+            return null;
+        }
+
+        // 기존 파라미터를 복사하여 새로운 맵 생성
+        Map<String, Object> additionalParameters = new LinkedHashMap<>(authorizationRequest.getAdditionalParameters());
+        
+        // 현재 요청 중인 소셜 서비스 식별 (google, kakao 등)
+        String registrationId = (String) authorizationRequest.getAttribute("registration_id");
+
+        // 서비스별 prompt 파라미터 추가
+        if ("google".equals(registrationId)) {
+            additionalParameters.put("prompt", "select_account");
+        } else if ("kakao".equals(registrationId)) {
+            additionalParameters.put("prompt", "select_account");
+        }
+
+        // 변경된 파라미터를 포함하여 새로운 인증 요청 객체 빌드
+        return OAuth2AuthorizationRequest.from(authorizationRequest)
+                .additionalParameters(additionalParameters)
+                .build();
+    }
+}

--- a/src/main/java/hotspot/user/common/security/oauth/CustomOAuth2AuthorizationRequestResolver.java
+++ b/src/main/java/hotspot/user/common/security/oauth/CustomOAuth2AuthorizationRequestResolver.java
@@ -20,6 +20,13 @@ import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequ
  */
 public class CustomOAuth2AuthorizationRequestResolver implements OAuth2AuthorizationRequestResolver {
 
+    private static final String REGISTRATION_ID_GOOGLE = "google";
+    private static final String REGISTRATION_ID_KAKAO = "kakao";
+    private static final String PARAM_PROMPT = "prompt";
+    private static final String PROMPT_SELECT_ACCOUNT = "select_account";
+    private static final String PROMPT_LOGIN = "login";
+    private static final String REGISTRATION_ID_ATTR = "registration_id";
+
     private final OAuth2AuthorizationRequestResolver defaultResolver;
 
     public CustomOAuth2AuthorizationRequestResolver(ClientRegistrationRepository clientRegistrationRepository) {
@@ -52,13 +59,15 @@ public class CustomOAuth2AuthorizationRequestResolver implements OAuth2Authoriza
         Map<String, Object> additionalParameters = new LinkedHashMap<>(authorizationRequest.getAdditionalParameters());
 
         // 현재 요청 중인 소셜 서비스 식별 (google, kakao 등)
-        String registrationId = (String) authorizationRequest.getAttribute("registration_id");
+        String registrationId = (String) authorizationRequest.getAttribute(REGISTRATION_ID_ATTR);
 
         // 서비스별 prompt 파라미터 추가
-        if ("google".equals(registrationId)) {
-            additionalParameters.put("prompt", "select_account");
-        } else if ("kakao".equals(registrationId)) {
-            additionalParameters.put("prompt", "select_account");
+        switch (registrationId) {
+            case REGISTRATION_ID_GOOGLE -> additionalParameters.put(PARAM_PROMPT, PROMPT_SELECT_ACCOUNT);
+            case REGISTRATION_ID_KAKAO -> additionalParameters.put(PARAM_PROMPT, PROMPT_LOGIN);
+            default -> {
+                // 지원하지 않는 registrationId는 파라미터를 추가하지 않음
+            }
         }
 
         // 변경된 파라미터를 포함하여 새로운 인증 요청 객체 빌드


### PR DESCRIPTION
## 🎫 지라 티켓

<!-- 지라 티켓을 작성해주세요 ex) HOTSPOT-123 -->
HOTSPOT-278

---

## 🔗 GitHub 이슈
<!-- 자동 close를 원하면 아래 형식으로 작성
예) Closes #12
-->
Closes #158

---


## ✅ 작업 사항

<!-- 작업한 부분을 설명해주세요. -->

로그아웃 이후 로그인 버튼 누르면 이전 계정으로 로그인되지 않고 로그인 창이 뜨도록 코드 수정

---

`CustomOAuth2AuthorizationRequestResolver`
- 소셜 서비스 인증 요청 시 prompt 파라미터를 강제로 추가하도록 설정
  * Google: prompt=select_account 추가 (항상 계정 선택창 노출)
  * Kakao: prompt=login 추가 (기존 세션 무시하고 로그인 창 노출)

---

## 📋 체크리스트

<!-- PR 제출 전 확인해주세요. 해당 항목에 [x]로 체크해주세요. -->

- [x] 코드가 정상적으로 빌드됩니다.
- [x] 관련 테스트 코드를 작성했습니다.
- [x] 기존 테스트가 모두 통과합니다.
- [x] 코드 스타일(Spotless, Checkstyle)을 준수합니다.
- [x] Jira 티켓 상태를 In Review / Done으로 변경했습니다.

---

## ⌨ 기타
