### PR TITLE
[HOTSPOT-350] 주간 사용량 분석 리포트 신청/조회/설정 api 구현

### DIFF
--- a/src/main/java/hotspot/user/common/exception/code/FamilyReportErrorCode.java
+++ b/src/main/java/hotspot/user/common/exception/code/FamilyReportErrorCode.java
@@ -1,0 +1,17 @@
+package hotspot.user.common.exception.code;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum FamilyReportErrorCode implements BaseErrorCode {
+    RECEIVE_DAY_REQUIRED(HttpStatus.BAD_REQUEST, "FAMILY_REPORT_001", "리포트 수신 요일은 필수입니다."),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String customCode;
+    private final String message;
+}

--- a/src/main/java/hotspot/user/common/exception/code/FamilyReportErrorCode.java
+++ b/src/main/java/hotspot/user/common/exception/code/FamilyReportErrorCode.java
@@ -9,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum FamilyReportErrorCode implements BaseErrorCode {
     RECEIVE_DAY_REQUIRED(HttpStatus.BAD_REQUEST, "FAMILY_REPORT_001", "리포트 수신 요일은 필수입니다."),
+    FAMILY_REPORT_SUBSCRIPTION_NOT_FOUND(HttpStatus.NOT_FOUND, "FAMILY_REPORT_002", "가족 AI 리포트 구독 정보를 찾을 수 없습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/hotspot/user/familyReport/controller/FamilyReportController.java
+++ b/src/main/java/hotspot/user/familyReport/controller/FamilyReportController.java
@@ -5,6 +5,7 @@ import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -14,7 +15,9 @@ import hotspot.user.common.ApiResponse;
 import hotspot.user.common.security.PrincipalDetails;
 import hotspot.user.familyReport.controller.port.CreateFamilyReportSubscriptionService;
 import hotspot.user.familyReport.controller.port.FindFamilyReportSubscriptionService;
+import hotspot.user.familyReport.controller.port.UpdateFamilyReportReceiveDayService;
 import hotspot.user.familyReport.controller.request.CreateFamilyReportSubscriptionRequest;
+import hotspot.user.familyReport.controller.request.UpdateFamilyReportReceiveDayRequest;
 import hotspot.user.familyReport.controller.response.FamilyReportSubscriptionResponse;
 import hotspot.user.familyReport.controller.swagger.FamilyReportApi;
 import lombok.RequiredArgsConstructor;
@@ -26,6 +29,7 @@ public class FamilyReportController implements FamilyReportApi {
 
     private final CreateFamilyReportSubscriptionService createFamilyReportSubscriptionService;
     private final FindFamilyReportSubscriptionService findFamilyReportSubscriptionService;
+    private final UpdateFamilyReportReceiveDayService updateFamilyReportReceiveDayService;
 
     @Override
     @GetMapping("/families")
@@ -45,6 +49,21 @@ public class FamilyReportController implements FamilyReportApi {
             @AuthenticationPrincipal PrincipalDetails principal) {
 
         createFamilyReportSubscriptionService.createSubscription(
+                principal.getFamilyId(),
+                principal.getRole(),
+                request
+        );
+
+        return ResponseEntity.ok(ApiResponse.success());
+    }
+
+    @Override
+    @PatchMapping("/families/receive-day")
+    public ResponseEntity<ApiResponse<Void>> updateFamilyReportReceiveDay(
+            @Valid @RequestBody UpdateFamilyReportReceiveDayRequest request,
+            @AuthenticationPrincipal PrincipalDetails principal) {
+
+        updateFamilyReportReceiveDayService.updateReceiveDay(
                 principal.getFamilyId(),
                 principal.getRole(),
                 request

--- a/src/main/java/hotspot/user/familyReport/controller/FamilyReportController.java
+++ b/src/main/java/hotspot/user/familyReport/controller/FamilyReportController.java
@@ -1,8 +1,8 @@
 package hotspot.user.familyReport.controller;
 
-import jakarta.validation.Valid;
-
 import java.util.List;
+
+import jakarta.validation.Valid;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;

--- a/src/main/java/hotspot/user/familyReport/controller/FamilyReportController.java
+++ b/src/main/java/hotspot/user/familyReport/controller/FamilyReportController.java
@@ -2,6 +2,8 @@ package hotspot.user.familyReport.controller;
 
 import jakarta.validation.Valid;
 
+import java.util.List;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -16,10 +18,12 @@ import hotspot.user.common.ApiResponse;
 import hotspot.user.common.security.PrincipalDetails;
 import hotspot.user.familyReport.controller.port.CancelFamilyReportSubscriptionService;
 import hotspot.user.familyReport.controller.port.CreateFamilyReportSubscriptionService;
+import hotspot.user.familyReport.controller.port.FindFamilyReportMembersService;
 import hotspot.user.familyReport.controller.port.FindFamilyReportSubscriptionService;
 import hotspot.user.familyReport.controller.port.UpdateFamilyReportReceiveDayService;
 import hotspot.user.familyReport.controller.request.CreateFamilyReportSubscriptionRequest;
 import hotspot.user.familyReport.controller.request.UpdateFamilyReportReceiveDayRequest;
+import hotspot.user.familyReport.controller.response.FamilyReportMemberResponse;
 import hotspot.user.familyReport.controller.response.FamilyReportSubscriptionResponse;
 import hotspot.user.familyReport.controller.swagger.FamilyReportApi;
 import lombok.RequiredArgsConstructor;
@@ -31,6 +35,7 @@ public class FamilyReportController implements FamilyReportApi {
 
     private final CancelFamilyReportSubscriptionService cancelFamilyReportSubscriptionService;
     private final CreateFamilyReportSubscriptionService createFamilyReportSubscriptionService;
+    private final FindFamilyReportMembersService findFamilyReportMembersService;
     private final FindFamilyReportSubscriptionService findFamilyReportSubscriptionService;
     private final UpdateFamilyReportReceiveDayService updateFamilyReportReceiveDayService;
 
@@ -41,6 +46,17 @@ public class FamilyReportController implements FamilyReportApi {
 
         FamilyReportSubscriptionResponse response =
                 findFamilyReportSubscriptionService.findSubscription(principal.getFamilyId());
+
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @Override
+    @GetMapping("/families/members")
+    public ResponseEntity<ApiResponse<List<FamilyReportMemberResponse>>> findFamilyReportMembers(
+            @AuthenticationPrincipal PrincipalDetails principal) {
+
+        List<FamilyReportMemberResponse> response =
+                findFamilyReportMembersService.findMembers(principal.getFamilyId());
 
         return ResponseEntity.ok(ApiResponse.success(response));
     }

--- a/src/main/java/hotspot/user/familyReport/controller/FamilyReportController.java
+++ b/src/main/java/hotspot/user/familyReport/controller/FamilyReportController.java
@@ -1,0 +1,33 @@
+package hotspot.user.familyReport.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import hotspot.user.common.ApiResponse;
+import hotspot.user.common.security.PrincipalDetails;
+import hotspot.user.familyReport.controller.port.FindFamilyReportSubscriptionService;
+import hotspot.user.familyReport.controller.response.FamilyReportSubscriptionResponse;
+import hotspot.user.familyReport.controller.swagger.FamilyReportApi;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/ai-reports")
+public class FamilyReportController implements FamilyReportApi {
+
+    private final FindFamilyReportSubscriptionService findFamilyReportSubscriptionService;
+
+    @Override
+    @GetMapping("/families")
+    public ResponseEntity<ApiResponse<FamilyReportSubscriptionResponse>> findFamilyReportSubscription(
+            @AuthenticationPrincipal PrincipalDetails principal) {
+
+        FamilyReportSubscriptionResponse response =
+                findFamilyReportSubscriptionService.findSubscription(principal.getFamilyId());
+
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+}

--- a/src/main/java/hotspot/user/familyReport/controller/FamilyReportController.java
+++ b/src/main/java/hotspot/user/familyReport/controller/FamilyReportController.java
@@ -4,6 +4,7 @@ import jakarta.validation.Valid;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -13,6 +14,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import hotspot.user.common.ApiResponse;
 import hotspot.user.common.security.PrincipalDetails;
+import hotspot.user.familyReport.controller.port.CancelFamilyReportSubscriptionService;
 import hotspot.user.familyReport.controller.port.CreateFamilyReportSubscriptionService;
 import hotspot.user.familyReport.controller.port.FindFamilyReportSubscriptionService;
 import hotspot.user.familyReport.controller.port.UpdateFamilyReportReceiveDayService;
@@ -27,6 +29,7 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("/api/v1/ai-reports")
 public class FamilyReportController implements FamilyReportApi {
 
+    private final CancelFamilyReportSubscriptionService cancelFamilyReportSubscriptionService;
     private final CreateFamilyReportSubscriptionService createFamilyReportSubscriptionService;
     private final FindFamilyReportSubscriptionService findFamilyReportSubscriptionService;
     private final UpdateFamilyReportReceiveDayService updateFamilyReportReceiveDayService;
@@ -67,6 +70,19 @@ public class FamilyReportController implements FamilyReportApi {
                 principal.getFamilyId(),
                 principal.getRole(),
                 request
+        );
+
+        return ResponseEntity.ok(ApiResponse.success());
+    }
+
+    @Override
+    @DeleteMapping("/families")
+    public ResponseEntity<ApiResponse<Void>> cancelFamilyReportSubscription(
+            @AuthenticationPrincipal PrincipalDetails principal) {
+
+        cancelFamilyReportSubscriptionService.cancelSubscription(
+                principal.getFamilyId(),
+                principal.getRole()
         );
 
         return ResponseEntity.ok(ApiResponse.success());

--- a/src/main/java/hotspot/user/familyReport/controller/FamilyReportController.java
+++ b/src/main/java/hotspot/user/familyReport/controller/FamilyReportController.java
@@ -1,14 +1,20 @@
 package hotspot.user.familyReport.controller;
 
+import jakarta.validation.Valid;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import hotspot.user.common.ApiResponse;
 import hotspot.user.common.security.PrincipalDetails;
+import hotspot.user.familyReport.controller.port.CreateFamilyReportSubscriptionService;
 import hotspot.user.familyReport.controller.port.FindFamilyReportSubscriptionService;
+import hotspot.user.familyReport.controller.request.CreateFamilyReportSubscriptionRequest;
 import hotspot.user.familyReport.controller.response.FamilyReportSubscriptionResponse;
 import hotspot.user.familyReport.controller.swagger.FamilyReportApi;
 import lombok.RequiredArgsConstructor;
@@ -18,6 +24,7 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("/api/v1/ai-reports")
 public class FamilyReportController implements FamilyReportApi {
 
+    private final CreateFamilyReportSubscriptionService createFamilyReportSubscriptionService;
     private final FindFamilyReportSubscriptionService findFamilyReportSubscriptionService;
 
     @Override
@@ -29,5 +36,20 @@ public class FamilyReportController implements FamilyReportApi {
                 findFamilyReportSubscriptionService.findSubscription(principal.getFamilyId());
 
         return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @Override
+    @PostMapping("/families")
+    public ResponseEntity<ApiResponse<Void>> createFamilyReportSubscription(
+            @Valid @RequestBody CreateFamilyReportSubscriptionRequest request,
+            @AuthenticationPrincipal PrincipalDetails principal) {
+
+        createFamilyReportSubscriptionService.createSubscription(
+                principal.getFamilyId(),
+                principal.getRole(),
+                request
+        );
+
+        return ResponseEntity.ok(ApiResponse.success());
     }
 }

--- a/src/main/java/hotspot/user/familyReport/controller/port/CancelFamilyReportSubscriptionService.java
+++ b/src/main/java/hotspot/user/familyReport/controller/port/CancelFamilyReportSubscriptionService.java
@@ -1,0 +1,8 @@
+package hotspot.user.familyReport.controller.port;
+
+import hotspot.user.member.domain.FamilyRole;
+
+public interface CancelFamilyReportSubscriptionService {
+
+    void cancelSubscription(Long familyId, FamilyRole requesterRole);
+}

--- a/src/main/java/hotspot/user/familyReport/controller/port/CreateFamilyReportSubscriptionService.java
+++ b/src/main/java/hotspot/user/familyReport/controller/port/CreateFamilyReportSubscriptionService.java
@@ -1,0 +1,13 @@
+package hotspot.user.familyReport.controller.port;
+
+import hotspot.user.familyReport.controller.request.CreateFamilyReportSubscriptionRequest;
+import hotspot.user.member.domain.FamilyRole;
+
+public interface CreateFamilyReportSubscriptionService {
+
+    void createSubscription(
+            Long familyId,
+            FamilyRole requesterRole,
+            CreateFamilyReportSubscriptionRequest request
+    );
+}

--- a/src/main/java/hotspot/user/familyReport/controller/port/FindFamilyReportMembersService.java
+++ b/src/main/java/hotspot/user/familyReport/controller/port/FindFamilyReportMembersService.java
@@ -1,0 +1,10 @@
+package hotspot.user.familyReport.controller.port;
+
+import java.util.List;
+
+import hotspot.user.familyReport.controller.response.FamilyReportMemberResponse;
+
+public interface FindFamilyReportMembersService {
+
+    List<FamilyReportMemberResponse> findMembers(Long familyId);
+}

--- a/src/main/java/hotspot/user/familyReport/controller/port/FindFamilyReportSubscriptionService.java
+++ b/src/main/java/hotspot/user/familyReport/controller/port/FindFamilyReportSubscriptionService.java
@@ -1,0 +1,8 @@
+package hotspot.user.familyReport.controller.port;
+
+import hotspot.user.familyReport.controller.response.FamilyReportSubscriptionResponse;
+
+public interface FindFamilyReportSubscriptionService {
+
+    FamilyReportSubscriptionResponse findSubscription(Long familyId);
+}

--- a/src/main/java/hotspot/user/familyReport/controller/port/UpdateFamilyReportReceiveDayService.java
+++ b/src/main/java/hotspot/user/familyReport/controller/port/UpdateFamilyReportReceiveDayService.java
@@ -1,0 +1,13 @@
+package hotspot.user.familyReport.controller.port;
+
+import hotspot.user.familyReport.controller.request.UpdateFamilyReportReceiveDayRequest;
+import hotspot.user.member.domain.FamilyRole;
+
+public interface UpdateFamilyReportReceiveDayService {
+
+    void updateReceiveDay(
+            Long familyId,
+            FamilyRole requesterRole,
+            UpdateFamilyReportReceiveDayRequest request
+    );
+}

--- a/src/main/java/hotspot/user/familyReport/controller/request/CreateFamilyReportSubscriptionRequest.java
+++ b/src/main/java/hotspot/user/familyReport/controller/request/CreateFamilyReportSubscriptionRequest.java
@@ -1,0 +1,11 @@
+package hotspot.user.familyReport.controller.request;
+
+import java.time.DayOfWeek;
+
+import jakarta.validation.constraints.NotNull;
+
+public record CreateFamilyReportSubscriptionRequest(
+        @NotNull(message = "리포트 수신 요일은 필수입니다.")
+        DayOfWeek receiveDay
+) {
+}

--- a/src/main/java/hotspot/user/familyReport/controller/request/UpdateFamilyReportReceiveDayRequest.java
+++ b/src/main/java/hotspot/user/familyReport/controller/request/UpdateFamilyReportReceiveDayRequest.java
@@ -1,0 +1,11 @@
+package hotspot.user.familyReport.controller.request;
+
+import java.time.DayOfWeek;
+
+import jakarta.validation.constraints.NotNull;
+
+public record UpdateFamilyReportReceiveDayRequest(
+        @NotNull(message = "리포트 수신 요일은 필수입니다.")
+        DayOfWeek receiveDay
+) {
+}

--- a/src/main/java/hotspot/user/familyReport/controller/response/FamilyReportMemberResponse.java
+++ b/src/main/java/hotspot/user/familyReport/controller/response/FamilyReportMemberResponse.java
@@ -1,0 +1,13 @@
+package hotspot.user.familyReport.controller.response;
+
+import hotspot.user.member.domain.FamilyRole;
+import lombok.Builder;
+
+@Builder
+public record FamilyReportMemberResponse(
+        Long subId,
+        String name,
+        FamilyRole familyRole,
+        Long reportId
+) {
+}

--- a/src/main/java/hotspot/user/familyReport/controller/response/FamilyReportSubscriptionResponse.java
+++ b/src/main/java/hotspot/user/familyReport/controller/response/FamilyReportSubscriptionResponse.java
@@ -1,0 +1,15 @@
+package hotspot.user.familyReport.controller.response;
+
+import lombok.Builder;
+
+@Builder
+public record FamilyReportSubscriptionResponse(
+        boolean subscribed
+) {
+
+    public static FamilyReportSubscriptionResponse unsubscribed() {
+        return FamilyReportSubscriptionResponse.builder()
+                .subscribed(false)
+                .build();
+    }
+}

--- a/src/main/java/hotspot/user/familyReport/controller/swagger/FamilyReportApi.java
+++ b/src/main/java/hotspot/user/familyReport/controller/swagger/FamilyReportApi.java
@@ -10,6 +10,7 @@ import hotspot.user.common.ApiResponse;
 import hotspot.user.common.exception.ErrorResponse;
 import hotspot.user.common.security.PrincipalDetails;
 import hotspot.user.familyReport.controller.request.CreateFamilyReportSubscriptionRequest;
+import hotspot.user.familyReport.controller.request.UpdateFamilyReportReceiveDayRequest;
 import hotspot.user.familyReport.controller.response.FamilyReportSubscriptionResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -42,5 +43,20 @@ public interface FamilyReportApi {
     })
     ResponseEntity<ApiResponse<Void>> createFamilyReportSubscription(
             @Valid @RequestBody CreateFamilyReportSubscriptionRequest request,
+            @Parameter(hidden = true) @AuthenticationPrincipal PrincipalDetails principal);
+
+    @Operation(summary = "가족 AI 리포트 수신 요일 변경",
+            description = "가족 OWNER가 현재 구독 중인 AI 주간 리포트의 수신 요일을 변경합니다.")
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "변경 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "권한 없음",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "구독 정보를 찾을 수 없음",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    ResponseEntity<ApiResponse<Void>> updateFamilyReportReceiveDay(
+            @Valid @RequestBody UpdateFamilyReportReceiveDayRequest request,
             @Parameter(hidden = true) @AuthenticationPrincipal PrincipalDetails principal);
 }

--- a/src/main/java/hotspot/user/familyReport/controller/swagger/FamilyReportApi.java
+++ b/src/main/java/hotspot/user/familyReport/controller/swagger/FamilyReportApi.java
@@ -1,13 +1,13 @@
 package hotspot.user.familyReport.controller.swagger;
 
-import jakarta.validation.Valid;
-
 import java.util.List;
+
+import jakarta.validation.Valid;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 
 import hotspot.user.common.ApiResponse;
 import hotspot.user.common.exception.ErrorResponse;

--- a/src/main/java/hotspot/user/familyReport/controller/swagger/FamilyReportApi.java
+++ b/src/main/java/hotspot/user/familyReport/controller/swagger/FamilyReportApi.java
@@ -1,0 +1,29 @@
+package hotspot.user.familyReport.controller.swagger;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+import hotspot.user.common.ApiResponse;
+import hotspot.user.common.exception.ErrorResponse;
+import hotspot.user.common.security.PrincipalDetails;
+import hotspot.user.familyReport.controller.response.FamilyReportSubscriptionResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "AI Report", description = "AI 주간 리포트 구독 API")
+public interface FamilyReportApi {
+
+    @Operation(summary = "가족 AI 리포트 구독 여부 조회",
+            description = "현재 로그인한 사용자가 속한 가족의 AI 주간 리포트 구독 여부와 수신 요일을 조회합니다.")
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 실패",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    ResponseEntity<ApiResponse<FamilyReportSubscriptionResponse>> findFamilyReportSubscription(
+            @Parameter(hidden = true) @AuthenticationPrincipal PrincipalDetails principal);
+}

--- a/src/main/java/hotspot/user/familyReport/controller/swagger/FamilyReportApi.java
+++ b/src/main/java/hotspot/user/familyReport/controller/swagger/FamilyReportApi.java
@@ -2,6 +2,8 @@ package hotspot.user.familyReport.controller.swagger;
 
 import jakarta.validation.Valid;
 
+import java.util.List;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -12,6 +14,7 @@ import hotspot.user.common.exception.ErrorResponse;
 import hotspot.user.common.security.PrincipalDetails;
 import hotspot.user.familyReport.controller.request.CreateFamilyReportSubscriptionRequest;
 import hotspot.user.familyReport.controller.request.UpdateFamilyReportReceiveDayRequest;
+import hotspot.user.familyReport.controller.response.FamilyReportMemberResponse;
 import hotspot.user.familyReport.controller.response.FamilyReportSubscriptionResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -31,6 +34,16 @@ public interface FamilyReportApi {
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     ResponseEntity<ApiResponse<FamilyReportSubscriptionResponse>> findFamilyReportSubscription(
+            @Parameter(hidden = true) @AuthenticationPrincipal PrincipalDetails principal);
+
+    @Operation(summary = "가족 AI 리포트 구성원 목록 조회",
+            description = "현재 로그인한 사용자가 속한 가족의 구성원 목록과 이번 주 리포트 식별자를 조회합니다.")
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 실패",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    ResponseEntity<ApiResponse<List<FamilyReportMemberResponse>>> findFamilyReportMembers(
             @Parameter(hidden = true) @AuthenticationPrincipal PrincipalDetails principal);
 
     @Operation(summary = "가족 AI 리포트 구독 신청",

--- a/src/main/java/hotspot/user/familyReport/controller/swagger/FamilyReportApi.java
+++ b/src/main/java/hotspot/user/familyReport/controller/swagger/FamilyReportApi.java
@@ -5,6 +5,7 @@ import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.DeleteMapping;
 
 import hotspot.user.common.ApiResponse;
 import hotspot.user.common.exception.ErrorResponse;
@@ -58,5 +59,18 @@ public interface FamilyReportApi {
     })
     ResponseEntity<ApiResponse<Void>> updateFamilyReportReceiveDay(
             @Valid @RequestBody UpdateFamilyReportReceiveDayRequest request,
+            @Parameter(hidden = true) @AuthenticationPrincipal PrincipalDetails principal);
+
+    @Operation(summary = "가족 AI 리포트 구독 취소",
+            description = "가족 OWNER가 현재 구독 중인 AI 주간 리포트를 취소합니다.")
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "취소 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "권한 없음",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "구독 정보를 찾을 수 없음",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @DeleteMapping("/families")
+    ResponseEntity<ApiResponse<Void>> cancelFamilyReportSubscription(
             @Parameter(hidden = true) @AuthenticationPrincipal PrincipalDetails principal);
 }

--- a/src/main/java/hotspot/user/familyReport/controller/swagger/FamilyReportApi.java
+++ b/src/main/java/hotspot/user/familyReport/controller/swagger/FamilyReportApi.java
@@ -1,11 +1,15 @@
 package hotspot.user.familyReport.controller.swagger;
 
+import jakarta.validation.Valid;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.RequestBody;
 
 import hotspot.user.common.ApiResponse;
 import hotspot.user.common.exception.ErrorResponse;
 import hotspot.user.common.security.PrincipalDetails;
+import hotspot.user.familyReport.controller.request.CreateFamilyReportSubscriptionRequest;
 import hotspot.user.familyReport.controller.response.FamilyReportSubscriptionResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -18,12 +22,25 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 public interface FamilyReportApi {
 
     @Operation(summary = "가족 AI 리포트 구독 여부 조회",
-            description = "현재 로그인한 사용자가 속한 가족의 AI 주간 리포트 구독 여부와 수신 요일을 조회합니다.")
+            description = "현재 로그인한 사용자가 속한 가족의 AI 주간 리포트 구독 여부를 조회합니다.")
     @ApiResponses(value = {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 실패",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     ResponseEntity<ApiResponse<FamilyReportSubscriptionResponse>> findFamilyReportSubscription(
+            @Parameter(hidden = true) @AuthenticationPrincipal PrincipalDetails principal);
+
+    @Operation(summary = "가족 AI 리포트 구독 신청",
+            description = "가족 OWNER가 AI 주간 리포트 구독을 신청하고 수신 요일을 설정합니다.")
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "신청 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "권한 없음",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    ResponseEntity<ApiResponse<Void>> createFamilyReportSubscription(
+            @Valid @RequestBody CreateFamilyReportSubscriptionRequest request,
             @Parameter(hidden = true) @AuthenticationPrincipal PrincipalDetails principal);
 }

--- a/src/main/java/hotspot/user/familyReport/domain/FamilyReport.java
+++ b/src/main/java/hotspot/user/familyReport/domain/FamilyReport.java
@@ -1,0 +1,34 @@
+package hotspot.user.familyReport.domain;
+
+import java.time.DayOfWeek;
+import java.time.LocalDateTime;
+
+import hotspot.user.family.domain.Family;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class FamilyReport {
+
+    private Long id;
+    private Family family;
+    private DayOfWeek receiveDay;
+    private boolean active;
+    private LocalDateTime createdTime;
+    private LocalDateTime modifiedTime;
+
+    public void updateReceiveDay(DayOfWeek receiveDay) {
+        this.receiveDay = receiveDay;
+    }
+
+    public void activate() {
+        this.active = true;
+    }
+
+    public void deactivate() {
+        this.active = false;
+    }
+}

--- a/src/main/java/hotspot/user/familyReport/domain/FamilyReport.java
+++ b/src/main/java/hotspot/user/familyReport/domain/FamilyReport.java
@@ -16,7 +16,7 @@ public class FamilyReport {
     private Long id;
     private Family family;
     private DayOfWeek receiveDay;
-    private boolean active;
+    private boolean isActive;
     private LocalDateTime createdTime;
     private LocalDateTime modifiedTime;
 
@@ -25,10 +25,10 @@ public class FamilyReport {
     }
 
     public void activate() {
-        this.active = true;
+        this.isActive = true;
     }
 
     public void deactivate() {
-        this.active = false;
+        this.isActive = false;
     }
 }

--- a/src/main/java/hotspot/user/familyReport/infrastructure/FamilyReportJpaRepository.java
+++ b/src/main/java/hotspot/user/familyReport/infrastructure/FamilyReportJpaRepository.java
@@ -1,0 +1,34 @@
+package hotspot.user.familyReport.infrastructure;
+
+import java.time.DayOfWeek;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import hotspot.user.familyReport.infrastructure.entity.FamilyReportEntity;
+
+public interface FamilyReportJpaRepository extends JpaRepository<FamilyReportEntity, Long> {
+
+    @EntityGraph(attributePaths = {"family"})
+    Optional<FamilyReportEntity> findByFamilyFamilyId(Long familyId);
+
+    @Modifying(clearAutomatically = true)
+    @Query("""
+            UPDATE FamilyReportEntity fr
+            SET fr.receiveDay = :receiveDay
+            WHERE fr.family.familyId = :familyId
+            """)
+    void updateReceiveDay(@Param("familyId") Long familyId, @Param("receiveDay") DayOfWeek receiveDay);
+
+    @Modifying(clearAutomatically = true)
+    @Query("""
+            UPDATE FamilyReportEntity fr
+            SET fr.isActive = :isActive
+            WHERE fr.family.familyId = :familyId
+            """)
+    void updateActive(@Param("familyId") Long familyId, @Param("isActive") boolean isActive);
+}

--- a/src/main/java/hotspot/user/familyReport/infrastructure/FamilyReportJpaRepository.java
+++ b/src/main/java/hotspot/user/familyReport/infrastructure/FamilyReportJpaRepository.java
@@ -21,14 +21,20 @@ public interface FamilyReportJpaRepository extends JpaRepository<FamilyReportEnt
             UPDATE FamilyReportEntity fr
             SET fr.receiveDay = :receiveDay
             WHERE fr.family.familyId = :familyId
+              AND fr.isActive = true
             """)
-    void updateReceiveDay(@Param("familyId") Long familyId, @Param("receiveDay") DayOfWeek receiveDay);
+    int updateReceiveDay(@Param("familyId") Long familyId, @Param("receiveDay") DayOfWeek receiveDay);
 
     @Modifying(clearAutomatically = true)
     @Query("""
             UPDATE FamilyReportEntity fr
-            SET fr.isActive = :isActive
+            SET fr.isActive = :newIsActive
             WHERE fr.family.familyId = :familyId
+              AND fr.isActive = :currentIsActive
             """)
-    void updateActive(@Param("familyId") Long familyId, @Param("isActive") boolean isActive);
+    int updateActive(
+            @Param("familyId") Long familyId,
+            @Param("currentIsActive") boolean currentIsActive,
+            @Param("newIsActive") boolean newIsActive
+    );
 }

--- a/src/main/java/hotspot/user/familyReport/infrastructure/FamilyReportRepositoryImpl.java
+++ b/src/main/java/hotspot/user/familyReport/infrastructure/FamilyReportRepositoryImpl.java
@@ -1,0 +1,40 @@
+package hotspot.user.familyReport.infrastructure;
+
+import java.time.DayOfWeek;
+import java.util.Optional;
+
+import org.springframework.stereotype.Repository;
+
+import hotspot.user.familyReport.domain.FamilyReport;
+import hotspot.user.familyReport.infrastructure.entity.FamilyReportEntity;
+import hotspot.user.familyReport.service.port.FamilyReportRepository;
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class FamilyReportRepositoryImpl implements FamilyReportRepository {
+
+    private final FamilyReportJpaRepository familyReportJpaRepository;
+
+    @Override
+    public Optional<FamilyReport> findByFamilyId(Long familyId) {
+        return familyReportJpaRepository.findByFamilyFamilyId(familyId)
+                .map(FamilyReportEntity::entityToDomain);
+    }
+
+    @Override
+    public FamilyReport save(FamilyReport familyReport) {
+        FamilyReportEntity entity = FamilyReportEntity.domainToEntity(familyReport);
+        return familyReportJpaRepository.save(entity).entityToDomain();
+    }
+
+    @Override
+    public void updateReceiveDay(Long familyId, DayOfWeek receiveDay) {
+        familyReportJpaRepository.updateReceiveDay(familyId, receiveDay);
+    }
+
+    @Override
+    public void updateActive(Long familyId, boolean isActive) {
+        familyReportJpaRepository.updateActive(familyId, isActive);
+    }
+}

--- a/src/main/java/hotspot/user/familyReport/infrastructure/FamilyReportRepositoryImpl.java
+++ b/src/main/java/hotspot/user/familyReport/infrastructure/FamilyReportRepositoryImpl.java
@@ -29,12 +29,12 @@ public class FamilyReportRepositoryImpl implements FamilyReportRepository {
     }
 
     @Override
-    public void updateReceiveDay(Long familyId, DayOfWeek receiveDay) {
-        familyReportJpaRepository.updateReceiveDay(familyId, receiveDay);
+    public int updateReceiveDay(Long familyId, DayOfWeek receiveDay) {
+        return familyReportJpaRepository.updateReceiveDay(familyId, receiveDay);
     }
 
     @Override
-    public void updateActive(Long familyId, boolean isActive) {
-        familyReportJpaRepository.updateActive(familyId, isActive);
+    public int updateActive(Long familyId, boolean currentIsActive, boolean newIsActive) {
+        return familyReportJpaRepository.updateActive(familyId, currentIsActive, newIsActive);
     }
 }

--- a/src/main/java/hotspot/user/familyReport/infrastructure/entity/FamilyReportEntity.java
+++ b/src/main/java/hotspot/user/familyReport/infrastructure/entity/FamilyReportEntity.java
@@ -1,0 +1,70 @@
+package hotspot.user.familyReport.infrastructure.entity;
+
+import java.time.DayOfWeek;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
+import hotspot.user.common.BaseEntity;
+import hotspot.user.family.infrastructure.entity.FamilyEntity;
+import hotspot.user.familyReport.domain.FamilyReport;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Table(name = "family_report")
+public class FamilyReportEntity extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long familyReportId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "family_id", nullable = false)
+    private FamilyEntity family;
+
+    @Column(nullable = false, length = 10)
+    @Enumerated(EnumType.STRING)
+    private DayOfWeek receiveDay;
+
+    @Column(name = "is_active", nullable = false)
+    private Boolean isActive;
+
+    public static FamilyReportEntity domainToEntity(FamilyReport familyReport) {
+        return FamilyReportEntity.builder()
+                .familyReportId(familyReport.getId())
+                .family(FamilyEntity.builder()
+                        .familyId(familyReport.getFamily().getId())
+                        .build())
+                .receiveDay(familyReport.getReceiveDay())
+                .isActive(familyReport.isActive())
+                .build();
+    }
+
+    public FamilyReport entityToDomain() {
+        return FamilyReport.builder()
+                .id(this.familyReportId)
+                .family(this.family.entityToDomain())
+                .receiveDay(this.receiveDay)
+                .active(Boolean.TRUE.equals(this.isActive))
+                .createdTime(getCreatedTime())
+                .modifiedTime(getModifiedTime())
+                .build();
+    }
+}

--- a/src/main/java/hotspot/user/familyReport/infrastructure/entity/FamilyReportEntity.java
+++ b/src/main/java/hotspot/user/familyReport/infrastructure/entity/FamilyReportEntity.java
@@ -62,7 +62,7 @@ public class FamilyReportEntity extends BaseEntity {
                 .id(this.familyReportId)
                 .family(this.family.entityToDomain())
                 .receiveDay(this.receiveDay)
-                .active(Boolean.TRUE.equals(this.isActive))
+                .isActive(Boolean.TRUE.equals(this.isActive))
                 .createdTime(getCreatedTime())
                 .modifiedTime(getModifiedTime())
                 .build();

--- a/src/main/java/hotspot/user/familyReport/service/CancelFamilyReportSubscriptionServiceImpl.java
+++ b/src/main/java/hotspot/user/familyReport/service/CancelFamilyReportSubscriptionServiceImpl.java
@@ -1,0 +1,35 @@
+package hotspot.user.familyReport.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import hotspot.user.common.exception.ApplicationException;
+import hotspot.user.common.exception.code.AuthErrorCode;
+import hotspot.user.common.exception.code.FamilyReportErrorCode;
+import hotspot.user.familyReport.controller.port.CancelFamilyReportSubscriptionService;
+import hotspot.user.familyReport.domain.FamilyReport;
+import hotspot.user.familyReport.service.port.FamilyReportRepository;
+import hotspot.user.member.domain.FamilyRole;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class CancelFamilyReportSubscriptionServiceImpl implements CancelFamilyReportSubscriptionService {
+
+    private final FamilyReportRepository familyReportRepository;
+
+    @Override
+    public void cancelSubscription(Long familyId, FamilyRole requesterRole) {
+        if (requesterRole != FamilyRole.OWNER) {
+            throw new ApplicationException(AuthErrorCode.ACCESS_DENIED);
+        }
+
+        FamilyReport familyReport = familyReportRepository.findByFamilyId(familyId)
+                .filter(FamilyReport::isActive)
+                .orElseThrow(() -> new ApplicationException(FamilyReportErrorCode.FAMILY_REPORT_SUBSCRIPTION_NOT_FOUND));
+
+        familyReport.deactivate();
+        familyReportRepository.save(familyReport);
+    }
+}

--- a/src/main/java/hotspot/user/familyReport/service/CancelFamilyReportSubscriptionServiceImpl.java
+++ b/src/main/java/hotspot/user/familyReport/service/CancelFamilyReportSubscriptionServiceImpl.java
@@ -7,7 +7,6 @@ import hotspot.user.common.exception.ApplicationException;
 import hotspot.user.common.exception.code.AuthErrorCode;
 import hotspot.user.common.exception.code.FamilyReportErrorCode;
 import hotspot.user.familyReport.controller.port.CancelFamilyReportSubscriptionService;
-import hotspot.user.familyReport.domain.FamilyReport;
 import hotspot.user.familyReport.service.port.FamilyReportRepository;
 import hotspot.user.member.domain.FamilyRole;
 import lombok.RequiredArgsConstructor;
@@ -25,12 +24,10 @@ public class CancelFamilyReportSubscriptionServiceImpl implements CancelFamilyRe
             throw new ApplicationException(AuthErrorCode.ACCESS_DENIED);
         }
 
-        FamilyReport familyReport = familyReportRepository.findByFamilyId(familyId)
-                .filter(FamilyReport::isActive)
-                .orElseThrow(() ->
-                        new ApplicationException(FamilyReportErrorCode.FAMILY_REPORT_SUBSCRIPTION_NOT_FOUND));
+        int updatedCount = familyReportRepository.updateActive(familyId, true, false);
 
-        familyReport.deactivate();
-        familyReportRepository.save(familyReport);
+        if (updatedCount == 0) {
+            throw new ApplicationException(FamilyReportErrorCode.FAMILY_REPORT_SUBSCRIPTION_NOT_FOUND);
+        }
     }
 }

--- a/src/main/java/hotspot/user/familyReport/service/CancelFamilyReportSubscriptionServiceImpl.java
+++ b/src/main/java/hotspot/user/familyReport/service/CancelFamilyReportSubscriptionServiceImpl.java
@@ -27,7 +27,8 @@ public class CancelFamilyReportSubscriptionServiceImpl implements CancelFamilyRe
 
         FamilyReport familyReport = familyReportRepository.findByFamilyId(familyId)
                 .filter(FamilyReport::isActive)
-                .orElseThrow(() -> new ApplicationException(FamilyReportErrorCode.FAMILY_REPORT_SUBSCRIPTION_NOT_FOUND));
+                .orElseThrow(() ->
+                        new ApplicationException(FamilyReportErrorCode.FAMILY_REPORT_SUBSCRIPTION_NOT_FOUND));
 
         familyReport.deactivate();
         familyReportRepository.save(familyReport);

--- a/src/main/java/hotspot/user/familyReport/service/CreateFamilyReportSubscriptionServiceImpl.java
+++ b/src/main/java/hotspot/user/familyReport/service/CreateFamilyReportSubscriptionServiceImpl.java
@@ -1,0 +1,47 @@
+package hotspot.user.familyReport.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import hotspot.user.common.exception.ApplicationException;
+import hotspot.user.common.exception.code.AuthErrorCode;
+import hotspot.user.family.domain.Family;
+import hotspot.user.familyReport.controller.port.CreateFamilyReportSubscriptionService;
+import hotspot.user.familyReport.controller.request.CreateFamilyReportSubscriptionRequest;
+import hotspot.user.familyReport.domain.FamilyReport;
+import hotspot.user.familyReport.service.port.FamilyReportRepository;
+import hotspot.user.member.domain.FamilyRole;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class CreateFamilyReportSubscriptionServiceImpl implements CreateFamilyReportSubscriptionService {
+
+    private final FamilyReportRepository familyReportRepository;
+
+    @Override
+    public void createSubscription(
+            Long familyId,
+            FamilyRole requesterRole,
+            CreateFamilyReportSubscriptionRequest request
+    ) {
+        if (requesterRole != FamilyRole.OWNER) {
+            throw new ApplicationException(AuthErrorCode.ACCESS_DENIED);
+        }
+
+        FamilyReport familyReport = familyReportRepository.findByFamilyId(familyId)
+                .map(existing -> {
+                    existing.updateReceiveDay(request.receiveDay());
+                    existing.activate();
+                    return existing;
+                })
+                .orElseGet(() -> FamilyReport.builder()
+                        .family(Family.builder().id(familyId).build())
+                        .receiveDay(request.receiveDay())
+                        .active(true)
+                        .build());
+
+        familyReportRepository.save(familyReport);
+    }
+}

--- a/src/main/java/hotspot/user/familyReport/service/CreateFamilyReportSubscriptionServiceImpl.java
+++ b/src/main/java/hotspot/user/familyReport/service/CreateFamilyReportSubscriptionServiceImpl.java
@@ -39,7 +39,7 @@ public class CreateFamilyReportSubscriptionServiceImpl implements CreateFamilyRe
                 .orElseGet(() -> FamilyReport.builder()
                         .family(Family.builder().id(familyId).build())
                         .receiveDay(request.receiveDay())
-                        .active(true)
+                        .isActive(true)
                         .build());
 
         familyReportRepository.save(familyReport);

--- a/src/main/java/hotspot/user/familyReport/service/FindFamilyReportMembersServiceImpl.java
+++ b/src/main/java/hotspot/user/familyReport/service/FindFamilyReportMembersServiceImpl.java
@@ -1,0 +1,56 @@
+package hotspot.user.familyReport.service;
+
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import hotspot.user.family.service.port.FamilySubscriptionRepository;
+import hotspot.user.familyReport.controller.port.FindFamilyReportMembersService;
+import hotspot.user.familyReport.controller.response.FamilyReportMemberResponse;
+import hotspot.user.member.domain.FamilyRole;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class FindFamilyReportMembersServiceImpl implements FindFamilyReportMembersService {
+
+    private static final Map<FamilyRole, Integer> FAMILY_ROLE_ORDER = Map.of(
+            FamilyRole.OWNER, 0,
+            FamilyRole.PARENT, 1,
+            FamilyRole.CHILD, 2
+    );
+
+    private final FamilySubscriptionRepository familySubscriptionRepository;
+
+    @Override
+    public List<FamilyReportMemberResponse> findMembers(Long familyId) {
+        return familySubscriptionRepository.findByFamilyId(familyId)
+                .stream()
+                .sorted((left, right) -> {
+                    int roleCompare = Integer.compare(
+                            FAMILY_ROLE_ORDER.getOrDefault(left.getFamilyRole(), Integer.MAX_VALUE),
+                            FAMILY_ROLE_ORDER.getOrDefault(right.getFamilyRole(), Integer.MAX_VALUE)
+                    );
+
+                    if (roleCompare != 0) {
+                        return roleCompare;
+                    }
+
+                    return Long.compare(
+                            left.getSubscription().getId(),
+                            right.getSubscription().getId()
+                    );
+                })
+                .map(familySubscription -> FamilyReportMemberResponse.builder()
+                        .subId(familySubscription.getSubscription().getId())
+                        .name(familySubscription.getSubscription().getMember().getName())
+                        .familyRole(familySubscription.getFamilyRole())
+                        // TODO: batch DB weekly_report 연동 후 이번 주 reportId 세팅
+                        .reportId(null)
+                        .build())
+                .toList();
+    }
+}

--- a/src/main/java/hotspot/user/familyReport/service/FindFamilyReportMembersServiceImpl.java
+++ b/src/main/java/hotspot/user/familyReport/service/FindFamilyReportMembersServiceImpl.java
@@ -48,7 +48,7 @@ public class FindFamilyReportMembersServiceImpl implements FindFamilyReportMembe
                         .subId(familySubscription.getSubscription().getId())
                         .name(familySubscription.getSubscription().getMember().getName())
                         .familyRole(familySubscription.getFamilyRole())
-                        // TODO: batch DB weekly_report 연동 후 이번 주 reportId 세팅
+                        // batch DB weekly_report 연동 후 이번 주 reportId 세팅 예정
                         .reportId(null)
                         .build())
                 .toList();

--- a/src/main/java/hotspot/user/familyReport/service/FindFamilyReportMembersServiceImpl.java
+++ b/src/main/java/hotspot/user/familyReport/service/FindFamilyReportMembersServiceImpl.java
@@ -1,5 +1,6 @@
 package hotspot.user.familyReport.service;
 
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 
@@ -29,21 +30,13 @@ public class FindFamilyReportMembersServiceImpl implements FindFamilyReportMembe
     public List<FamilyReportMemberResponse> findMembers(Long familyId) {
         return familySubscriptionRepository.findByFamilyId(familyId)
                 .stream()
-                .sorted((left, right) -> {
-                    int roleCompare = Integer.compare(
-                            FAMILY_ROLE_ORDER.getOrDefault(left.getFamilyRole(), Integer.MAX_VALUE),
-                            FAMILY_ROLE_ORDER.getOrDefault(right.getFamilyRole(), Integer.MAX_VALUE)
-                    );
-
-                    if (roleCompare != 0) {
-                        return roleCompare;
-                    }
-
-                    return Long.compare(
-                            left.getSubscription().getId(),
-                            right.getSubscription().getId()
-                    );
-                })
+                .sorted(Comparator
+                        .comparing((hotspot.user.family.domain.FamilySubscription familySubscription) ->
+                                FAMILY_ROLE_ORDER.getOrDefault(
+                                        familySubscription.getFamilyRole(),
+                                        Integer.MAX_VALUE
+                                ))
+                        .thenComparing(familySubscription -> familySubscription.getSubscription().getId()))
                 .map(familySubscription -> FamilyReportMemberResponse.builder()
                         .subId(familySubscription.getSubscription().getId())
                         .name(familySubscription.getSubscription().getMember().getName())

--- a/src/main/java/hotspot/user/familyReport/service/FindFamilyReportSubscriptionServiceImpl.java
+++ b/src/main/java/hotspot/user/familyReport/service/FindFamilyReportSubscriptionServiceImpl.java
@@ -1,0 +1,27 @@
+package hotspot.user.familyReport.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import hotspot.user.familyReport.controller.port.FindFamilyReportSubscriptionService;
+import hotspot.user.familyReport.controller.response.FamilyReportSubscriptionResponse;
+import hotspot.user.familyReport.service.port.FamilyReportRepository;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class FindFamilyReportSubscriptionServiceImpl implements FindFamilyReportSubscriptionService {
+
+    private final FamilyReportRepository familyReportRepository;
+
+    @Override
+    public FamilyReportSubscriptionResponse findSubscription(Long familyId) {
+        return familyReportRepository.findByFamilyId(familyId)
+                .filter(familyReport -> familyReport.isActive())
+                .map(familyReport -> FamilyReportSubscriptionResponse.builder()
+                        .subscribed(true)
+                        .build())
+                .orElseGet(FamilyReportSubscriptionResponse::unsubscribed);
+    }
+}

--- a/src/main/java/hotspot/user/familyReport/service/UpdateFamilyReportReceiveDayServiceImpl.java
+++ b/src/main/java/hotspot/user/familyReport/service/UpdateFamilyReportReceiveDayServiceImpl.java
@@ -8,7 +8,6 @@ import hotspot.user.common.exception.code.AuthErrorCode;
 import hotspot.user.common.exception.code.FamilyReportErrorCode;
 import hotspot.user.familyReport.controller.port.UpdateFamilyReportReceiveDayService;
 import hotspot.user.familyReport.controller.request.UpdateFamilyReportReceiveDayRequest;
-import hotspot.user.familyReport.domain.FamilyReport;
 import hotspot.user.familyReport.service.port.FamilyReportRepository;
 import hotspot.user.member.domain.FamilyRole;
 import lombok.RequiredArgsConstructor;
@@ -30,12 +29,10 @@ public class UpdateFamilyReportReceiveDayServiceImpl implements UpdateFamilyRepo
             throw new ApplicationException(AuthErrorCode.ACCESS_DENIED);
         }
 
-        FamilyReport familyReport = familyReportRepository.findByFamilyId(familyId)
-                .filter(FamilyReport::isActive)
-                .orElseThrow(() ->
-                        new ApplicationException(FamilyReportErrorCode.FAMILY_REPORT_SUBSCRIPTION_NOT_FOUND));
+        int updatedCount = familyReportRepository.updateReceiveDay(familyId, request.receiveDay());
 
-        familyReport.updateReceiveDay(request.receiveDay());
-        familyReportRepository.save(familyReport);
+        if (updatedCount == 0) {
+            throw new ApplicationException(FamilyReportErrorCode.FAMILY_REPORT_SUBSCRIPTION_NOT_FOUND);
+        }
     }
 }

--- a/src/main/java/hotspot/user/familyReport/service/UpdateFamilyReportReceiveDayServiceImpl.java
+++ b/src/main/java/hotspot/user/familyReport/service/UpdateFamilyReportReceiveDayServiceImpl.java
@@ -32,7 +32,8 @@ public class UpdateFamilyReportReceiveDayServiceImpl implements UpdateFamilyRepo
 
         FamilyReport familyReport = familyReportRepository.findByFamilyId(familyId)
                 .filter(FamilyReport::isActive)
-                .orElseThrow(() -> new ApplicationException(FamilyReportErrorCode.FAMILY_REPORT_SUBSCRIPTION_NOT_FOUND));
+                .orElseThrow(() ->
+                        new ApplicationException(FamilyReportErrorCode.FAMILY_REPORT_SUBSCRIPTION_NOT_FOUND));
 
         familyReport.updateReceiveDay(request.receiveDay());
         familyReportRepository.save(familyReport);

--- a/src/main/java/hotspot/user/familyReport/service/UpdateFamilyReportReceiveDayServiceImpl.java
+++ b/src/main/java/hotspot/user/familyReport/service/UpdateFamilyReportReceiveDayServiceImpl.java
@@ -1,0 +1,40 @@
+package hotspot.user.familyReport.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import hotspot.user.common.exception.ApplicationException;
+import hotspot.user.common.exception.code.AuthErrorCode;
+import hotspot.user.common.exception.code.FamilyReportErrorCode;
+import hotspot.user.familyReport.controller.port.UpdateFamilyReportReceiveDayService;
+import hotspot.user.familyReport.controller.request.UpdateFamilyReportReceiveDayRequest;
+import hotspot.user.familyReport.domain.FamilyReport;
+import hotspot.user.familyReport.service.port.FamilyReportRepository;
+import hotspot.user.member.domain.FamilyRole;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class UpdateFamilyReportReceiveDayServiceImpl implements UpdateFamilyReportReceiveDayService {
+
+    private final FamilyReportRepository familyReportRepository;
+
+    @Override
+    public void updateReceiveDay(
+            Long familyId,
+            FamilyRole requesterRole,
+            UpdateFamilyReportReceiveDayRequest request
+    ) {
+        if (requesterRole != FamilyRole.OWNER) {
+            throw new ApplicationException(AuthErrorCode.ACCESS_DENIED);
+        }
+
+        FamilyReport familyReport = familyReportRepository.findByFamilyId(familyId)
+                .filter(FamilyReport::isActive)
+                .orElseThrow(() -> new ApplicationException(FamilyReportErrorCode.FAMILY_REPORT_SUBSCRIPTION_NOT_FOUND));
+
+        familyReport.updateReceiveDay(request.receiveDay());
+        familyReportRepository.save(familyReport);
+    }
+}

--- a/src/main/java/hotspot/user/familyReport/service/port/FamilyReportRepository.java
+++ b/src/main/java/hotspot/user/familyReport/service/port/FamilyReportRepository.java
@@ -1,0 +1,17 @@
+package hotspot.user.familyReport.service.port;
+
+import java.time.DayOfWeek;
+import java.util.Optional;
+
+import hotspot.user.familyReport.domain.FamilyReport;
+
+public interface FamilyReportRepository {
+
+    Optional<FamilyReport> findByFamilyId(Long familyId);
+
+    FamilyReport save(FamilyReport familyReport);
+
+    void updateReceiveDay(Long familyId, DayOfWeek receiveDay);
+
+    void updateActive(Long familyId, boolean isActive);
+}

--- a/src/main/java/hotspot/user/familyReport/service/port/FamilyReportRepository.java
+++ b/src/main/java/hotspot/user/familyReport/service/port/FamilyReportRepository.java
@@ -11,7 +11,7 @@ public interface FamilyReportRepository {
 
     FamilyReport save(FamilyReport familyReport);
 
-    void updateReceiveDay(Long familyId, DayOfWeek receiveDay);
+    int updateReceiveDay(Long familyId, DayOfWeek receiveDay);
 
-    void updateActive(Long familyId, boolean isActive);
+    int updateActive(Long familyId, boolean currentIsActive, boolean newIsActive);
 }

--- a/src/test/java/hotspot/user/familyReport/controller/FamilyReportControllerTest.java
+++ b/src/test/java/hotspot/user/familyReport/controller/FamilyReportControllerTest.java
@@ -5,13 +5,11 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -21,6 +19,8 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import hotspot.user.common.security.jwt.JwtFilter;
 import hotspot.user.common.security.jwt.JwtProvider;

--- a/src/test/java/hotspot/user/familyReport/controller/FamilyReportControllerTest.java
+++ b/src/test/java/hotspot/user/familyReport/controller/FamilyReportControllerTest.java
@@ -1,10 +1,15 @@
 package hotspot.user.familyReport.controller;
 
 import static hotspot.user.util.TestSecurityUtil.setAuthentication;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -17,7 +22,9 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import hotspot.user.common.security.jwt.JwtFilter;
 import hotspot.user.common.security.jwt.JwtProvider;
+import hotspot.user.familyReport.controller.port.CreateFamilyReportSubscriptionService;
 import hotspot.user.familyReport.controller.port.FindFamilyReportSubscriptionService;
+import hotspot.user.familyReport.controller.request.CreateFamilyReportSubscriptionRequest;
 import hotspot.user.familyReport.controller.response.FamilyReportSubscriptionResponse;
 import hotspot.user.member.domain.FamilyRole;
 
@@ -27,6 +34,12 @@ class FamilyReportControllerTest {
 
     @Autowired
     private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private CreateFamilyReportSubscriptionService createFamilyReportSubscriptionService;
 
     @MockBean
     private FindFamilyReportSubscriptionService findFamilyReportSubscriptionService;
@@ -67,5 +80,24 @@ class FamilyReportControllerTest {
         mockMvc.perform(get("/api/v1/ai-reports/families"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.subscribed").value(false));
+    }
+
+    @Test
+    @DisplayName("가족 AI 리포트 구독 신청 성공")
+    void createFamilyReportSubscriptionSuccess() throws Exception {
+        setAuthentication(1L, 100L, FamilyRole.OWNER);
+
+        CreateFamilyReportSubscriptionRequest request =
+                new CreateFamilyReportSubscriptionRequest(java.time.DayOfWeek.TUESDAY);
+
+        doNothing().when(createFamilyReportSubscriptionService)
+                .createSubscription(100L, FamilyRole.OWNER, any(CreateFamilyReportSubscriptionRequest.class));
+
+        mockMvc.perform(post("/api/v1/ai-reports/families")
+                        .contentType(org.springframework.http.MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("200"))
+                .andExpect(jsonPath("$.data").doesNotExist());
     }
 }

--- a/src/test/java/hotspot/user/familyReport/controller/FamilyReportControllerTest.java
+++ b/src/test/java/hotspot/user/familyReport/controller/FamilyReportControllerTest.java
@@ -4,6 +4,7 @@ import static hotspot.user.util.TestSecurityUtil.setAuthentication;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -24,7 +25,9 @@ import hotspot.user.common.security.jwt.JwtFilter;
 import hotspot.user.common.security.jwt.JwtProvider;
 import hotspot.user.familyReport.controller.port.CreateFamilyReportSubscriptionService;
 import hotspot.user.familyReport.controller.port.FindFamilyReportSubscriptionService;
+import hotspot.user.familyReport.controller.port.UpdateFamilyReportReceiveDayService;
 import hotspot.user.familyReport.controller.request.CreateFamilyReportSubscriptionRequest;
+import hotspot.user.familyReport.controller.request.UpdateFamilyReportReceiveDayRequest;
 import hotspot.user.familyReport.controller.response.FamilyReportSubscriptionResponse;
 import hotspot.user.member.domain.FamilyRole;
 
@@ -43,6 +46,9 @@ class FamilyReportControllerTest {
 
     @MockBean
     private FindFamilyReportSubscriptionService findFamilyReportSubscriptionService;
+
+    @MockBean
+    private UpdateFamilyReportReceiveDayService updateFamilyReportReceiveDayService;
 
     @MockBean
     private JwtFilter jwtFilter;
@@ -94,6 +100,25 @@ class FamilyReportControllerTest {
                 .createSubscription(100L, FamilyRole.OWNER, any(CreateFamilyReportSubscriptionRequest.class));
 
         mockMvc.perform(post("/api/v1/ai-reports/families")
+                        .contentType(org.springframework.http.MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("200"))
+                .andExpect(jsonPath("$.data").doesNotExist());
+    }
+
+    @Test
+    @DisplayName("가족 AI 리포트 수신 요일 변경 성공")
+    void updateFamilyReportReceiveDaySuccess() throws Exception {
+        setAuthentication(1L, 100L, FamilyRole.OWNER);
+
+        UpdateFamilyReportReceiveDayRequest request =
+                new UpdateFamilyReportReceiveDayRequest(java.time.DayOfWeek.THURSDAY);
+
+        doNothing().when(updateFamilyReportReceiveDayService)
+                .updateReceiveDay(100L, FamilyRole.OWNER, any(UpdateFamilyReportReceiveDayRequest.class));
+
+        mockMvc.perform(patch("/api/v1/ai-reports/families/receive-day")
                         .contentType(org.springframework.http.MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())

--- a/src/test/java/hotspot/user/familyReport/controller/FamilyReportControllerTest.java
+++ b/src/test/java/hotspot/user/familyReport/controller/FamilyReportControllerTest.java
@@ -4,6 +4,7 @@ import static hotspot.user.util.TestSecurityUtil.setAuthentication;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -23,6 +24,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import hotspot.user.common.security.jwt.JwtFilter;
 import hotspot.user.common.security.jwt.JwtProvider;
+import hotspot.user.familyReport.controller.port.CancelFamilyReportSubscriptionService;
 import hotspot.user.familyReport.controller.port.CreateFamilyReportSubscriptionService;
 import hotspot.user.familyReport.controller.port.FindFamilyReportSubscriptionService;
 import hotspot.user.familyReport.controller.port.UpdateFamilyReportReceiveDayService;
@@ -40,6 +42,9 @@ class FamilyReportControllerTest {
 
     @Autowired
     private ObjectMapper objectMapper;
+
+    @MockBean
+    private CancelFamilyReportSubscriptionService cancelFamilyReportSubscriptionService;
 
     @MockBean
     private CreateFamilyReportSubscriptionService createFamilyReportSubscriptionService;
@@ -121,6 +126,20 @@ class FamilyReportControllerTest {
         mockMvc.perform(patch("/api/v1/ai-reports/families/receive-day")
                         .contentType(org.springframework.http.MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("200"))
+                .andExpect(jsonPath("$.data").doesNotExist());
+    }
+
+    @Test
+    @DisplayName("가족 AI 리포트 구독 취소 성공")
+    void cancelFamilyReportSubscriptionSuccess() throws Exception {
+        setAuthentication(1L, 100L, FamilyRole.OWNER);
+
+        doNothing().when(cancelFamilyReportSubscriptionService)
+                .cancelSubscription(100L, FamilyRole.OWNER);
+
+        mockMvc.perform(delete("/api/v1/ai-reports/families"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value("200"))
                 .andExpect(jsonPath("$.data").doesNotExist());

--- a/src/test/java/hotspot/user/familyReport/controller/FamilyReportControllerTest.java
+++ b/src/test/java/hotspot/user/familyReport/controller/FamilyReportControllerTest.java
@@ -2,6 +2,7 @@ package hotspot.user.familyReport.controller;
 
 import static hotspot.user.util.TestSecurityUtil.setAuthentication;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
@@ -139,7 +140,11 @@ class FamilyReportControllerTest {
                 new CreateFamilyReportSubscriptionRequest(java.time.DayOfWeek.TUESDAY);
 
         doNothing().when(createFamilyReportSubscriptionService)
-                .createSubscription(100L, FamilyRole.OWNER, any(CreateFamilyReportSubscriptionRequest.class));
+                .createSubscription(
+                        eq(100L),
+                        eq(FamilyRole.OWNER),
+                        any(CreateFamilyReportSubscriptionRequest.class)
+                );
 
         mockMvc.perform(post("/api/v1/ai-reports/families")
                         .contentType(org.springframework.http.MediaType.APPLICATION_JSON)
@@ -158,7 +163,11 @@ class FamilyReportControllerTest {
                 new UpdateFamilyReportReceiveDayRequest(java.time.DayOfWeek.THURSDAY);
 
         doNothing().when(updateFamilyReportReceiveDayService)
-                .updateReceiveDay(100L, FamilyRole.OWNER, any(UpdateFamilyReportReceiveDayRequest.class));
+                .updateReceiveDay(
+                        eq(100L),
+                        eq(FamilyRole.OWNER),
+                        any(UpdateFamilyReportReceiveDayRequest.class)
+                );
 
         mockMvc.perform(patch("/api/v1/ai-reports/families/receive-day")
                         .contentType(org.springframework.http.MediaType.APPLICATION_JSON)

--- a/src/test/java/hotspot/user/familyReport/controller/FamilyReportControllerTest.java
+++ b/src/test/java/hotspot/user/familyReport/controller/FamilyReportControllerTest.java
@@ -1,0 +1,71 @@
+package hotspot.user.familyReport.controller;
+
+import static hotspot.user.util.TestSecurityUtil.setAuthentication;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.test.web.servlet.MockMvc;
+
+import hotspot.user.common.security.jwt.JwtFilter;
+import hotspot.user.common.security.jwt.JwtProvider;
+import hotspot.user.familyReport.controller.port.FindFamilyReportSubscriptionService;
+import hotspot.user.familyReport.controller.response.FamilyReportSubscriptionResponse;
+import hotspot.user.member.domain.FamilyRole;
+
+@WebMvcTest(FamilyReportController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class FamilyReportControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private FindFamilyReportSubscriptionService findFamilyReportSubscriptionService;
+
+    @MockBean
+    private JwtFilter jwtFilter;
+
+    @MockBean
+    private JwtProvider jwtProvider;
+
+    @MockBean
+    private JpaMetamodelMappingContext jpaMetamodelMappingContext;
+
+    @Test
+    @DisplayName("가족 AI 리포트 구독 여부 조회 성공")
+    void findFamilyReportSubscriptionSuccess() throws Exception {
+        setAuthentication(1L, 100L, FamilyRole.OWNER);
+
+        given(findFamilyReportSubscriptionService.findSubscription(100L))
+                .willReturn(FamilyReportSubscriptionResponse.builder()
+                        .subscribed(true)
+                        .build());
+
+        mockMvc.perform(get("/api/v1/ai-reports/families"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("200"))
+                .andExpect(jsonPath("$.data.subscribed").value(true));
+    }
+
+    @Test
+    @DisplayName("미구독 상태 조회 성공")
+    void findFamilyReportSubscriptionUnsubscribed() throws Exception {
+        setAuthentication(1L, 100L, FamilyRole.CHILD);
+
+        given(findFamilyReportSubscriptionService.findSubscription(100L))
+                .willReturn(FamilyReportSubscriptionResponse.unsubscribed());
+
+        mockMvc.perform(get("/api/v1/ai-reports/families"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.subscribed").value(false));
+    }
+}

--- a/src/test/java/hotspot/user/familyReport/controller/FamilyReportControllerTest.java
+++ b/src/test/java/hotspot/user/familyReport/controller/FamilyReportControllerTest.java
@@ -26,10 +26,12 @@ import hotspot.user.common.security.jwt.JwtFilter;
 import hotspot.user.common.security.jwt.JwtProvider;
 import hotspot.user.familyReport.controller.port.CancelFamilyReportSubscriptionService;
 import hotspot.user.familyReport.controller.port.CreateFamilyReportSubscriptionService;
+import hotspot.user.familyReport.controller.port.FindFamilyReportMembersService;
 import hotspot.user.familyReport.controller.port.FindFamilyReportSubscriptionService;
 import hotspot.user.familyReport.controller.port.UpdateFamilyReportReceiveDayService;
 import hotspot.user.familyReport.controller.request.CreateFamilyReportSubscriptionRequest;
 import hotspot.user.familyReport.controller.request.UpdateFamilyReportReceiveDayRequest;
+import hotspot.user.familyReport.controller.response.FamilyReportMemberResponse;
 import hotspot.user.familyReport.controller.response.FamilyReportSubscriptionResponse;
 import hotspot.user.member.domain.FamilyRole;
 
@@ -48,6 +50,9 @@ class FamilyReportControllerTest {
 
     @MockBean
     private CreateFamilyReportSubscriptionService createFamilyReportSubscriptionService;
+
+    @MockBean
+    private FindFamilyReportMembersService findFamilyReportMembersService;
 
     @MockBean
     private FindFamilyReportSubscriptionService findFamilyReportSubscriptionService;
@@ -78,6 +83,38 @@ class FamilyReportControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value("200"))
                 .andExpect(jsonPath("$.data.subscribed").value(true));
+    }
+
+    @Test
+    @DisplayName("가족 AI 리포트 구성원 목록 조회 성공")
+    void findFamilyReportMembersSuccess() throws Exception {
+        setAuthentication(1L, 100L, FamilyRole.OWNER);
+
+        given(findFamilyReportMembersService.findMembers(100L))
+                .willReturn(java.util.List.of(
+                        FamilyReportMemberResponse.builder()
+                                .subId(10L)
+                                .name("홍길동")
+                                .familyRole(FamilyRole.OWNER)
+                                .reportId(null)
+                                .build(),
+                        FamilyReportMemberResponse.builder()
+                                .subId(11L)
+                                .name("김철수")
+                                .familyRole(FamilyRole.CHILD)
+                                .reportId(null)
+                                .build()
+                ));
+
+        mockMvc.perform(get("/api/v1/ai-reports/families/members"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("200"))
+                .andExpect(jsonPath("$.data[0].subId").value(10L))
+                .andExpect(jsonPath("$.data[0].name").value("홍길동"))
+                .andExpect(jsonPath("$.data[0].familyRole").value("OWNER"))
+                .andExpect(jsonPath("$.data[1].subId").value(11L))
+                .andExpect(jsonPath("$.data[1].name").value("김철수"))
+                .andExpect(jsonPath("$.data[1].familyRole").value("CHILD"));
     }
 
     @Test

--- a/src/test/java/hotspot/user/familyReport/domain/FamilyReportTest.java
+++ b/src/test/java/hotspot/user/familyReport/domain/FamilyReportTest.java
@@ -1,0 +1,58 @@
+package hotspot.user.familyReport.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.DayOfWeek;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import hotspot.user.family.domain.Family;
+
+class FamilyReportTest {
+
+    @Test
+    @DisplayName("수신 요일을 변경할 수 있다")
+    void updateReceiveDaySuccess() {
+        FamilyReport familyReport = FamilyReport.builder()
+                .id(1L)
+                .family(Family.builder().id(10L).build())
+                .receiveDay(DayOfWeek.MONDAY)
+                .isActive(true)
+                .build();
+
+        familyReport.updateReceiveDay(DayOfWeek.FRIDAY);
+
+        assertThat(familyReport.getReceiveDay()).isEqualTo(DayOfWeek.FRIDAY);
+    }
+
+    @Test
+    @DisplayName("비활성 구독을 활성화할 수 있다")
+    void activateSuccess() {
+        FamilyReport familyReport = FamilyReport.builder()
+                .id(1L)
+                .family(Family.builder().id(10L).build())
+                .receiveDay(DayOfWeek.MONDAY)
+                .isActive(false)
+                .build();
+
+        familyReport.activate();
+
+        assertThat(familyReport.isActive()).isTrue();
+    }
+
+    @Test
+    @DisplayName("활성 구독을 비활성화할 수 있다")
+    void deactivateSuccess() {
+        FamilyReport familyReport = FamilyReport.builder()
+                .id(1L)
+                .family(Family.builder().id(10L).build())
+                .receiveDay(DayOfWeek.MONDAY)
+                .isActive(true)
+                .build();
+
+        familyReport.deactivate();
+
+        assertThat(familyReport.isActive()).isFalse();
+    }
+}

--- a/src/test/java/hotspot/user/familyReport/infrastructure/FamilyReportRepositoryImplTest.java
+++ b/src/test/java/hotspot/user/familyReport/infrastructure/FamilyReportRepositoryImplTest.java
@@ -89,8 +89,8 @@ class FamilyReportRepositoryImplTest {
     @Test
     @DisplayName("가족별 활성 상태를 수정할 수 있다")
     void updateActiveSuccess() {
-        familyReportRepository.updateActive(1L, false);
+        familyReportRepository.updateActive(1L, true, false);
 
-        verify(familyReportJpaRepository).updateActive(1L, false);
+        verify(familyReportJpaRepository).updateActive(1L, true, false);
     }
 }

--- a/src/test/java/hotspot/user/familyReport/infrastructure/FamilyReportRepositoryImplTest.java
+++ b/src/test/java/hotspot/user/familyReport/infrastructure/FamilyReportRepositoryImplTest.java
@@ -57,7 +57,7 @@ class FamilyReportRepositoryImplTest {
         FamilyReport familyReport = FamilyReport.builder()
                 .family(Family.builder().id(1L).build())
                 .receiveDay(DayOfWeek.FRIDAY)
-                .active(true)
+                .isActive(true)
                 .build();
 
         FamilyReportEntity savedEntity = FamilyReportEntity.builder()

--- a/src/test/java/hotspot/user/familyReport/infrastructure/FamilyReportRepositoryImplTest.java
+++ b/src/test/java/hotspot/user/familyReport/infrastructure/FamilyReportRepositoryImplTest.java
@@ -1,0 +1,96 @@
+package hotspot.user.familyReport.infrastructure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import java.time.DayOfWeek;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import hotspot.user.family.domain.Family;
+import hotspot.user.family.infrastructure.entity.FamilyEntity;
+import hotspot.user.familyReport.domain.FamilyReport;
+import hotspot.user.familyReport.infrastructure.entity.FamilyReportEntity;
+
+@ExtendWith(MockitoExtension.class)
+class FamilyReportRepositoryImplTest {
+
+    @Mock
+    private FamilyReportJpaRepository familyReportJpaRepository;
+
+    @InjectMocks
+    private FamilyReportRepositoryImpl familyReportRepository;
+
+    @Test
+    @DisplayName("가족 ID로 리포트 구독 정보를 조회할 수 있다")
+    void findByFamilyIdSuccess() {
+        Long familyId = 1L;
+        FamilyReportEntity entity = FamilyReportEntity.builder()
+                .familyReportId(10L)
+                .family(FamilyEntity.builder().familyId(familyId).build())
+                .receiveDay(DayOfWeek.MONDAY)
+                .isActive(true)
+                .build();
+
+        given(familyReportJpaRepository.findByFamilyFamilyId(familyId))
+                .willReturn(Optional.of(entity));
+
+        Optional<FamilyReport> result = familyReportRepository.findByFamilyId(familyId);
+
+        assertThat(result).isPresent();
+        assertThat(result.get().getId()).isEqualTo(10L);
+        assertThat(result.get().getReceiveDay()).isEqualTo(DayOfWeek.MONDAY);
+        assertThat(result.get().isActive()).isTrue();
+    }
+
+    @Test
+    @DisplayName("가족 리포트 구독 정보를 저장할 수 있다")
+    void saveSuccess() {
+        FamilyReport familyReport = FamilyReport.builder()
+                .family(Family.builder().id(1L).build())
+                .receiveDay(DayOfWeek.FRIDAY)
+                .active(true)
+                .build();
+
+        FamilyReportEntity savedEntity = FamilyReportEntity.builder()
+                .familyReportId(11L)
+                .family(FamilyEntity.builder().familyId(1L).build())
+                .receiveDay(DayOfWeek.FRIDAY)
+                .isActive(true)
+                .build();
+
+        given(familyReportJpaRepository.save(any(FamilyReportEntity.class))).willReturn(savedEntity);
+
+        FamilyReport result = familyReportRepository.save(familyReport);
+
+        assertThat(result.getId()).isEqualTo(11L);
+        assertThat(result.getFamily().getId()).isEqualTo(1L);
+        assertThat(result.getReceiveDay()).isEqualTo(DayOfWeek.FRIDAY);
+        assertThat(result.isActive()).isTrue();
+        verify(familyReportJpaRepository).save(any(FamilyReportEntity.class));
+    }
+
+    @Test
+    @DisplayName("가족별 수신 요일을 수정할 수 있다")
+    void updateReceiveDaySuccess() {
+        familyReportRepository.updateReceiveDay(1L, DayOfWeek.SUNDAY);
+
+        verify(familyReportJpaRepository).updateReceiveDay(1L, DayOfWeek.SUNDAY);
+    }
+
+    @Test
+    @DisplayName("가족별 활성 상태를 수정할 수 있다")
+    void updateActiveSuccess() {
+        familyReportRepository.updateActive(1L, false);
+
+        verify(familyReportJpaRepository).updateActive(1L, false);
+    }
+}

--- a/src/test/java/hotspot/user/familyReport/service/CancelFamilyReportSubscriptionServiceImplTest.java
+++ b/src/test/java/hotspot/user/familyReport/service/CancelFamilyReportSubscriptionServiceImplTest.java
@@ -1,12 +1,7 @@
 package hotspot.user.familyReport.service;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.verify;
-
-import java.time.DayOfWeek;
-import java.util.Optional;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -18,8 +13,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import hotspot.user.common.exception.ApplicationException;
 import hotspot.user.common.exception.code.AuthErrorCode;
 import hotspot.user.common.exception.code.FamilyReportErrorCode;
-import hotspot.user.family.domain.Family;
-import hotspot.user.familyReport.domain.FamilyReport;
 import hotspot.user.familyReport.service.port.FamilyReportRepository;
 import hotspot.user.member.domain.FamilyRole;
 
@@ -35,19 +28,9 @@ class CancelFamilyReportSubscriptionServiceImplTest {
     @Test
     @DisplayName("가족 OWNER는 활성 구독을 취소할 수 있다")
     void cancelSubscriptionSuccess() {
-        given(familyReportRepository.findByFamilyId(1L))
-                .willReturn(Optional.of(FamilyReport.builder()
-                        .id(10L)
-                        .family(Family.builder().id(1L).build())
-                        .receiveDay(DayOfWeek.MONDAY)
-                        .active(true)
-                        .build()));
-        given(familyReportRepository.save(any(FamilyReport.class)))
-                .willAnswer(invocation -> invocation.getArgument(0));
+        given(familyReportRepository.updateActive(1L, true, false)).willReturn(1);
 
         service.cancelSubscription(1L, FamilyRole.OWNER);
-
-        verify(familyReportRepository).save(any(FamilyReport.class));
     }
 
     @Test
@@ -61,7 +44,7 @@ class CancelFamilyReportSubscriptionServiceImplTest {
     @Test
     @DisplayName("활성 구독이 없으면 취소할 수 없다")
     void cancelSubscriptionNotFound() {
-        given(familyReportRepository.findByFamilyId(1L)).willReturn(Optional.empty());
+        given(familyReportRepository.updateActive(1L, true, false)).willReturn(0);
 
         assertThatThrownBy(() -> service.cancelSubscription(1L, FamilyRole.OWNER))
                 .isInstanceOf(ApplicationException.class)

--- a/src/test/java/hotspot/user/familyReport/service/CancelFamilyReportSubscriptionServiceImplTest.java
+++ b/src/test/java/hotspot/user/familyReport/service/CancelFamilyReportSubscriptionServiceImplTest.java
@@ -1,0 +1,70 @@
+package hotspot.user.familyReport.service;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import java.time.DayOfWeek;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import hotspot.user.common.exception.ApplicationException;
+import hotspot.user.common.exception.code.AuthErrorCode;
+import hotspot.user.common.exception.code.FamilyReportErrorCode;
+import hotspot.user.family.domain.Family;
+import hotspot.user.familyReport.domain.FamilyReport;
+import hotspot.user.familyReport.service.port.FamilyReportRepository;
+import hotspot.user.member.domain.FamilyRole;
+
+@ExtendWith(MockitoExtension.class)
+class CancelFamilyReportSubscriptionServiceImplTest {
+
+    @Mock
+    private FamilyReportRepository familyReportRepository;
+
+    @InjectMocks
+    private CancelFamilyReportSubscriptionServiceImpl service;
+
+    @Test
+    @DisplayName("가족 OWNER는 활성 구독을 취소할 수 있다")
+    void cancelSubscriptionSuccess() {
+        given(familyReportRepository.findByFamilyId(1L))
+                .willReturn(Optional.of(FamilyReport.builder()
+                        .id(10L)
+                        .family(Family.builder().id(1L).build())
+                        .receiveDay(DayOfWeek.MONDAY)
+                        .active(true)
+                        .build()));
+        given(familyReportRepository.save(any(FamilyReport.class)))
+                .willAnswer(invocation -> invocation.getArgument(0));
+
+        service.cancelSubscription(1L, FamilyRole.OWNER);
+
+        verify(familyReportRepository).save(any(FamilyReport.class));
+    }
+
+    @Test
+    @DisplayName("가족 OWNER가 아니면 구독을 취소할 수 없다")
+    void cancelSubscriptionDenied() {
+        assertThatThrownBy(() -> service.cancelSubscription(1L, FamilyRole.CHILD))
+                .isInstanceOf(ApplicationException.class)
+                .hasFieldOrPropertyWithValue("code", AuthErrorCode.ACCESS_DENIED);
+    }
+
+    @Test
+    @DisplayName("활성 구독이 없으면 취소할 수 없다")
+    void cancelSubscriptionNotFound() {
+        given(familyReportRepository.findByFamilyId(1L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.cancelSubscription(1L, FamilyRole.OWNER))
+                .isInstanceOf(ApplicationException.class)
+                .hasFieldOrPropertyWithValue("code", FamilyReportErrorCode.FAMILY_REPORT_SUBSCRIPTION_NOT_FOUND);
+    }
+}

--- a/src/test/java/hotspot/user/familyReport/service/CreateFamilyReportSubscriptionServiceImplTest.java
+++ b/src/test/java/hotspot/user/familyReport/service/CreateFamilyReportSubscriptionServiceImplTest.java
@@ -44,7 +44,7 @@ class CreateFamilyReportSubscriptionServiceImplTest {
                         .id(10L)
                         .family(Family.builder().id(1L).build())
                         .receiveDay(DayOfWeek.WEDNESDAY)
-                        .active(true)
+                        .isActive(true)
                         .build());
 
         service.createSubscription(1L, FamilyRole.OWNER, request);
@@ -63,7 +63,7 @@ class CreateFamilyReportSubscriptionServiceImplTest {
                         .id(10L)
                         .family(Family.builder().id(1L).build())
                         .receiveDay(DayOfWeek.MONDAY)
-                        .active(false)
+                        .isActive(false)
                         .build()));
         given(familyReportRepository.save(any(FamilyReport.class)))
                 .willAnswer(invocation -> invocation.getArgument(0));

--- a/src/test/java/hotspot/user/familyReport/service/CreateFamilyReportSubscriptionServiceImplTest.java
+++ b/src/test/java/hotspot/user/familyReport/service/CreateFamilyReportSubscriptionServiceImplTest.java
@@ -1,6 +1,5 @@
 package hotspot.user.familyReport.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;

--- a/src/test/java/hotspot/user/familyReport/service/CreateFamilyReportSubscriptionServiceImplTest.java
+++ b/src/test/java/hotspot/user/familyReport/service/CreateFamilyReportSubscriptionServiceImplTest.java
@@ -1,0 +1,87 @@
+package hotspot.user.familyReport.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import java.time.DayOfWeek;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import hotspot.user.common.exception.ApplicationException;
+import hotspot.user.common.exception.code.AuthErrorCode;
+import hotspot.user.family.domain.Family;
+import hotspot.user.familyReport.controller.request.CreateFamilyReportSubscriptionRequest;
+import hotspot.user.familyReport.domain.FamilyReport;
+import hotspot.user.familyReport.service.port.FamilyReportRepository;
+import hotspot.user.member.domain.FamilyRole;
+
+@ExtendWith(MockitoExtension.class)
+class CreateFamilyReportSubscriptionServiceImplTest {
+
+    @Mock
+    private FamilyReportRepository familyReportRepository;
+
+    @InjectMocks
+    private CreateFamilyReportSubscriptionServiceImpl service;
+
+    @Test
+    @DisplayName("가족 OWNER는 신규 리포트 구독을 신청할 수 있다")
+    void createSubscriptionSuccess() {
+        CreateFamilyReportSubscriptionRequest request =
+                new CreateFamilyReportSubscriptionRequest(DayOfWeek.WEDNESDAY);
+
+        given(familyReportRepository.findByFamilyId(1L)).willReturn(Optional.empty());
+        given(familyReportRepository.save(any(FamilyReport.class)))
+                .willReturn(FamilyReport.builder()
+                        .id(10L)
+                        .family(Family.builder().id(1L).build())
+                        .receiveDay(DayOfWeek.WEDNESDAY)
+                        .active(true)
+                        .build());
+
+        service.createSubscription(1L, FamilyRole.OWNER, request);
+
+        verify(familyReportRepository).save(any(FamilyReport.class));
+    }
+
+    @Test
+    @DisplayName("기존 구독 이력이 있으면 수신 요일을 변경하고 재활성화한다")
+    void createSubscriptionReactivateSuccess() {
+        CreateFamilyReportSubscriptionRequest request =
+                new CreateFamilyReportSubscriptionRequest(DayOfWeek.FRIDAY);
+
+        given(familyReportRepository.findByFamilyId(1L))
+                .willReturn(Optional.of(FamilyReport.builder()
+                        .id(10L)
+                        .family(Family.builder().id(1L).build())
+                        .receiveDay(DayOfWeek.MONDAY)
+                        .active(false)
+                        .build()));
+        given(familyReportRepository.save(any(FamilyReport.class)))
+                .willAnswer(invocation -> invocation.getArgument(0));
+
+        service.createSubscription(1L, FamilyRole.OWNER, request);
+
+        verify(familyReportRepository).save(any(FamilyReport.class));
+    }
+
+    @Test
+    @DisplayName("가족 OWNER가 아니면 리포트 구독 신청이 불가능하다")
+    void createSubscriptionDenied() {
+        CreateFamilyReportSubscriptionRequest request =
+                new CreateFamilyReportSubscriptionRequest(DayOfWeek.WEDNESDAY);
+
+        assertThatThrownBy(() -> service.createSubscription(1L, FamilyRole.CHILD, request))
+                .isInstanceOf(ApplicationException.class)
+                .hasFieldOrPropertyWithValue("code", AuthErrorCode.ACCESS_DENIED);
+    }
+}

--- a/src/test/java/hotspot/user/familyReport/service/FindFamilyReportMembersServiceImplTest.java
+++ b/src/test/java/hotspot/user/familyReport/service/FindFamilyReportMembersServiceImplTest.java
@@ -1,0 +1,79 @@
+package hotspot.user.familyReport.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import hotspot.user.family.domain.Family;
+import hotspot.user.family.domain.FamilySubscription;
+import hotspot.user.family.service.port.FamilySubscriptionRepository;
+import hotspot.user.familyReport.controller.response.FamilyReportMemberResponse;
+import hotspot.user.member.domain.FamilyRole;
+import hotspot.user.member.domain.Member;
+import hotspot.user.subscription.domain.Subscription;
+
+@ExtendWith(MockitoExtension.class)
+class FindFamilyReportMembersServiceImplTest {
+
+    @Mock
+    private FamilySubscriptionRepository familySubscriptionRepository;
+
+    @InjectMocks
+    private FindFamilyReportMembersServiceImpl service;
+
+    @Test
+    @DisplayName("가족 구성원 목록은 대표, 부모, 자녀 순으로 조회된다")
+    void findMembersSuccess() {
+        given(familySubscriptionRepository.findByFamilyId(1L))
+                .willReturn(List.of(
+                        FamilySubscription.builder()
+                                .family(Family.builder().id(1L).build())
+                                .subscription(Subscription.builder()
+                                        .id(12L)
+                                        .member(Member.builder().id(3L).name("김영희").build())
+                                        .build())
+                                .familyRole(FamilyRole.CHILD)
+                                .build(),
+                        FamilySubscription.builder()
+                                .family(Family.builder().id(1L).build())
+                                .subscription(Subscription.builder()
+                                        .id(11L)
+                                        .member(Member.builder().id(2L).name("김철수").build())
+                                        .build())
+                                .familyRole(FamilyRole.PARENT)
+                                .build(),
+                        FamilySubscription.builder()
+                                .family(Family.builder().id(1L).build())
+                                .subscription(Subscription.builder()
+                                        .id(10L)
+                                        .member(Member.builder().id(1L).name("홍길동").build())
+                                        .build())
+                                .familyRole(FamilyRole.OWNER)
+                                .build()
+                ));
+
+        List<FamilyReportMemberResponse> result = service.findMembers(1L);
+
+        assertThat(result).hasSize(3);
+        assertThat(result.get(0).subId()).isEqualTo(10L);
+        assertThat(result.get(0).name()).isEqualTo("홍길동");
+        assertThat(result.get(0).familyRole()).isEqualTo(FamilyRole.OWNER);
+        assertThat(result.get(0).reportId()).isNull();
+        assertThat(result.get(1).subId()).isEqualTo(11L);
+        assertThat(result.get(1).name()).isEqualTo("김철수");
+        assertThat(result.get(1).familyRole()).isEqualTo(FamilyRole.PARENT);
+        assertThat(result.get(1).reportId()).isNull();
+        assertThat(result.get(2).subId()).isEqualTo(12L);
+        assertThat(result.get(2).name()).isEqualTo("김영희");
+        assertThat(result.get(2).familyRole()).isEqualTo(FamilyRole.CHILD);
+        assertThat(result.get(2).reportId()).isNull();
+    }
+}

--- a/src/test/java/hotspot/user/familyReport/service/FindFamilyReportSubscriptionServiceImplTest.java
+++ b/src/test/java/hotspot/user/familyReport/service/FindFamilyReportSubscriptionServiceImplTest.java
@@ -1,0 +1,68 @@
+package hotspot.user.familyReport.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import hotspot.user.family.domain.Family;
+import hotspot.user.familyReport.controller.response.FamilyReportSubscriptionResponse;
+import hotspot.user.familyReport.domain.FamilyReport;
+import hotspot.user.familyReport.service.port.FamilyReportRepository;
+
+@ExtendWith(MockitoExtension.class)
+class FindFamilyReportSubscriptionServiceImplTest {
+
+    @Mock
+    private FamilyReportRepository familyReportRepository;
+
+    @InjectMocks
+    private FindFamilyReportSubscriptionServiceImpl service;
+
+    @Test
+    @DisplayName("활성화된 구독이 있으면 구독 상태와 수신 요일을 반환한다")
+    void findSubscriptionSuccess() {
+        given(familyReportRepository.findByFamilyId(1L))
+                        .willReturn(Optional.of(FamilyReport.builder()
+                        .id(10L)
+                        .family(Family.builder().id(1L).build())
+                        .active(true)
+                        .build()));
+
+        FamilyReportSubscriptionResponse result = service.findSubscription(1L);
+
+        assertThat(result.subscribed()).isTrue();
+    }
+
+    @Test
+    @DisplayName("구독 정보가 없으면 미구독 상태를 반환한다")
+    void findSubscriptionWhenNotFound() {
+        given(familyReportRepository.findByFamilyId(1L)).willReturn(Optional.empty());
+
+        FamilyReportSubscriptionResponse result = service.findSubscription(1L);
+
+        assertThat(result.subscribed()).isFalse();
+    }
+
+    @Test
+    @DisplayName("비활성화된 구독은 미구독 상태로 반환한다")
+    void findSubscriptionWhenInactive() {
+        given(familyReportRepository.findByFamilyId(1L))
+                        .willReturn(Optional.of(FamilyReport.builder()
+                        .id(10L)
+                        .family(Family.builder().id(1L).build())
+                        .active(false)
+                        .build()));
+
+        FamilyReportSubscriptionResponse result = service.findSubscription(1L);
+
+        assertThat(result.subscribed()).isFalse();
+    }
+}

--- a/src/test/java/hotspot/user/familyReport/service/FindFamilyReportSubscriptionServiceImplTest.java
+++ b/src/test/java/hotspot/user/familyReport/service/FindFamilyReportSubscriptionServiceImplTest.java
@@ -30,10 +30,10 @@ class FindFamilyReportSubscriptionServiceImplTest {
     @DisplayName("활성화된 구독이 있으면 구독 상태와 수신 요일을 반환한다")
     void findSubscriptionSuccess() {
         given(familyReportRepository.findByFamilyId(1L))
-                        .willReturn(Optional.of(FamilyReport.builder()
+                .willReturn(Optional.of(FamilyReport.builder()
                         .id(10L)
                         .family(Family.builder().id(1L).build())
-                        .active(true)
+                        .isActive(true)
                         .build()));
 
         FamilyReportSubscriptionResponse result = service.findSubscription(1L);
@@ -55,10 +55,10 @@ class FindFamilyReportSubscriptionServiceImplTest {
     @DisplayName("비활성화된 구독은 미구독 상태로 반환한다")
     void findSubscriptionWhenInactive() {
         given(familyReportRepository.findByFamilyId(1L))
-                        .willReturn(Optional.of(FamilyReport.builder()
+                .willReturn(Optional.of(FamilyReport.builder()
                         .id(10L)
                         .family(Family.builder().id(1L).build())
-                        .active(false)
+                        .isActive(false)
                         .build()));
 
         FamilyReportSubscriptionResponse result = service.findSubscription(1L);

--- a/src/test/java/hotspot/user/familyReport/service/UpdateFamilyReportReceiveDayServiceImplTest.java
+++ b/src/test/java/hotspot/user/familyReport/service/UpdateFamilyReportReceiveDayServiceImplTest.java
@@ -1,12 +1,9 @@
 package hotspot.user.familyReport.service;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.verify;
 
 import java.time.DayOfWeek;
-import java.util.Optional;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -18,9 +15,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import hotspot.user.common.exception.ApplicationException;
 import hotspot.user.common.exception.code.AuthErrorCode;
 import hotspot.user.common.exception.code.FamilyReportErrorCode;
-import hotspot.user.family.domain.Family;
 import hotspot.user.familyReport.controller.request.UpdateFamilyReportReceiveDayRequest;
-import hotspot.user.familyReport.domain.FamilyReport;
 import hotspot.user.familyReport.service.port.FamilyReportRepository;
 import hotspot.user.member.domain.FamilyRole;
 
@@ -39,19 +34,9 @@ class UpdateFamilyReportReceiveDayServiceImplTest {
         UpdateFamilyReportReceiveDayRequest request =
                 new UpdateFamilyReportReceiveDayRequest(DayOfWeek.SUNDAY);
 
-        given(familyReportRepository.findByFamilyId(1L))
-                .willReturn(Optional.of(FamilyReport.builder()
-                        .id(10L)
-                        .family(Family.builder().id(1L).build())
-                        .receiveDay(DayOfWeek.MONDAY)
-                        .active(true)
-                        .build()));
-        given(familyReportRepository.save(any(FamilyReport.class)))
-                .willAnswer(invocation -> invocation.getArgument(0));
+        given(familyReportRepository.updateReceiveDay(1L, DayOfWeek.SUNDAY)).willReturn(1);
 
         service.updateReceiveDay(1L, FamilyRole.OWNER, request);
-
-        verify(familyReportRepository).save(any(FamilyReport.class));
     }
 
     @Test
@@ -71,7 +56,7 @@ class UpdateFamilyReportReceiveDayServiceImplTest {
         UpdateFamilyReportReceiveDayRequest request =
                 new UpdateFamilyReportReceiveDayRequest(DayOfWeek.SUNDAY);
 
-        given(familyReportRepository.findByFamilyId(1L)).willReturn(Optional.empty());
+        given(familyReportRepository.updateReceiveDay(1L, DayOfWeek.SUNDAY)).willReturn(0);
 
         assertThatThrownBy(() -> service.updateReceiveDay(1L, FamilyRole.OWNER, request))
                 .isInstanceOf(ApplicationException.class)

--- a/src/test/java/hotspot/user/familyReport/service/UpdateFamilyReportReceiveDayServiceImplTest.java
+++ b/src/test/java/hotspot/user/familyReport/service/UpdateFamilyReportReceiveDayServiceImplTest.java
@@ -1,0 +1,80 @@
+package hotspot.user.familyReport.service;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import java.time.DayOfWeek;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import hotspot.user.common.exception.ApplicationException;
+import hotspot.user.common.exception.code.AuthErrorCode;
+import hotspot.user.common.exception.code.FamilyReportErrorCode;
+import hotspot.user.family.domain.Family;
+import hotspot.user.familyReport.controller.request.UpdateFamilyReportReceiveDayRequest;
+import hotspot.user.familyReport.domain.FamilyReport;
+import hotspot.user.familyReport.service.port.FamilyReportRepository;
+import hotspot.user.member.domain.FamilyRole;
+
+@ExtendWith(MockitoExtension.class)
+class UpdateFamilyReportReceiveDayServiceImplTest {
+
+    @Mock
+    private FamilyReportRepository familyReportRepository;
+
+    @InjectMocks
+    private UpdateFamilyReportReceiveDayServiceImpl service;
+
+    @Test
+    @DisplayName("가족 OWNER는 활성 구독의 수신 요일을 변경할 수 있다")
+    void updateReceiveDaySuccess() {
+        UpdateFamilyReportReceiveDayRequest request =
+                new UpdateFamilyReportReceiveDayRequest(DayOfWeek.SUNDAY);
+
+        given(familyReportRepository.findByFamilyId(1L))
+                .willReturn(Optional.of(FamilyReport.builder()
+                        .id(10L)
+                        .family(Family.builder().id(1L).build())
+                        .receiveDay(DayOfWeek.MONDAY)
+                        .active(true)
+                        .build()));
+        given(familyReportRepository.save(any(FamilyReport.class)))
+                .willAnswer(invocation -> invocation.getArgument(0));
+
+        service.updateReceiveDay(1L, FamilyRole.OWNER, request);
+
+        verify(familyReportRepository).save(any(FamilyReport.class));
+    }
+
+    @Test
+    @DisplayName("가족 OWNER가 아니면 수신 요일을 변경할 수 없다")
+    void updateReceiveDayDenied() {
+        UpdateFamilyReportReceiveDayRequest request =
+                new UpdateFamilyReportReceiveDayRequest(DayOfWeek.SUNDAY);
+
+        assertThatThrownBy(() -> service.updateReceiveDay(1L, FamilyRole.CHILD, request))
+                .isInstanceOf(ApplicationException.class)
+                .hasFieldOrPropertyWithValue("code", AuthErrorCode.ACCESS_DENIED);
+    }
+
+    @Test
+    @DisplayName("활성 구독이 없으면 수신 요일을 변경할 수 없다")
+    void updateReceiveDayNotFound() {
+        UpdateFamilyReportReceiveDayRequest request =
+                new UpdateFamilyReportReceiveDayRequest(DayOfWeek.SUNDAY);
+
+        given(familyReportRepository.findByFamilyId(1L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.updateReceiveDay(1L, FamilyRole.OWNER, request))
+                .isInstanceOf(ApplicationException.class)
+                .hasFieldOrPropertyWithValue("code", FamilyReportErrorCode.FAMILY_REPORT_SUBSCRIPTION_NOT_FOUND);
+    }
+}


### PR DESCRIPTION
## 🎫 지라 티켓

<!-- 지라 티켓을 작성해주세요 ex) HOTSPOT-123 -->
HOTSPOT-350

---

## 🔗 GitHub 이슈
<!-- 자동 close를 원하면 아래 형식으로 작성
예) Closes #12
-->
Closes #195 

---


## ✅ 작업 사항

<!-- 작업한 부분을 설명해주세요. -->

- 구독 여부 조회 api
- 가족 구성원 목록 + 이번주 분석 여부 조회 api
- 리포트 신청 + 요일 설정 api
- 리포트 요일 변경 api
- 리포트 구독 취소 api

---

## 📋 체크리스트

<!-- PR 제출 전 확인해주세요. 해당 항목에 [x]로 체크해주세요. -->

- [x] 코드가 정상적으로 빌드됩니다.
- [x] 관련 테스트 코드를 작성했습니다.
- [x] 기존 테스트가 모두 통과합니다.
- [x] 코드 스타일(Spotless, Checkstyle)을 준수합니다.
- [x] Jira 티켓 상태를 In Review / Done으로 변경했습니다.

---

## ⌨ 기타
- 가족 구성원 목록 + 이번주 분석 여부 조회 api
- 구성원별 월별 주간 리포트 리스트 조회 api

위의 두 api는 미완성 및 미구현입니다. 배치 DB 연결 후 다시 완성하도록 하겠습니다.
