### PR TITLE
[HOTSPOT-306] 데이터 선물할 때 무제한 요금제일 때 선물 불가능한 버그 수정

### DIFF
--- a/src/main/java/hotspot/user/presentData/service/SendPresentDataServiceImpl.java
+++ b/src/main/java/hotspot/user/presentData/service/SendPresentDataServiceImpl.java
@@ -105,10 +105,9 @@ public class SendPresentDataServiceImpl implements SendPresentDataService {
 
         DataPeriod period = giverSubscription.getPlan().getDataPeriod();
 
-        long dataAmount = giverSubscription.getPlan().getDataAmount();
-
-        // 무제한 용금제일 경우에는 무조건 선물 가능하도록 예외 처리 로직 추가
-        if(dataAmount <= -1) return;
+        Long dataAmount = giverSubscription.getPlan().getDataAmount();
+        // 무제한 요금제일 경우에는 무조건 선물 가능하도록 예외 처리 로직 추가
+        if (dataAmount != null && dataAmount == -1L) return;
 
         long remainingKb =
                 subscriptionUsageRepository.findRemainingPlanKb(giverSubscription.getId(), period);

--- a/src/main/java/hotspot/user/presentData/service/SendPresentDataServiceImpl.java
+++ b/src/main/java/hotspot/user/presentData/service/SendPresentDataServiceImpl.java
@@ -107,7 +107,9 @@ public class SendPresentDataServiceImpl implements SendPresentDataService {
 
         Long dataAmount = giverSubscription.getPlan().getDataAmount();
         // 무제한 요금제일 경우에는 무조건 선물 가능하도록 예외 처리 로직 추가
-        if (dataAmount != null && dataAmount == -1L) return;
+        if (dataAmount != null && dataAmount == -1L) {
+            return;
+        }
 
         long remainingKb =
                 subscriptionUsageRepository.findRemainingPlanKb(giverSubscription.getId(), period);

--- a/src/main/java/hotspot/user/presentData/service/SendPresentDataServiceImpl.java
+++ b/src/main/java/hotspot/user/presentData/service/SendPresentDataServiceImpl.java
@@ -105,6 +105,11 @@ public class SendPresentDataServiceImpl implements SendPresentDataService {
 
         DataPeriod period = giverSubscription.getPlan().getDataPeriod();
 
+        long dataAmount = giverSubscription.getPlan().getDataAmount();
+
+        // 무제한 용금제일 경우에는 무조건 선물 가능하도록 예외 처리 로직 추가
+        if(dataAmount <= -1) return;
+
         long remainingKb =
                 subscriptionUsageRepository.findRemainingPlanKb(giverSubscription.getId(), period);
 


### PR DESCRIPTION
## 🎫 지라 티켓

<!-- 지라 티켓을 작성해주세요 ex) HOTSPOT-123 -->
HOTSPOT-306

---

## 🔗 GitHub 이슈
<!-- 자동 close를 원하면 아래 형식으로 작성
예) Closes #12
-->
Closes #173

---


## ✅ 작업 사항

<!-- 작업한 부분을 설명해주세요. -->
`SendPresentDataServiceImpl`
- `validateEnoughPlanRemaining`
  - 무제한 데이터 (-1)일 때는 선물 가능하도록 예외 처리 로직 추가


---

## 📋 체크리스트

<!-- PR 제출 전 확인해주세요. 해당 항목에 [x]로 체크해주세요. -->

- [x] 코드가 정상적으로 빌드됩니다.
- [x] 관련 테스트 코드를 작성했습니다.
- [x] 기존 테스트가 모두 통과합니다.
- [x] 코드 스타일(Spotless, Checkstyle)을 준수합니다.
- [x] Jira 티켓 상태를 In Review / Done으로 변경했습니다.

---

## ⌨ 기타
