### PR TITLE
[HOTSPOT-374] 정책 일괄 해제 알림 및 선물 데이터 이름 파싱 수정

### DIFF
--- a/src/main/java/hotspot/user/kafka/mapper/strategy/usage/UsageThresholdAlertEventMappingStrategy.java
+++ b/src/main/java/hotspot/user/kafka/mapper/strategy/usage/UsageThresholdAlertEventMappingStrategy.java
@@ -3,7 +3,6 @@ package hotspot.user.kafka.mapper.strategy.usage;
 import java.util.List;
 import java.util.Map;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import hotspot.user.common.exception.ApplicationException;
@@ -22,11 +21,6 @@ public class UsageThresholdAlertEventMappingStrategy implements UserAlertEventMa
 
     private final PresentDataRepository presentDataRepository;
 
-    public UsageThresholdAlertEventMappingStrategy() {
-        this.presentDataRepository = null;
-    }
-
-    @Autowired
     public UsageThresholdAlertEventMappingStrategy(PresentDataRepository presentDataRepository) {
         this.presentDataRepository = presentDataRepository;
     }
@@ -106,7 +100,7 @@ public class UsageThresholdAlertEventMappingStrategy implements UserAlertEventMa
         }
 
         Long giftId = parseGiftId(event.giftId());
-        if (giftId != null && presentDataRepository != null) {
+        if (giftId != null) {
             Map<Long, String> giverNames = presentDataRepository.findGiftGiverNames(List.of(giftId));
             String senderNameFromGift = giverNames.get(giftId);
             if (senderNameFromGift != null && !senderNameFromGift.isBlank()) {

--- a/src/main/java/hotspot/user/kafka/mapper/strategy/usage/UsageThresholdAlertEventMappingStrategy.java
+++ b/src/main/java/hotspot/user/kafka/mapper/strategy/usage/UsageThresholdAlertEventMappingStrategy.java
@@ -1,5 +1,9 @@
 package hotspot.user.kafka.mapper.strategy.usage;
 
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import hotspot.user.common.exception.ApplicationException;
@@ -11,9 +15,21 @@ import hotspot.user.kafka.mapper.strategy.UserAlertEventMappingStrategy;
 import hotspot.user.kafka.mapper.support.AlertEventMappingSupport;
 import hotspot.user.kafka.mapper.template.AlertMessageTemplateRegistry;
 import hotspot.user.kafka.model.AlertNotificationMappingResult;
+import hotspot.user.presentData.service.port.PresentDataRepository;
 
 @Component
 public class UsageThresholdAlertEventMappingStrategy implements UserAlertEventMappingStrategy {
+
+    private final PresentDataRepository presentDataRepository;
+
+    public UsageThresholdAlertEventMappingStrategy() {
+        this.presentDataRepository = null;
+    }
+
+    @Autowired
+    public UsageThresholdAlertEventMappingStrategy(PresentDataRepository presentDataRepository) {
+        this.presentDataRepository = presentDataRepository;
+    }
 
     @Override
     public boolean supports(KafkaEventType eventType) {
@@ -34,7 +50,7 @@ public class UsageThresholdAlertEventMappingStrategy implements UserAlertEventMa
         }
 
         if (isGiftAlertType(normalizedAlertType)) {
-            String senderName = AlertEventMappingSupport.defaultIfBlank(event.presentSenderName(), "누군가");
+            String senderName = resolveGiftSenderName(event);
             return AlertMessageTemplateRegistry.create(resolveGiftNotificationType(threshold), senderName);
         }
 
@@ -81,5 +97,34 @@ public class UsageThresholdAlertEventMappingStrategy implements UserAlertEventMa
 
     private boolean isGiftAlertType(String alertType) {
         return "GIFT_REMAINING".equals(alertType);
+    }
+
+    private String resolveGiftSenderName(UserAlertEvent event) {
+        String senderNameFromEvent = AlertEventMappingSupport.defaultIfBlank(event.presentSenderName(), null);
+        if (senderNameFromEvent != null) {
+            return senderNameFromEvent;
+        }
+
+        Long giftId = parseGiftId(event.giftId());
+        if (giftId != null && presentDataRepository != null) {
+            Map<Long, String> giverNames = presentDataRepository.findGiftGiverNames(List.of(giftId));
+            String senderNameFromGift = giverNames.get(giftId);
+            if (senderNameFromGift != null && !senderNameFromGift.isBlank()) {
+                return senderNameFromGift;
+            }
+        }
+
+        return "누군가";
+    }
+
+    private Long parseGiftId(String giftIdRaw) {
+        if (giftIdRaw == null || giftIdRaw.isBlank()) {
+            return null;
+        }
+        try {
+            return Long.parseLong(giftIdRaw.trim());
+        } catch (NumberFormatException ex) {
+            return null;
+        }
     }
 }

--- a/src/main/java/hotspot/user/policy/service/UpdateFamilyBlockPolicyStatusServiceImpl.java
+++ b/src/main/java/hotspot/user/policy/service/UpdateFamilyBlockPolicyStatusServiceImpl.java
@@ -18,6 +18,9 @@ import hotspot.user.common.exception.code.PolicyErrorCode;
 import hotspot.user.member.domain.FamilyRole;
 import hotspot.user.member.domain.MemberDetailInfo;
 import hotspot.user.member.service.port.MemberRepository;
+import hotspot.user.outbox.notificationOutbox.domain.event.AlertAction;
+import hotspot.user.outbox.notificationOutbox.domain.event.PolicyAlertOutboxEvent;
+import hotspot.user.outbox.notificationOutbox.service.port.UserAlertNotificationOutboxPort;
 import hotspot.user.policy.controller.port.UpdateFamilyBlockPolicyStatusService;
 import hotspot.user.policy.controller.request.UpdateFamilyBlockPolicyStatusRequest;
 import hotspot.user.policy.controller.response.UpdateFamilyBlockPolicyStatusResponse;
@@ -41,6 +44,7 @@ public class UpdateFamilyBlockPolicyStatusServiceImpl implements UpdateFamilyBlo
     private final BlockPolicyRepository blockPolicyRepository;
     private final PolicySubRepository policySubRepository;
     private final FamilyPolicyDeactivatePublisher familyPolicyDeactivatePublisher;
+    private final UserAlertNotificationOutboxPort userAlertNotificationOutboxPort;
 
     @Override
     public UpdateFamilyBlockPolicyStatusResponse updateFamilyBlockPolicyStatus(
@@ -53,6 +57,8 @@ public class UpdateFamilyBlockPolicyStatusServiceImpl implements UpdateFamilyBlo
 
         // 2. 해당 가족이 생성한 모든 정책을 조회한다.
         List<BlockPolicy> allFamilyPolicies = blockPolicyRepository.findAllByFamilyId(requesterFamilyId);
+        Map<Long, BlockPolicy> allFamilyPolicyMap = allFamilyPolicies.stream()
+                .collect(Collectors.toMap(BlockPolicy::getId, policy -> policy));
 
         // 3. 요청받은 ID 리스트가 모두 우리 가족의 정책인지 검증한다.
         List<Long> requestActiveIds = request.blockPolicyIdList();
@@ -83,6 +89,10 @@ public class UpdateFamilyBlockPolicyStatusServiceImpl implements UpdateFamilyBlo
             blockPolicyRepository.bulkActivate(toActivate);
         }
         if (!toDeactivate.isEmpty()) {
+            Map<Long, List<Long>> activeSubIdsByPolicyId =
+                    policySubRepository.findActiveSubIdsByBlockPolicyIds(toDeactivate);
+
+            publishPolicyReleasedAlerts(activeSubIdsByPolicyId, allFamilyPolicyMap, requesterFamilyId);
 
             familyPolicyDeactivatePublisher.publish(toDeactivate, requesterFamilyId);
 
@@ -119,5 +129,33 @@ public class UpdateFamilyBlockPolicyStatusServiceImpl implements UpdateFamilyBlo
         if (!familyPolicyIds.containsAll(requestIds)) {
             throw new ApplicationException(PolicyErrorCode.POLICY_ACCESS_DENIED);
         }
+    }
+
+    private void publishPolicyReleasedAlerts(
+            Map<Long, List<Long>> activeSubIdsByPolicyId,
+            Map<Long, BlockPolicy> policyMap,
+            Long familyId
+    ) {
+        if (activeSubIdsByPolicyId == null || activeSubIdsByPolicyId.isEmpty()) {
+            return;
+        }
+
+        activeSubIdsByPolicyId.forEach((policyId, subIds) -> {
+            BlockPolicy policy = policyMap.get(policyId);
+            if (policy == null || subIds == null || subIds.isEmpty()) {
+                return;
+            }
+
+            subIds.stream()
+                    .filter(Objects::nonNull)
+                    .distinct()
+                    .forEach(subId -> userAlertNotificationOutboxPort.appendPolicyAlert(new PolicyAlertOutboxEvent(
+                            subId,
+                            familyId,
+                            policy.getName(),
+                            policy.getPolicyType(),
+                            AlertAction.RELEASED
+                    )));
+        });
     }
 }

--- a/src/test/java/hotspot/user/kafka/mapper/orchestrator/UserAlertEventNotificationMapperTest.java
+++ b/src/test/java/hotspot/user/kafka/mapper/orchestrator/UserAlertEventNotificationMapperTest.java
@@ -2,6 +2,7 @@ package hotspot.user.kafka.mapper.orchestrator;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -20,12 +21,13 @@ import hotspot.user.kafka.mapper.strategy.policy.PolicyAlertEventMappingStrategy
 import hotspot.user.kafka.mapper.strategy.present.PresentDataAlertEventMappingStrategy;
 import hotspot.user.kafka.mapper.strategy.usage.UsageThresholdAlertEventMappingStrategy;
 import hotspot.user.notification.domain.Notification;
+import hotspot.user.presentData.service.port.PresentDataRepository;
 
 class UserAlertEventNotificationMapperTest {
 
     private final UserAlertEventNotificationMapper mapper = new UserAlertEventNotificationMapper(
             new UserAlertEventMappingStrategyRegistry(List.of(
-                    new UsageThresholdAlertEventMappingStrategy(),
+                    new UsageThresholdAlertEventMappingStrategy(mock(PresentDataRepository.class)),
                     new PolicyAlertEventMappingStrategy(),
                     new AppServiceAlertEventMappingStrategy(),
                     new PresentDataAlertEventMappingStrategy(),

--- a/src/test/java/hotspot/user/kafka/mapper/registry/UserAlertEventMappingStrategyRegistryTest.java
+++ b/src/test/java/hotspot/user/kafka/mapper/registry/UserAlertEventMappingStrategyRegistryTest.java
@@ -2,6 +2,7 @@ package hotspot.user.kafka.mapper.registry;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
 
 import java.util.List;
 
@@ -19,6 +20,7 @@ import hotspot.user.kafka.mapper.strategy.policy.PolicyAlertEventMappingStrategy
 import hotspot.user.kafka.mapper.strategy.present.PresentDataAlertEventMappingStrategy;
 import hotspot.user.kafka.mapper.strategy.usage.UsageThresholdAlertEventMappingStrategy;
 import hotspot.user.kafka.model.AlertNotificationMappingResult;
+import hotspot.user.presentData.service.port.PresentDataRepository;
 
 class UserAlertEventMappingStrategyRegistryTest {
 
@@ -49,7 +51,7 @@ class UserAlertEventMappingStrategyRegistryTest {
 
         assertThatThrownBy(() -> new UserAlertEventMappingStrategyRegistry(
                 List.of(
-                        new UsageThresholdAlertEventMappingStrategy(),
+                        new UsageThresholdAlertEventMappingStrategy(mock(PresentDataRepository.class)),
                         duplicated,
                         new PolicyAlertEventMappingStrategy(),
                         new AppServiceAlertEventMappingStrategy(),
@@ -66,7 +68,7 @@ class UserAlertEventMappingStrategyRegistryTest {
     void unsupportedEventType() {
         assertThatThrownBy(() -> new UserAlertEventMappingStrategyRegistry(
                 List.of(
-                        new UsageThresholdAlertEventMappingStrategy(),
+                        new UsageThresholdAlertEventMappingStrategy(mock(PresentDataRepository.class)),
                         new AppServiceAlertEventMappingStrategy(),
                         new PresentDataAlertEventMappingStrategy(),
                         new FamilyMemberApplyAlertEventMappingStrategy()
@@ -78,7 +80,7 @@ class UserAlertEventMappingStrategyRegistryTest {
 
     private List<UserAlertEventMappingStrategy> defaultStrategies() {
         return List.of(
-                new UsageThresholdAlertEventMappingStrategy(),
+                new UsageThresholdAlertEventMappingStrategy(mock(PresentDataRepository.class)),
                 new PolicyAlertEventMappingStrategy(),
                 new AppServiceAlertEventMappingStrategy(),
                 new PresentDataAlertEventMappingStrategy(),

--- a/src/test/java/hotspot/user/kafka/mapper/strategy/usage/UsageThresholdAlertEventMappingStrategyTest.java
+++ b/src/test/java/hotspot/user/kafka/mapper/strategy/usage/UsageThresholdAlertEventMappingStrategyTest.java
@@ -2,6 +2,7 @@ package hotspot.user.kafka.mapper.strategy.usage;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
 
 import java.time.LocalDateTime;
 
@@ -12,10 +13,12 @@ import hotspot.user.common.exception.ApplicationException;
 import hotspot.user.common.exception.code.KafkaErrorCode;
 import hotspot.user.kafka.domain.NotificationType;
 import hotspot.user.kafka.dto.UserAlertEvent;
+import hotspot.user.presentData.service.port.PresentDataRepository;
 
 class UsageThresholdAlertEventMappingStrategyTest {
 
-    private final UsageThresholdAlertEventMappingStrategy strategy = new UsageThresholdAlertEventMappingStrategy();
+    private final UsageThresholdAlertEventMappingStrategy strategy =
+            new UsageThresholdAlertEventMappingStrategy(mock(PresentDataRepository.class));
 
     @Test
     @DisplayName("maps plan/family/gift threshold types")

--- a/src/test/java/hotspot/user/policy/service/UpdateFamilyBlockPolicyStatusServiceImplTest.java
+++ b/src/test/java/hotspot/user/policy/service/UpdateFamilyBlockPolicyStatusServiceImplTest.java
@@ -4,11 +4,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import org.junit.jupiter.api.DisplayName;
@@ -25,9 +28,11 @@ import hotspot.user.common.exception.code.PolicyErrorCode;
 import hotspot.user.member.domain.FamilyRole;
 import hotspot.user.member.domain.MemberDetailInfo;
 import hotspot.user.member.service.port.MemberRepository;
+import hotspot.user.outbox.notificationOutbox.service.port.UserAlertNotificationOutboxPort;
 import hotspot.user.policy.controller.request.UpdateFamilyBlockPolicyStatusRequest;
 import hotspot.user.policy.controller.response.UpdateFamilyBlockPolicyStatusResponse;
 import hotspot.user.policy.domain.BlockPolicy;
+import hotspot.user.policy.domain.PolicyType;
 import hotspot.user.policy.service.port.BlockPolicyRepository;
 import hotspot.user.policy.service.port.PolicySubRepository;
 import hotspot.user.policy.service.util.FamilyPolicyDeactivatePublisher;
@@ -46,6 +51,9 @@ class UpdateFamilyBlockPolicyStatusServiceImplTest {
 
     @Mock
     private FamilyPolicyDeactivatePublisher familyPolicyDeactivatePublisher;
+
+    @Mock
+    private UserAlertNotificationOutboxPort userAlertNotificationOutboxPort;
 
     @InjectMocks
     private UpdateFamilyBlockPolicyStatusServiceImpl service;
@@ -68,12 +76,19 @@ class UpdateFamilyBlockPolicyStatusServiceImplTest {
                 .build();
         given(memberRepository.findDetailById(MEMBER_ID)).willReturn(Optional.of(memberDetail));
 
-        BlockPolicy p1 = BlockPolicy.builder().id(1L).isActive(true).build();
-        BlockPolicy p2 = BlockPolicy.builder().id(2L).isActive(false).build();
-        BlockPolicy p3 = BlockPolicy.builder().id(3L).isActive(true).build();
+        BlockPolicy p1 = BlockPolicy.builder().id(1L).isActive(true).policyType(PolicyType.SCHEDULED).build();
+        BlockPolicy p2 = BlockPolicy.builder().id(2L).isActive(false).policyType(PolicyType.SCHEDULED).build();
+        BlockPolicy p3 = BlockPolicy.builder()
+                .id(3L)
+                .name("night-block")
+                .isActive(true)
+                .policyType(PolicyType.ONCE)
+                .build();
 
         given(blockPolicyRepository.findAllByFamilyId(FAMILY_ID))
                 .willReturn(List.of(p1, p2, p3));
+        given(policySubRepository.findActiveSubIdsByBlockPolicyIds(List.of(3L)))
+                .willReturn(Map.of(3L, List.of(777L)));
 
         UpdateFamilyBlockPolicyStatusResponse response =
                 service.updateFamilyBlockPolicyStatus(request, MEMBER_ID, FAMILY_ID);
@@ -84,6 +99,11 @@ class UpdateFamilyBlockPolicyStatusServiceImplTest {
         verify(blockPolicyRepository).bulkDeActive(List.of(3L));
 
         verify(policySubRepository).bulkDeActiveByBlockPolicyIds(List.of(3L));
+        verify(userAlertNotificationOutboxPort, times(1)).appendPolicyAlert(argThat(event ->
+                event.subId().equals(777L)
+                        && event.familyId().equals(FAMILY_ID)
+                        && event.policyName().equals("night-block")
+        ));
 
         assertThat(response.familyId()).isEqualTo(FAMILY_ID);
         assertThat(response.blockedPolicyIdList())
@@ -184,5 +204,7 @@ class UpdateFamilyBlockPolicyStatusServiceImplTest {
         verify(blockPolicyRepository, never()).bulkActivate(anyList());
         verify(blockPolicyRepository, never()).bulkDeActive(anyList());
         verify(policySubRepository, never()).bulkDeActiveByBlockPolicyIds(anyList());
-        verify(familyPolicyDeactivatePublisher, never()).publish(anyList(), anyLong());    }
+        verify(familyPolicyDeactivatePublisher, never()).publish(anyList(), anyLong());
+        verify(userAlertNotificationOutboxPort, never()).appendPolicyAlert(argThat(event -> true));
+    }
 }


### PR DESCRIPTION
## 🎫 지라 티켓

<!-- 지라 티켓을 작성해주세요 ex) HOTSPOT-123 -->
HOTSPOT-374

---

## 🔗 GitHub 이슈
<!-- 자동 close를 원하면 아래 형식으로 작성
예) Closes #12
-->
Closes #206 

---


## ✅ 작업 사항

<!-- 작업한 부분을 설명해주세요. -->
- 가족 정책 일괄 비활성화 시 RELEASED 알림 outbox 발행 추가
- 선물 사용량 알림에서 발신자명 누락 시 giftId 기반 조회로 보정
- 가족 정책 비활성화 시 RELEASED 알림 발행 검증 추가

---

## 📋 체크리스트

<!-- PR 제출 전 확인해주세요. 해당 항목에 [x]로 체크해주세요. -->

- [x] 코드가 정상적으로 빌드됩니다.
- [x] 관련 테스트 코드를 작성했습니다.
- [x] 기존 테스트가 모두 통과합니다.
- [x] 코드 스타일(Spotless, Checkstyle)을 준수합니다.
- [x] Jira 티켓 상태를 In Review / Done으로 변경했습니다.

---

## ⌨ 기타
