### PR TITLE
[HOTSPOT-318] 앱 차단 서비스 전체 목록 조회 시 비활성화 서비스도 조회하는 버그 수정

### DIFF
--- a/src/main/java/hotspot/user/policy/infrastructure/AppBlockedServiceJpaRepository.java
+++ b/src/main/java/hotspot/user/policy/infrastructure/AppBlockedServiceJpaRepository.java
@@ -20,6 +20,7 @@ public interface AppBlockedServiceJpaRepository extends JpaRepository<AppBlocked
         from AppBlockedServiceEntity a
         where a.appBlockedServiceId in :ids
           and a.isActive = true
+          and a.isDeleted = false
     """)
     List<AppBlockedServiceEntity> findByIdInAndIsActiveTrue(
             @Param("ids") List<Long> ids

--- a/src/main/java/hotspot/user/policy/infrastructure/AppBlockedServiceJpaRepository.java
+++ b/src/main/java/hotspot/user/policy/infrastructure/AppBlockedServiceJpaRepository.java
@@ -12,6 +12,8 @@ import hotspot.user.policy.infrastructure.entity.AppBlockedServiceEntity;
 public interface AppBlockedServiceJpaRepository extends JpaRepository<AppBlockedServiceEntity, Long> {
     long countByAppBlockedServiceIdIn(Set<Long> ids);
 
+    List<AppBlockedServiceEntity> findByIsActiveTrue();
+
     // 관리자가 생성한 앱 차단 서비스 중 활성화된 것만 가져오기
     @Query("""
         select a

--- a/src/main/java/hotspot/user/policy/infrastructure/AppBlockedServiceRepositoryImpl.java
+++ b/src/main/java/hotspot/user/policy/infrastructure/AppBlockedServiceRepositoryImpl.java
@@ -17,7 +17,7 @@ public class AppBlockedServiceRepositoryImpl implements AppBlockedServiceReposit
 
     @Override
     public List<AppBlockedService> findAll() {
-        return appBlockedServiceJpaRepository.findAll().stream()
+        return appBlockedServiceJpaRepository.findByIsActiveTrue().stream()
                 .map(AppBlockedServiceEntity::entityToDomain)
                 .toList();
     }

--- a/src/test/java/hotspot/user/policy/infrastructure/AppBlockedServiceRepositoryImplTest.java
+++ b/src/test/java/hotspot/user/policy/infrastructure/AppBlockedServiceRepositoryImplTest.java
@@ -44,7 +44,7 @@ class AppBlockedServiceRepositoryImplTest {
                 .blockedServiceCode("TIKTOK")
                 .build();
 
-        given(appBlockedServiceJpaRepository.findAll()).willReturn(List.of(entity1, entity2));
+        given(appBlockedServiceJpaRepository.findByIsActiveTrue()).willReturn(List.of(entity1, entity2));
 
         List<AppBlockedService> result = appBlockedServiceRepository.findAll();
 


### PR DESCRIPTION
## 🎫 지라 티켓

<!-- 지라 티켓을 작성해주세요 ex) HOTSPOT-123 -->
HOTSPOT-318

---

## 🔗 GitHub 이슈
<!-- 자동 close를 원하면 아래 형식으로 작성
예) Closes #12
-->
Closes #181

---


## ✅ 작업 사항

<!-- 작업한 부분을 설명해주세요. -->
관리자의 차단 앱 서비스 조회 시 `isActive = true`인것만 조회하도록 `jpaRepository.findAll() -> findByIsActiveTrue()`로 변경


---

## 📋 체크리스트

<!-- PR 제출 전 확인해주세요. 해당 항목에 [x]로 체크해주세요. -->

- [x] 코드가 정상적으로 빌드됩니다.
- [x] 관련 테스트 코드를 작성했습니다.
- [x] 기존 테스트가 모두 통과합니다.
- [x] 코드 스타일(Spotless, Checkstyle)을 준수합니다.
- [x] Jira 티켓 상태를 In Review / Done으로 변경했습니다.

---

## ⌨ 기타
